### PR TITLE
ci: skip Terraform plan on Dependabot PRs; tame dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,12 +4,24 @@ updates:
     directory: "/"
     schedule:
       interval: weekly
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 5
+    # Group routine updates into a single PR and leave major (breaking) bumps
+    # for manual review rather than opening a flood of individual PRs.
     groups:
-      dev-dependencies:
-        dependency-type: development
+      minor-and-patch:
+        update-types:
+          - minor
+          - patch
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - version-update:semver-major
   - package-ecosystem: github-actions
     directory: "/"
     schedule:
       interval: weekly
     open-pull-requests-limit: 5
+    groups:
+      actions:
+        patterns:
+          - "*"

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -50,9 +50,14 @@ jobs:
 
   plan:
     needs: fmt-validate
-    # Skip on fork PRs: they cannot mint the GCP OIDC token (id-token: write) and
-    # only get a read-only GITHUB_TOKEN, so the plan + PR-comment steps would fail.
-    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+    # Skip on fork PRs (can't mint the GCP OIDC token / only get a read-only
+    # GITHUB_TOKEN) and on Dependabot PRs (an action-version bump touches this
+    # workflow file and would otherwise fire a prod/stg plan, contending on the
+    # shared Terraform state lock across the batch of Dependabot PRs).
+    if: >-
+      github.event_name == 'pull_request'
+      && github.event.pull_request.head.repo.full_name == github.repository
+      && github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false


### PR DESCRIPTION
Follow-up to the dependabot.yml added in #1, which opened a flood of PRs and caused Terraform `plan` failures.

**Root cause of the failures:** a Dependabot action-version bump edits a workflow file, matching `terraform.yml`'s path trigger, so each such PR fired a prod/stg `terraform plan`. Many running at once collided on the shared GCS state lock (`Error 412 ... acquiring the state lock`). Plan-only, no infra touched — but noisy.

**Changes**
- `terraform.yml`: guard the `plan` job with `github.actor != 'dependabot[bot]'` (alongside the existing fork-PR guard).
- `dependabot.yml`: group minor/patch, **ignore major** (breaking) npm bumps, group action updates, cap open PRs to 5 — prevents the flood.

🤖 Generated with [Claude Code](https://claude.com/claude-code)