### PR TITLE
Add MTQ (MITHQAL Settlement Unit) token

### DIFF
--- a/tokens/GAGRdrY6jcRTmD7A9KzvXA5sGMpNAkkRXwDoXBrEjxS4/metadata.json
+++ b/tokens/GAGRdrY6jcRTmD7A9KzvXA5sGMpNAkkRXwDoXBrEjxS4/metadata.json
@@ -1,0 +1,18 @@
+{
+  "mint": "GAGRdrY6jcRTmD7A9KzvXA5sGMpNAkkRXwDoXBrEjxS4",
+  "name": "MITHQAL Settlement Unit",
+  "symbol": "MTQ",
+  "decimals": 18,
+  "logoURI": "https://mithqal.vercel.app/mtq-logo.png",
+  "tags": [
+    "settlement",
+    "trade",
+    "institutional",
+    "sharia-compliant"
+  ],
+  "extensions": {
+    "website": "https://mithqal.vercel.app/",
+    "github": "https://github.com/MITHQALMTQ/mithqal",
+    "twitter": "https://x.com/MithqalMTQ"
+  }
+}


### PR DESCRIPTION
### Summary

This PR adds the token metadata for **MTQ**, the settlement unit of MITHQAL (Constitutional Monetary Institution).

- **Mint Address:** `GAGRdrY6jcRTmD7A9KzvXA5sGMpNAkkRXwDoXBrEjxS4`
- **Symbol:** MTQ
- **Decimals:** 18
- **LogoURI:** https://mithqal.vercel.app/mtq-logo.png
- **Tags:** settlement, trade, institutional, sharia-compliant

### Why

MITHQAL is a fully reserved (100%+), Shari'ah‑compliant settlement infrastructure for international trade, with 10‑minute finality. The MTQ token represents the settlement unit on Solana, enabling integration with Solana wallets, explorers, and DeFi protocols.

This metadata ensures MTQ is correctly displayed across the ecosystem.

### Risk / Impact

- ✅ No user‑facing risk – this is metadata only (no smart contract changes)
- ✅ No API or auth risk
- ✅ No operational risk
- ✅ All existing token entries remain unchanged

### Verification

- [x] `run check:repo-hygiene`
- [x] `run verify:api-health-routes`
- [x] `run lint`
- [x] `run build`
- [x] `run audit:deps`

### Docs / Tests

No documentation or tests required – this is a simple metadata addition.

### Linked issue

N/A