### PR TITLE
Extend api_request_events partition coverage and add a partition roll-forward cron

### DIFF
--- a/alert-rules/api-usage-partition-cron-silent.json
+++ b/alert-rules/api-usage-partition-cron-silent.json
@@ -1,0 +1,93 @@
+{
+  "uid": "tokens-api-usage-partition-cron-silent",
+  "title": "tokens-assets: partition maintenance cron hasn't reported in over a day",
+  "ruleGroup": "tokens-crons",
+  "folderUID": "tokens-xyz",
+  "noDataState": "Alerting",
+  "execErrState": "OK",
+  "for": "0s",
+  "data": [
+    {
+      "refId": "A",
+      "datasourceUid": "grafanacloud-logs",
+      "queryType": "range",
+      "relativeTimeRange": {
+        "from": 93600,
+        "to": 0
+      },
+      "model": {
+        "expr": "sum(count_over_time({service=\"tokens-assets-prd-us\"} |~ \"\\\\[createApiUsagePartitions\\\\]\" [26h]))",
+        "queryType": "range",
+        "refId": "A"
+      }
+    },
+    {
+      "refId": "B",
+      "datasourceUid": "__expr__",
+      "queryType": "",
+      "relativeTimeRange": {
+        "from": 0,
+        "to": 0
+      },
+      "model": {
+        "type": "reduce",
+        "refId": "B",
+        "expression": "A",
+        "reducer": "last",
+        "settings": {
+          "mode": "replaceNN",
+          "replaceWithValue": 0
+        }
+      }
+    },
+    {
+      "refId": "C",
+      "datasourceUid": "__expr__",
+      "queryType": "",
+      "relativeTimeRange": {
+        "from": 0,
+        "to": 0
+      },
+      "model": {
+        "type": "threshold",
+        "refId": "C",
+        "expression": "B",
+        "conditions": [
+          {
+            "evaluator": {
+              "type": "lt",
+              "params": [
+                1
+              ]
+            },
+            "operator": {
+              "type": "and"
+            },
+            "query": {
+              "params": [
+                "B"
+              ]
+            },
+            "reducer": {
+              "type": "last",
+              "params": []
+            },
+            "type": "query"
+          }
+        ]
+      }
+    }
+  ],
+  "condition": "C",
+  "labels": {
+    "service": "tokens-assets",
+    "severity": "warning",
+    "pagerduty": "false",
+    "slack": "true"
+  },
+  "annotations": {
+    "summary": "create-api-usage-partitions cron produced no log lines in the last 26h",
+    "description": "The daily create-api-usage-partitions job (00:45 UTC) logged nothing at all in over a day — the companion unhealthy alert only fires on failure lines the job itself emits, so total silence (Cloud Scheduler job paused or deleted, invoker SA missing run.invoker, /jobs disabled on the service) would otherwise go unnoticed until partition coverage runs out and api_request_events inserts fall through to the default partition. Check the Cloud Scheduler run history for tokens-create-api-usage-partitions-prd and the cloudrun-assets service logs.",
+    "runbook_url": "https://github.com/solana-foundation/tokens/issues/23"
+  }
+}

--- a/alert-rules/api-usage-partition-cron-silent.json
+++ b/alert-rules/api-usage-partition-cron-silent.json
@@ -12,7 +12,7 @@
       "datasourceUid": "grafanacloud-logs",
       "queryType": "range",
       "relativeTimeRange": {
-        "from": 93600,
+        "from": 300,
         "to": 0
       },
       "model": {

--- a/alert-rules/api-usage-partition-maintenance-unhealthy.json
+++ b/alert-rules/api-usage-partition-maintenance-unhealthy.json
@@ -1,0 +1,93 @@
+{
+  "uid": "tokens-api-usage-partitions-unhealthy",
+  "title": "tokens-assets: api_request_events partition maintenance unhealthy",
+  "ruleGroup": "tokens-crons",
+  "folderUID": "tokens-xyz",
+  "noDataState": "OK",
+  "execErrState": "OK",
+  "for": "0s",
+  "data": [
+    {
+      "refId": "A",
+      "datasourceUid": "grafanacloud-logs",
+      "queryType": "range",
+      "relativeTimeRange": {
+        "from": 90000,
+        "to": 0
+      },
+      "model": {
+        "expr": "sum(count_over_time({service=\"tokens-assets-prd-us\"} |~ \"\\\\[createApiUsagePartitions\\\\] ensure failed|\\\\[createApiUsagePartitions\\\\] probe failed|\\\\[createApiUsagePartitions\\\\] default partition has rows\" [25h]))",
+        "queryType": "range",
+        "refId": "A"
+      }
+    },
+    {
+      "refId": "B",
+      "datasourceUid": "__expr__",
+      "queryType": "",
+      "relativeTimeRange": {
+        "from": 0,
+        "to": 0
+      },
+      "model": {
+        "type": "reduce",
+        "refId": "B",
+        "expression": "A",
+        "reducer": "last",
+        "settings": {
+          "mode": "replaceNN",
+          "replaceWithValue": 0
+        }
+      }
+    },
+    {
+      "refId": "C",
+      "datasourceUid": "__expr__",
+      "queryType": "",
+      "relativeTimeRange": {
+        "from": 0,
+        "to": 0
+      },
+      "model": {
+        "type": "threshold",
+        "refId": "C",
+        "expression": "B",
+        "conditions": [
+          {
+            "evaluator": {
+              "type": "gt",
+              "params": [
+                0
+              ]
+            },
+            "operator": {
+              "type": "and"
+            },
+            "query": {
+              "params": [
+                "B"
+              ]
+            },
+            "reducer": {
+              "type": "last",
+              "params": []
+            },
+            "type": "query"
+          }
+        ]
+      }
+    }
+  ],
+  "condition": "C",
+  "labels": {
+    "service": "tokens-assets",
+    "severity": "warning",
+    "pagerduty": "false",
+    "slack": "true"
+  },
+  "annotations": {
+    "summary": "api_request_events partition pre-creation failing or rows landing in the default partition",
+    "description": "The daily create-api-usage-partitions cron logged a partition-ensure failure, or its probe found rows from the covered era in api_request_events_default (a month boundary was missed). Once rows for a month sit in the default partition, that month's partition can no longer be created with plain DDL and requires moving the rows out before ATTACH. Check Loki for [createApiUsagePartitions] lines and the Cloud Scheduler run history for tokens-create-api-usage-partitions-prd.",
+    "runbook_url": "https://github.com/solana-foundation/tokens/issues/23"
+  }
+}

--- a/alert-rules/api-usage-partition-maintenance-unhealthy.json
+++ b/alert-rules/api-usage-partition-maintenance-unhealthy.json
@@ -12,7 +12,7 @@
       "datasourceUid": "grafanacloud-logs",
       "queryType": "range",
       "relativeTimeRange": {
-        "from": 90000,
+        "from": 300,
         "to": 0
       },
       "model": {

--- a/apps/cloudrun-assets/src/db.ts
+++ b/apps/cloudrun-assets/src/db.ts
@@ -1455,6 +1455,74 @@ export function makePostgresJobsRepo(sql: Sql): JobsRepo {
             return rows[0]?.count ?? 0;
         },
 
+        async ensureApiRequestEventsPartition(tableName, fromBound, toBound) {
+            // Only the create-api-usage-partitions cron calls this, with
+            // internally generated values — but DDL cannot take bind
+            // parameters, so anything interpolated into it is pinned by
+            // regex first. These checks are load-bearing; do not relax them.
+            if (!/^api_request_events_y\d{4}m(0[1-9]|1[0-2])$/.test(tableName)) {
+                throw new Error(`ensureApiRequestEventsPartition: invalid table name ${JSON.stringify(tableName)}`);
+            }
+            const boundPattern = /^\d{4}-(0[1-9]|1[0-2])-01 00:00:00\+00$/;
+            if (!boundPattern.test(fromBound) || !boundPattern.test(toBound)) {
+                throw new Error('ensureApiRequestEventsPartition: invalid partition bound literal');
+            }
+            const expectedBounds = `FOR VALUES FROM ('${fromBound}') TO ('${toBound}')`;
+            try {
+                return await sql.begin(async tx => {
+                    // TimeZone pinned so pg_get_expr renders bounds
+                    // deterministically; lock_timeout so the ACCESS EXCLUSIVE
+                    // acquisition on the parent fails fast instead of damming
+                    // the insert path — the daily cron retries tomorrow.
+                    await tx`SET LOCAL TimeZone = 'UTC'`;
+                    await tx`SET LOCAL lock_timeout = '5s'`;
+                    const rows = await tx<{ bounds: string | null; parent_ok: boolean }[]>`
+                        SELECT pg_get_expr(c.relpartbound, c.oid) AS bounds,
+                               COALESCE(i.inhparent = 'public.api_request_events'::regclass, false) AS parent_ok
+                        FROM pg_class c
+                        JOIN pg_namespace n ON n.oid = c.relnamespace
+                        LEFT JOIN pg_inherits i ON i.inhrelid = c.oid
+                        WHERE n.nspname = 'public' AND c.relname = ${tableName}
+                    `;
+                    const row = rows[0];
+                    if (row) {
+                        return row.parent_ok && row.bounds === expectedBounds ? 'exists' : 'bound_mismatch';
+                    }
+                    await tx.unsafe(
+                        `CREATE TABLE IF NOT EXISTS public.${tableName} PARTITION OF public.api_request_events ` +
+                            `FOR VALUES FROM ('${fromBound}') TO ('${toBound}')`,
+                    );
+                    return 'created';
+                });
+            } catch (err) {
+                // Concurrent creation race: IF NOT EXISTS checks the name
+                // before taking the creation lock, so the loser of a race can
+                // still surface duplicate_table (42P07) or a catalog unique
+                // violation (23505). The partition exists either way.
+                const code = (err as { code?: unknown }).code;
+                if (code === '42P07' || code === '23505') return 'exists';
+                throw err;
+            }
+        },
+
+        async countApiRequestEventsDefaultRows(limit) {
+            const lim = Math.min(Math.max(limit, 1), 1_000_000);
+            // Only rows inside the partitioned era count as misplaced;
+            // 0003 anticipated pre-coverage historical imports living in the
+            // default partition, and coverage starts at 2026-05-01. LIMIT
+            // bounds the probe so it can never become an unbounded count.
+            const rows = await sql<{ count: number }[]>`
+                SELECT count(*)::int AS count
+                FROM (
+                    SELECT 1
+                    FROM api_request_events_default
+                    WHERE created_at >= '2026-05-01 00:00:00+00'::timestamptz
+                    LIMIT ${lim}
+                ) t
+            `;
+            return rows[0]?.count ?? 0;
+        },
+
         async getOhlcvBounds(address, interval) {
             const rows = await sql<{ min_time: number | null; max_time: number | null }[]>`
                 SELECT MIN(time) AS min_time, MAX(time) AS max_time

--- a/apps/cloudrun-assets/src/db.ts
+++ b/apps/cloudrun-assets/src/db.ts
@@ -1467,15 +1467,23 @@ export function makePostgresJobsRepo(sql: Sql): JobsRepo {
             if (!boundPattern.test(fromBound) || !boundPattern.test(toBound)) {
                 throw new Error('ensureApiRequestEventsPartition: invalid partition bound literal');
             }
+            // Name and lower bound must describe the same month, so a caller
+            // bug cannot create a partition whose name lies about its range.
+            const nameForFromBound = `api_request_events_y${fromBound.slice(0, 4)}m${fromBound.slice(5, 7)}`;
+            if (tableName !== nameForFromBound) {
+                throw new Error(
+                    `ensureApiRequestEventsPartition: table name ${tableName} does not match lower bound ${fromBound}`,
+                );
+            }
             const expectedBounds = `FOR VALUES FROM ('${fromBound}') TO ('${toBound}')`;
-            try {
-                return await sql.begin(async tx => {
-                    // TimeZone pinned so pg_get_expr renders bounds
-                    // deterministically; lock_timeout so the ACCESS EXCLUSIVE
-                    // acquisition on the parent fails fast instead of damming
-                    // the insert path — the daily cron retries tomorrow.
+
+            // TimeZone + DateStyle pinned so pg_get_expr renders bound
+            // constants deterministically ('YYYY-MM-DD HH:MI:SS+00') on any
+            // cluster configuration.
+            const inspect = () =>
+                sql.begin(async tx => {
                     await tx`SET LOCAL TimeZone = 'UTC'`;
-                    await tx`SET LOCAL lock_timeout = '5s'`;
+                    await tx`SET LOCAL DateStyle = 'ISO'`;
                     const rows = await tx<{ bounds: string | null; parent_ok: boolean }[]>`
                         SELECT pg_get_expr(c.relpartbound, c.oid) AS bounds,
                                COALESCE(i.inhparent = 'public.api_request_events'::regclass, false) AS parent_ok
@@ -1485,22 +1493,37 @@ export function makePostgresJobsRepo(sql: Sql): JobsRepo {
                         WHERE n.nspname = 'public' AND c.relname = ${tableName}
                     `;
                     const row = rows[0];
-                    if (row) {
-                        return row.parent_ok && row.bounds === expectedBounds ? 'exists' : 'bound_mismatch';
-                    }
+                    if (!row) return 'absent' as const;
+                    return row.parent_ok && row.bounds === expectedBounds
+                        ? ('exists' as const)
+                        : ('bound_mismatch' as const);
+                });
+
+            const before = await inspect();
+            if (before !== 'absent') return before;
+            try {
+                await sql.begin(async tx => {
+                    // lock_timeout so the ACCESS EXCLUSIVE acquisition on the
+                    // parent fails fast instead of damming the insert path —
+                    // the daily cron retries tomorrow.
+                    await tx`SET LOCAL lock_timeout = '5s'`;
                     await tx.unsafe(
                         `CREATE TABLE IF NOT EXISTS public.${tableName} PARTITION OF public.api_request_events ` +
                             `FOR VALUES FROM ('${fromBound}') TO ('${toBound}')`,
                     );
-                    return 'created';
                 });
+                return 'created';
             } catch (err) {
                 // Concurrent creation race: IF NOT EXISTS checks the name
                 // before taking the creation lock, so the loser of a race can
                 // still surface duplicate_table (42P07) or a catalog unique
-                // violation (23505). The partition exists either way.
+                // violation (23505). Something created the name concurrently —
+                // re-inspect rather than assume its bounds are right.
                 const code = (err as { code?: unknown }).code;
-                if (code === '42P07' || code === '23505') return 'exists';
+                if (code === '42P07' || code === '23505') {
+                    const after = await inspect();
+                    return after === 'absent' ? 'exists' : after;
+                }
                 throw err;
             }
         },

--- a/apps/cloudrun-assets/src/handlers/adminActions.test.ts
+++ b/apps/cloudrun-assets/src/handlers/adminActions.test.ts
@@ -268,6 +268,12 @@ function makeJobsRepo(state: FakeState): JobsRepo {
         async pruneApiRequestEventsForProject() {
             return 0;
         },
+        async ensureApiRequestEventsPartition() {
+            return 'created' as const;
+        },
+        async countApiRequestEventsDefaultRows() {
+            return 0;
+        },
         async getOhlcvBounds() {
             return { minTime: null, maxTime: null };
         },

--- a/apps/cloudrun-assets/src/handlers/cacheWarm.test.ts
+++ b/apps/cloudrun-assets/src/handlers/cacheWarm.test.ts
@@ -160,6 +160,12 @@ function makeJobsRepo(state: FakeState): JobsRepo {
         async pruneApiRequestEventsForProject() {
             return 0;
         },
+        async ensureApiRequestEventsPartition() {
+            return 'created' as const;
+        },
+        async countApiRequestEventsDefaultRows() {
+            return 0;
+        },
         async getOhlcvBounds(address, interval) {
             return state.ohlcvBoundsByKey?.[`${address}\n${interval}`] ?? { minTime: null, maxTime: null };
         },

--- a/apps/cloudrun-assets/src/handlers/crons.test.ts
+++ b/apps/cloudrun-assets/src/handlers/crons.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'bun:test';
 
 import {
     InvalidArgsError,
+    createApiUsagePartitions,
     pruneApiRequestEvents,
     refreshCuratedAssetMarkets,
     refreshCuratedAssetRisk,
@@ -78,6 +79,9 @@ interface MockRepoState {
     allProjectIds?: string[];
     prunedByProject?: Record<string, number>;
     pruneCalls?: { projectId: string; cutoffTs: number; beforeCreationTime: number }[];
+    partitionEnsureCalls?: { tableName: string; fromBound: string; toBound: string }[];
+    partitionEnsureOutcomes?: Record<string, 'created' | 'exists' | 'bound_mismatch' | 'throw'>;
+    defaultPartitionRows?: number;
     ohlcvBoundsByKey?: Record<string, { minTime: number | null; maxTime: number | null }>;
     upsertedOhlcvBatches?: { address: string; interval: string; candles: OhlcvCandle[] }[];
     ohlcvUpsertResult?: OhlcvUpsertResult;
@@ -98,6 +102,7 @@ function makeRepo(state: MockRepoState = {}): JobsRepo {
     state.appliedEndpointDeltas ??= [];
     state.upsertedOhlcvBatches ??= [];
     state.pruneCalls ??= [];
+    state.partitionEnsureCalls ??= [];
     return {
         async upsertVariantMarketFromBirdeye(args) {
             state.upsertedBirdeye!.push(args);
@@ -221,6 +226,15 @@ function makeRepo(state: MockRepoState = {}): JobsRepo {
         async pruneApiRequestEventsForProject(projectId, cutoffTs, beforeCreationTime) {
             state.pruneCalls!.push({ projectId, cutoffTs, beforeCreationTime });
             return state.prunedByProject?.[projectId] ?? 0;
+        },
+        async ensureApiRequestEventsPartition(tableName, fromBound, toBound) {
+            state.partitionEnsureCalls!.push({ tableName, fromBound, toBound });
+            const outcome = state.partitionEnsureOutcomes?.[tableName];
+            if (outcome === 'throw') throw new Error(`ensure failed for ${tableName}`);
+            return outcome ?? 'created';
+        },
+        async countApiRequestEventsDefaultRows() {
+            return state.defaultPartitionRows ?? 0;
         },
         async getOhlcvBounds(address, interval) {
             return state.ohlcvBoundsByKey?.[`${address}\n${interval}`] ?? { minTime: null, maxTime: null };
@@ -810,6 +824,135 @@ describe('pruneApiRequestEvents', () => {
         const res = await pruneApiRequestEvents(deps, {});
         expect(res.failed).toBe(1);
         expect(res.deleted).toBe(3);
+    });
+});
+
+describe('createApiUsagePartitions', () => {
+    it('ensures the current month plus monthsAhead future months with UTC month bounds', async () => {
+        const { deps, state } = makeDeps({
+            now: () => Date.UTC(2026, 7, 10, 12, 0, 0), // 2026-08-10T12:00Z
+            state: {
+                partitionEnsureOutcomes: { api_request_events_y2026m08: 'exists' },
+            },
+        });
+        const res = await createApiUsagePartitions(deps, { monthsAhead: 3 });
+        expect(res.ok).toBe(true);
+        expect(res.processed).toBe(4);
+        expect(state.partitionEnsureCalls!.map(c => c.tableName)).toEqual([
+            'api_request_events_y2026m08',
+            'api_request_events_y2026m09',
+            'api_request_events_y2026m10',
+            'api_request_events_y2026m11',
+        ]);
+        expect(state.partitionEnsureCalls![0]).toEqual({
+            tableName: 'api_request_events_y2026m08',
+            fromBound: '2026-08-01 00:00:00+00',
+            toBound: '2026-09-01 00:00:00+00',
+        });
+        expect(state.partitionEnsureCalls![1]).toEqual({
+            tableName: 'api_request_events_y2026m09',
+            fromBound: '2026-09-01 00:00:00+00',
+            toBound: '2026-10-01 00:00:00+00',
+        });
+        expect(res.existing).toEqual(['api_request_events_y2026m08']);
+        expect(res.created).toEqual([
+            'api_request_events_y2026m09',
+            'api_request_events_y2026m10',
+            'api_request_events_y2026m11',
+        ]);
+        expect(res.failed).toBe(0);
+        expect(res.boundMismatches).toEqual([]);
+    });
+
+    it('crosses year boundaries with correct partition names and bounds', async () => {
+        const { deps, state } = makeDeps({
+            now: () => Date.UTC(2026, 10, 15), // 2026-11-15T00:00Z
+        });
+        const res = await createApiUsagePartitions(deps, { monthsAhead: 3 });
+        expect(res.ok).toBe(true);
+        expect(state.partitionEnsureCalls!.map(c => c.tableName)).toEqual([
+            'api_request_events_y2026m11',
+            'api_request_events_y2026m12',
+            'api_request_events_y2027m01',
+            'api_request_events_y2027m02',
+        ]);
+        expect(state.partitionEnsureCalls![1]).toEqual({
+            tableName: 'api_request_events_y2026m12',
+            fromBound: '2026-12-01 00:00:00+00',
+            toBound: '2027-01-01 00:00:00+00',
+        });
+        expect(state.partitionEnsureCalls![2]).toEqual({
+            tableName: 'api_request_events_y2027m01',
+            fromBound: '2027-01-01 00:00:00+00',
+            toBound: '2027-02-01 00:00:00+00',
+        });
+    });
+
+    it('is idempotent when every partition already exists', async () => {
+        const { deps } = makeDeps({
+            now: () => Date.UTC(2026, 7, 10),
+            state: {
+                partitionEnsureOutcomes: {
+                    api_request_events_y2026m08: 'exists',
+                    api_request_events_y2026m09: 'exists',
+                    api_request_events_y2026m10: 'exists',
+                    api_request_events_y2026m11: 'exists',
+                },
+            },
+        });
+        const res = await createApiUsagePartitions(deps, { monthsAhead: 3 });
+        expect(res.created).toEqual([]);
+        expect(res.existing).toHaveLength(4);
+        expect(res.failed).toBe(0);
+    });
+
+    it('keeps ensuring later months when one month fails', async () => {
+        const { deps, state } = makeDeps({
+            now: () => Date.UTC(2026, 7, 10),
+            state: {
+                partitionEnsureOutcomes: { api_request_events_y2026m09: 'throw' },
+            },
+        });
+        const res = await createApiUsagePartitions(deps, { monthsAhead: 3 });
+        expect(res.failed).toBe(1);
+        expect(state.partitionEnsureCalls!).toHaveLength(4);
+        expect(res.created).toEqual([
+            'api_request_events_y2026m08',
+            'api_request_events_y2026m10',
+            'api_request_events_y2026m11',
+        ]);
+    });
+
+    it('reports a relation that exists with unexpected bounds as a bound mismatch', async () => {
+        const { deps } = makeDeps({
+            now: () => Date.UTC(2026, 7, 10),
+            state: {
+                partitionEnsureOutcomes: { api_request_events_y2026m09: 'bound_mismatch' },
+            },
+        });
+        const res = await createApiUsagePartitions(deps, { monthsAhead: 3 });
+        expect(res.boundMismatches).toEqual(['api_request_events_y2026m09']);
+        expect(res.failed).toBe(0);
+        expect(res.created).toEqual([
+            'api_request_events_y2026m08',
+            'api_request_events_y2026m10',
+            'api_request_events_y2026m11',
+        ]);
+    });
+
+    it('surfaces the default-partition row probe in the result', async () => {
+        const { deps } = makeDeps({
+            now: () => Date.UTC(2026, 7, 10),
+            state: { defaultPartitionRows: 5 },
+        });
+        const res = await createApiUsagePartitions(deps, {});
+        expect(res.defaultPartitionRows).toBe(5);
+        expect(res.failed).toBe(0);
+    });
+
+    it('rejects non-numeric args with InvalidArgsError', async () => {
+        const { deps } = makeDeps();
+        await expect(createApiUsagePartitions(deps, { monthsAhead: 'lots' })).rejects.toThrow(/numeric arg/);
     });
 });
 

--- a/apps/cloudrun-assets/src/handlers/crons.ts
+++ b/apps/cloudrun-assets/src/handlers/crons.ts
@@ -1810,6 +1810,11 @@ export async function createApiUsagePartitions(deps: CronDeps, rawArgs: unknown)
     const boundMismatches: string[] = [];
     let failed = 0;
 
+    // The "ensure failed" prefix is load-bearing: the Grafana alert rule
+    // matches it verbatim. Keep every failure branch on this one helper.
+    const logEnsureFailed = (tableName: string, detail: string) =>
+        console.error(`[createApiUsagePartitions] ensure failed month=${tableName} ${detail}`);
+
     // Current month plus monthsAhead future months, so processed = monthsAhead + 1.
     for (let k = 0; k <= monthsAhead; k++) {
         const { tableName, fromBound, toBound } = apiUsagePartitionForMonthUtc(
@@ -1824,34 +1829,35 @@ export async function createApiUsagePartitions(deps: CronDeps, rawArgs: unknown)
                 existing.push(tableName);
             } else {
                 boundMismatches.push(tableName);
-                console.error(
-                    `[createApiUsagePartitions] ensure failed month=${tableName} reason=bound_mismatch: a relation with this name exists but is not a partition of api_request_events with bounds [${fromBound}, ${toBound})`,
+                logEnsureFailed(
+                    tableName,
+                    `reason=bound_mismatch: a relation with this name exists but is not a partition of api_request_events with bounds [${fromBound}, ${toBound})`,
                 );
             }
         } catch (err) {
             failed += 1;
             const code = (err as { code?: unknown }).code;
             if (code === '23514') {
-                console.error(
-                    `[createApiUsagePartitions] ensure failed month=${tableName} code=23514: rows for this range already sit in api_request_events_default, so plain CREATE is blocked; move them out of the default partition and ATTACH the month manually`,
+                logEnsureFailed(
+                    tableName,
+                    'code=23514: rows for this range already sit in api_request_events_default, so plain CREATE is blocked; move them out of the default partition and ATTACH the month manually',
                 );
             } else {
-                console.error(
-                    `[createApiUsagePartitions] ensure failed month=${tableName}`,
-                    err instanceof Error ? err.message : String(err),
-                );
+                logEnsureFailed(tableName, err instanceof Error ? err.message : String(err));
             }
         }
     }
 
     // Tripwire: rows inside the covered era (2026-05 onward) sitting in the
     // default partition mean a month boundary was missed.
+    const probeLimit = 100_000;
     let defaultPartitionRows = 0;
     try {
-        defaultPartitionRows = await deps.repo.countApiRequestEventsDefaultRows(100_000);
+        defaultPartitionRows = await deps.repo.countApiRequestEventsDefaultRows(probeLimit);
         if (defaultPartitionRows > 0) {
+            const saturated = defaultPartitionRows >= probeLimit ? ' (probe saturated; actual count may be higher)' : '';
             console.warn(
-                `[createApiUsagePartitions] default partition has rows count=${defaultPartitionRows}: events are falling through to api_request_events_default instead of a monthly partition`,
+                `[createApiUsagePartitions] default partition has rows count=${defaultPartitionRows}${saturated}: events are falling through to api_request_events_default instead of a monthly partition`,
             );
         }
     } catch (err) {

--- a/apps/cloudrun-assets/src/handlers/crons.ts
+++ b/apps/cloudrun-assets/src/handlers/crons.ts
@@ -312,6 +312,12 @@ export interface JobsRepo {
         beforeCreationTime: number,
         batchSize: number,
     ): Promise<number>;
+    ensureApiRequestEventsPartition(
+        tableName: string,
+        fromBound: string,
+        toBound: string,
+    ): Promise<'created' | 'exists' | 'bound_mismatch'>;
+    countApiRequestEventsDefaultRows(limit: number): Promise<number>;
 
     getOhlcvBounds(address: string, interval: string): Promise<{ minTime: number | null; maxTime: number | null }>;
     upsertOhlcvCandles(
@@ -1774,6 +1780,103 @@ export async function pruneApiRequestEvents(deps: CronDeps, rawArgs: unknown): P
         deleted,
         cutoffTs,
         failed,
+    };
+}
+
+function apiUsagePartitionForMonthUtc(
+    year: number,
+    monthIndex: number,
+): { tableName: string; fromBound: string; toBound: string } {
+    const pad2 = (n: number) => String(n).padStart(2, '0');
+    const monthBound = (d: Date) => `${d.getUTCFullYear()}-${pad2(d.getUTCMonth() + 1)}-01 00:00:00+00`;
+    const from = new Date(Date.UTC(year, monthIndex, 1));
+    const to = new Date(Date.UTC(year, monthIndex + 1, 1));
+    return {
+        tableName: `api_request_events_y${from.getUTCFullYear()}m${pad2(from.getUTCMonth() + 1)}`,
+        fromBound: monthBound(from),
+        toBound: monthBound(to),
+    };
+}
+
+export async function createApiUsagePartitions(deps: CronDeps, rawArgs: unknown): Promise<CronResult> {
+    const args = asObject(rawArgs);
+    const monthsAhead = clampInt(args.monthsAhead, 3, 1, 12);
+
+    const start = deps.now();
+    const now = new Date(start);
+
+    const created: string[] = [];
+    const existing: string[] = [];
+    const boundMismatches: string[] = [];
+    let failed = 0;
+
+    // Current month plus monthsAhead future months, so processed = monthsAhead + 1.
+    for (let k = 0; k <= monthsAhead; k++) {
+        const { tableName, fromBound, toBound } = apiUsagePartitionForMonthUtc(
+            now.getUTCFullYear(),
+            now.getUTCMonth() + k,
+        );
+        try {
+            const outcome = await deps.repo.ensureApiRequestEventsPartition(tableName, fromBound, toBound);
+            if (outcome === 'created') {
+                created.push(tableName);
+            } else if (outcome === 'exists') {
+                existing.push(tableName);
+            } else {
+                boundMismatches.push(tableName);
+                console.error(
+                    `[createApiUsagePartitions] ensure failed month=${tableName} reason=bound_mismatch: a relation with this name exists but is not a partition of api_request_events with bounds [${fromBound}, ${toBound})`,
+                );
+            }
+        } catch (err) {
+            failed += 1;
+            const code = (err as { code?: unknown }).code;
+            if (code === '23514') {
+                console.error(
+                    `[createApiUsagePartitions] ensure failed month=${tableName} code=23514: rows for this range already sit in api_request_events_default, so plain CREATE is blocked; move them out of the default partition and ATTACH the month manually`,
+                );
+            } else {
+                console.error(
+                    `[createApiUsagePartitions] ensure failed month=${tableName}`,
+                    err instanceof Error ? err.message : String(err),
+                );
+            }
+        }
+    }
+
+    // Tripwire: rows inside the covered era (2026-05 onward) sitting in the
+    // default partition mean a month boundary was missed.
+    let defaultPartitionRows = 0;
+    try {
+        defaultPartitionRows = await deps.repo.countApiRequestEventsDefaultRows(100_000);
+        if (defaultPartitionRows > 0) {
+            console.warn(
+                `[createApiUsagePartitions] default partition has rows count=${defaultPartitionRows}: events are falling through to api_request_events_default instead of a monthly partition`,
+            );
+        }
+    } catch (err) {
+        failed += 1;
+        console.error(
+            '[createApiUsagePartitions] probe failed for api_request_events_default',
+            err instanceof Error ? err.message : String(err),
+        );
+    }
+
+    if (failed === 0 && boundMismatches.length === 0) {
+        console.log(
+            `[createApiUsagePartitions] ok created=[${created.join(',')}] existing=[${existing.join(',')}] defaultPartitionRows=${defaultPartitionRows}`,
+        );
+    }
+
+    return {
+        ok: true,
+        processed: monthsAhead + 1,
+        durationMs: deps.now() - start,
+        created,
+        existing,
+        boundMismatches,
+        failed,
+        defaultPartitionRows,
     };
 }
 

--- a/apps/cloudrun-assets/src/handlers/rwaXyz.test.ts
+++ b/apps/cloudrun-assets/src/handlers/rwaXyz.test.ts
@@ -107,6 +107,8 @@ function makeRecordingRepo(state: RecordingRepoState): JobsRepo {
         async applyRollupBatchAtomic() { return true; },
         async listAllProjectIds() { return []; },
         async pruneApiRequestEventsForProject() { return 0; },
+        async ensureApiRequestEventsPartition() { return 'created' as const; },
+        async countApiRequestEventsDefaultRows() { return 0; },
         async getOhlcvBounds() { return { minTime: null, maxTime: null }; },
         async upsertOhlcvCandles() { return { inserted: 0, updated: 0, skipped: 0 }; },
     };

--- a/apps/cloudrun-assets/src/server.jobs.test.ts
+++ b/apps/cloudrun-assets/src/server.jobs.test.ts
@@ -196,6 +196,8 @@ function emptyCronDeps(): CronDeps {
             async applyEndpointDailyRollupDelta() {},
             async listAllProjectIds() { return []; },
             async pruneApiRequestEventsForProject() { return 0; },
+            async ensureApiRequestEventsPartition() { return 'created' as const; },
+            async countApiRequestEventsDefaultRows() { return 0; },
             async getOhlcvBounds() { return { minTime: null, maxTime: null }; },
             async upsertOhlcvCandles() { return { inserted: 0, updated: 0, skipped: 0 }; },
             async applyRollupBatchAtomic() { return true; },

--- a/apps/cloudrun-assets/src/server.ts
+++ b/apps/cloudrun-assets/src/server.ts
@@ -93,6 +93,7 @@ import {
 } from './handlers/ohlcvReads';
 import {
     InvalidArgsError as CronInvalidArgsError,
+    createApiUsagePartitions,
     pruneApiRequestEvents,
     refreshCuratedAssetMarkets,
     refreshCuratedAssetRisk,
@@ -411,6 +412,7 @@ export function createApp(deps: ServerDeps) {
     jobs['refresh-curated-asset-risk'] = refreshCuratedAssetRisk;
     jobs['rollup-active-api-usage'] = rollupActiveApiUsage;
     jobs['prune-api-request-events'] = pruneApiRequestEvents;
+    jobs['create-api-usage-partitions'] = createApiUsagePartitions;
     jobs['refresh-curated-ohlcv-15m'] = refreshCuratedOhlcv;
     jobs['refresh-curated-ohlcv-1h'] = refreshCuratedOhlcv;
     jobs['refresh-curated-ohlcv-4h'] = refreshCuratedOhlcv;

--- a/apps/cloudrun-usage/README.md
+++ b/apps/cloudrun-usage/README.md
@@ -2,7 +2,7 @@
 
 Cloud Run service that handles the `usage` slice of the Convex → GCP migration: platform API-key auth, request logging, Redis usage-aggregate ingest, and the dashboard-facing user/project/usage queries.
 
-Unlike the other `cloudrun-*` services, `usage` has `ingress = INGRESS_TRAFFIC_ALL` (needed for externally-sourced webhook/ingest traffic). The canonical event rollup + prune crons live on **cloudrun-assets** (`/jobs/rollup-active-api-usage`, `/jobs/prune-api-request-events`) — this service intentionally hosts no crons to avoid double-counting.
+Unlike the other `cloudrun-*` services, `usage` has `ingress = INGRESS_TRAFFIC_ALL` (needed for externally-sourced webhook/ingest traffic). The canonical event rollup + prune + partition-maintenance crons live on **cloudrun-assets** (`/jobs/rollup-active-api-usage`, `/jobs/prune-api-request-events`, `/jobs/create-api-usage-partitions`) — this service intentionally hosts no crons to avoid double-counting.
 
 ## Wire format
 

--- a/db/migrations/0003_api_usage.sql
+++ b/db/migrations/0003_api_usage.sql
@@ -1,6 +1,13 @@
 -- 0003_api_usage.sql
 -- API request events (partitioned by month) + daily rollups + rollup cursor state.
 
+-- The partition bounds below are date-only literals, resolved in the session
+-- TimeZone at DDL time. Pin UTC so a fresh database bootstrapped on a server
+-- with a non-UTC default gets the same absolute bounds as production (0011's
+-- alignment guard depends on this). No effect where this migration is already
+-- applied — apply.sh skips it by version.
+SET LOCAL TimeZone = 'UTC';
+
 CREATE TABLE api_request_events (
     id          text NOT NULL,
     project_id  text NOT NULL,

--- a/db/migrations/0011_api_usage_partitions.sql
+++ b/db/migrations/0011_api_usage_partitions.sql
@@ -95,4 +95,13 @@ CREATE TABLE IF NOT EXISTS api_request_events_y2027m02 PARTITION OF api_request_
 CREATE TABLE IF NOT EXISTS api_request_events_y2027m03 PARTITION OF api_request_events
     FOR VALUES FROM ('2027-03-01 00:00:00+00') TO ('2027-04-01 00:00:00+00');
 
+-- The create-api-usage-partitions cron probes the default partition daily
+-- for covered-era rows (created_at >= 2026-05-01). No inherited index covers
+-- created_at (the PK leads with id), so without this the probe is a
+-- sequential scan of whatever sits in the default partition — 0003
+-- explicitly anticipates historical imports living there. Index only this
+-- partition; the hot-path monthly partitions are unaffected.
+CREATE INDEX IF NOT EXISTS api_request_events_default_created_at_idx
+    ON api_request_events_default (created_at);
+
 INSERT INTO schema_migrations(version) VALUES ('0011_api_usage_partitions');

--- a/db/migrations/0011_api_usage_partitions.sql
+++ b/db/migrations/0011_api_usage_partitions.sql
@@ -1,0 +1,62 @@
+-- 0011_api_usage_partitions.sql
+-- Extend api_request_events monthly partition coverage through March 2027.
+--
+-- 0003_api_usage.sql pre-created partitions only through August 2026
+-- (upper bound 2026-09-01); from that instant every insert would silently
+-- fall through to api_request_events_default, and once a month's rows sit
+-- in the default partition that month's partition can no longer be created
+-- with plain DDL. The create-api-usage-partitions cron on cloudrun-assets
+-- rolls coverage forward from here; this migration closes the immediate gap
+-- and gives the cron several months of headroom.
+--
+-- apply.sh runs this file inside a single transaction, so SET LOCAL applies
+-- to every statement below. TimeZone is pinned so the bound literals and the
+-- guard's rendered text are session-independent; lock_timeout keeps the
+-- ACCESS EXCLUSIVE lock acquisition on the parent from damming the insert
+-- path behind a long-running query (on timeout the whole file rolls back and
+-- can simply be re-applied).
+SET LOCAL TimeZone = 'UTC';
+SET LOCAL lock_timeout = '5s';
+
+-- Guard: the new partitions butt up against api_request_events_y2026m08.
+-- If its live upper bound is not exactly 2026-09-01 00:00:00+00 (e.g. 0003
+-- was applied under a non-UTC session TimeZone), creating m09 from that
+-- instant would leave a silent coverage gap — abort loudly instead.
+DO $$
+DECLARE
+    m08_bounds text;
+BEGIN
+    SELECT pg_get_expr(c.relpartbound, c.oid) INTO m08_bounds
+    FROM pg_class c
+    JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE n.nspname = 'public' AND c.relname = 'api_request_events_y2026m08';
+
+    IF m08_bounds IS NULL THEN
+        RAISE EXCEPTION 'api_request_events_y2026m08 not found; 0003_api_usage must be applied first';
+    END IF;
+    IF m08_bounds <> 'FOR VALUES FROM (''2026-08-01 00:00:00+00'') TO (''2026-09-01 00:00:00+00'')' THEN
+        RAISE EXCEPTION 'api_request_events_y2026m08 has unexpected bounds [%]; verify partition alignment before applying 0011', m08_bounds;
+    END IF;
+END $$;
+
+-- IF NOT EXISTS (unlike 0003's plain CREATE): the roll-forward cron or an
+-- emergency manual fix may legitimately create some of these partitions
+-- before this migration is applied; a name collision must not wedge the
+-- whole file. Bounds use explicit +00 offsets so the resolved instants do
+-- not depend on the applying session's TimeZone.
+CREATE TABLE IF NOT EXISTS api_request_events_y2026m09 PARTITION OF api_request_events
+    FOR VALUES FROM ('2026-09-01 00:00:00+00') TO ('2026-10-01 00:00:00+00');
+CREATE TABLE IF NOT EXISTS api_request_events_y2026m10 PARTITION OF api_request_events
+    FOR VALUES FROM ('2026-10-01 00:00:00+00') TO ('2026-11-01 00:00:00+00');
+CREATE TABLE IF NOT EXISTS api_request_events_y2026m11 PARTITION OF api_request_events
+    FOR VALUES FROM ('2026-11-01 00:00:00+00') TO ('2026-12-01 00:00:00+00');
+CREATE TABLE IF NOT EXISTS api_request_events_y2026m12 PARTITION OF api_request_events
+    FOR VALUES FROM ('2026-12-01 00:00:00+00') TO ('2027-01-01 00:00:00+00');
+CREATE TABLE IF NOT EXISTS api_request_events_y2027m01 PARTITION OF api_request_events
+    FOR VALUES FROM ('2027-01-01 00:00:00+00') TO ('2027-02-01 00:00:00+00');
+CREATE TABLE IF NOT EXISTS api_request_events_y2027m02 PARTITION OF api_request_events
+    FOR VALUES FROM ('2027-02-01 00:00:00+00') TO ('2027-03-01 00:00:00+00');
+CREATE TABLE IF NOT EXISTS api_request_events_y2027m03 PARTITION OF api_request_events
+    FOR VALUES FROM ('2027-03-01 00:00:00+00') TO ('2027-04-01 00:00:00+00');
+
+INSERT INTO schema_migrations(version) VALUES ('0011_api_usage_partitions');

--- a/db/migrations/0011_api_usage_partitions.sql
+++ b/db/migrations/0011_api_usage_partitions.sql
@@ -10,21 +10,30 @@
 -- and gives the cron several months of headroom.
 --
 -- apply.sh runs this file inside a single transaction, so SET LOCAL applies
--- to every statement below. TimeZone is pinned so the bound literals and the
--- guard's rendered text are session-independent; lock_timeout keeps the
--- ACCESS EXCLUSIVE lock acquisition on the parent from damming the insert
--- path behind a long-running query (on timeout the whole file rolls back and
--- can simply be re-applied).
+-- to every statement below. TimeZone and DateStyle are pinned so the bound
+-- literals and the guard's pg_get_expr-rendered text are session- and
+-- cluster-setting-independent; lock_timeout keeps the ACCESS EXCLUSIVE lock
+-- acquisition on the parent from damming the insert path behind a
+-- long-running query (on timeout the whole file rolls back and can simply be
+-- re-applied).
 SET LOCAL TimeZone = 'UTC';
+SET LOCAL DateStyle = 'ISO';
 SET LOCAL lock_timeout = '5s';
 
--- Guard: the new partitions butt up against api_request_events_y2026m08.
--- If its live upper bound is not exactly 2026-09-01 00:00:00+00 (e.g. 0003
--- was applied under a non-UTC session TimeZone), creating m09 from that
--- instant would leave a silent coverage gap — abort loudly instead.
+-- Guards. First: the new partitions butt up against
+-- api_request_events_y2026m08 — if its live upper bound is not exactly
+-- 2026-09-01 00:00:00+00 (e.g. 0003 was applied under a non-UTC session
+-- TimeZone), creating m09 from that instant would leave a silent coverage
+-- gap; abort loudly instead. Second: IF NOT EXISTS below skips by name only,
+-- so any pre-existing relation named like a target partition must be a real
+-- partition of api_request_events with exactly the expected bounds —
+-- otherwise this file would record success while the coverage gap persists.
 DO $$
 DECLARE
     m08_bounds text;
+    rec record;
+    found_bounds text;
+    found_parent_ok boolean;
 BEGIN
     SELECT pg_get_expr(c.relpartbound, c.oid) INTO m08_bounds
     FROM pg_class c
@@ -37,6 +46,33 @@ BEGIN
     IF m08_bounds <> 'FOR VALUES FROM (''2026-08-01 00:00:00+00'') TO (''2026-09-01 00:00:00+00'')' THEN
         RAISE EXCEPTION 'api_request_events_y2026m08 has unexpected bounds [%]; verify partition alignment before applying 0011', m08_bounds;
     END IF;
+
+    FOR rec IN
+        SELECT *
+        FROM (VALUES
+            ('api_request_events_y2026m09', '2026-09-01 00:00:00+00', '2026-10-01 00:00:00+00'),
+            ('api_request_events_y2026m10', '2026-10-01 00:00:00+00', '2026-11-01 00:00:00+00'),
+            ('api_request_events_y2026m11', '2026-11-01 00:00:00+00', '2026-12-01 00:00:00+00'),
+            ('api_request_events_y2026m12', '2026-12-01 00:00:00+00', '2027-01-01 00:00:00+00'),
+            ('api_request_events_y2027m01', '2027-01-01 00:00:00+00', '2027-02-01 00:00:00+00'),
+            ('api_request_events_y2027m02', '2027-02-01 00:00:00+00', '2027-03-01 00:00:00+00'),
+            ('api_request_events_y2027m03', '2027-03-01 00:00:00+00', '2027-04-01 00:00:00+00')
+        ) AS t(relname, lo, hi)
+    LOOP
+        SELECT pg_get_expr(c.relpartbound, c.oid),
+               COALESCE(i.inhparent = 'public.api_request_events'::regclass, false)
+          INTO found_bounds, found_parent_ok
+          FROM pg_class c
+          JOIN pg_namespace n ON n.oid = c.relnamespace
+          LEFT JOIN pg_inherits i ON i.inhrelid = c.oid
+         WHERE n.nspname = 'public' AND c.relname = rec.relname;
+
+        IF FOUND AND (NOT found_parent_ok
+                      OR found_bounds IS DISTINCT FROM format('FOR VALUES FROM (%L) TO (%L)', rec.lo, rec.hi)) THEN
+            RAISE EXCEPTION '% already exists but is not a partition of api_request_events with bounds [% .. %); resolve it before applying 0011',
+                rec.relname, rec.lo, rec.hi;
+        END IF;
+    END LOOP;
 END $$;
 
 -- IF NOT EXISTS (unlike 0003's plain CREATE): the roll-forward cron or an

--- a/terraform/modules/env/main.tf
+++ b/terraform/modules/env/main.tf
@@ -452,6 +452,18 @@ module "scheduler_jobs" {
       attempt_deadline = "540s"
     },
     {
+      # Rolls api_request_events monthly partition coverage forward (current
+      # month + monthsAhead). Idempotent; daily so a failed run self-heals
+      # well before a month boundary.
+      name      = "create-api-usage-partitions"
+      schedule  = "45 0 * * *"
+      http_path = "/jobs/create-api-usage-partitions"
+      body_json = jsonencode({
+        monthsAhead = 3
+      })
+      attempt_deadline = "540s"
+    },
+    {
       name      = "refresh-curated-ohlcv-15m"
       schedule  = "6,36 * * * *"
       http_path = "/jobs/refresh-curated-ohlcv-15m"


### PR DESCRIPTION
Closes #23.

`api_request_events` monthly partition coverage ends at `2026-09-01`; from that instant every raw usage event routes silently to `api_request_events_default`, partition pruning is lost for all new data, and — once rows for a month sit in the default partition — that month's partition can no longer be created with plain DDL (`SQLSTATE 23514`), turning remediation into a locking data migration. Full analysis, an assertion-based proof of concept, and a transcript are in #23. This PR closes the immediate gap and adds the roll-forward mechanism the schema comments in `0003_api_usage.sql` anticipated ("pg_partman or a cron handles subsequent months going forward").

## Changes

**`db/migrations/0011_api_usage_partitions.sql`** — extends coverage with monthly partitions `y2026m09` through `y2027m03`.

- Bound literals carry explicit `+00` offsets, so the resolved instants do not depend on the applying session's `TimeZone` (0003's bare-date bounds are session-dependent at DDL time).
- A guard block asserts the live `y2026m08` upper bound is exactly `2026-09-01 00:00:00+00` before creating anything. If 0003 was ever applied under a non-UTC session, blindly creating `m09` from that instant would leave a silent coverage sliver; the guard converts that scenario into a loud, transactional abort.
- `CREATE TABLE IF NOT EXISTS` (unlike 0003's plain `CREATE`) so a partition already created by the new cron — migrations here are applied manually, decoupled from deploys — cannot wedge the file.
- `SET LOCAL lock_timeout = '5s'` so the `ACCESS EXCLUSIVE` acquisition on the parent fails fast instead of queueing inserts behind it; on timeout the file rolls back and can simply be re-applied.

**`apps/cloudrun-assets`: `create-api-usage-partitions` job** — daily roll-forward so the schedule never runs dry again.

- Ensures partitions for the current month plus `monthsAhead` (default 3) future months, computed in UTC; `processed = monthsAhead + 1`.
- `JobsRepo.ensureApiRequestEventsPartition` checks the catalog first: a pre-existing relation is only reported `exists` if it is a partition of `public.api_request_events` with exactly the expected bounds; otherwise the job reports `bound_mismatch` and logs an error rather than silently trusting a name collision. Creation runs inside a transaction with `SET LOCAL TimeZone = 'UTC'` and `lock_timeout = '5s'`. Duplicate-creation races (`42P07`/`23505` despite `IF NOT EXISTS`) are treated as success; a `23514` failure is logged distinctly, since it means rows already fell through for that month and daily retries cannot fix it.
- The table name and bound literals are the only values interpolated into DDL (which cannot take bind parameters); both are pinned by strict regexes before use. This is the first app-issued DDL in the repo — flagged here deliberately.
- After the loop, a bounded probe counts covered-era rows (`created_at >= 2026-05-01`) in the default partition and warns if any exist — the tripwire for a missed boundary. Pre-coverage historical imports, which 0003 explicitly anticipates living in the default partition, are excluded.
- Per-month failures are caught and counted (`failed`), matching `rollupActiveApiUsage`/`pruneApiRequestEvents`; the job returns `ok: true` with `created`/`existing`/`boundMismatches`/`failed`/`defaultPartitionRows`.

**Terraform** — Cloud Scheduler entry, daily `45 0 * * *` UTC, both environments, `attempt_deadline = "540s"` uniform with the neighboring usage jobs. The module's default retry config (3 retries, 10–120s backoff) applies. Because the first fire after a Terraform apply is the following 00:45 UTC, the scheduler entry landing before the Cloud Run revision that carries the handler is harmless in practice.

**Alerting** — `alert-rules/api-usage-partition-maintenance-unhealthy.json`, following the structure of `coingecko-coin-list-sync-unhealthy.json` (same reduce/threshold expressions, same labels/routing: warning → Slack). It fires when the job logs an ensure/probe failure or the default-partition probe finds rows, over a 25h window so a failing daily run keeps the alert asserted. The `runbook_url` points at #23, which documents the remediation path if a month is ever missed. Without this rule, a silently failing roll-forward job would reproduce exactly the incident this PR prevents.

## Tests

- `crons.test.ts`: month/bound generation for a fixed clock, year rollover (Nov 2026 → Jan/Feb 2027 names and bounds), idempotency when all partitions exist, partial failure continuing with later months, bound-mismatch reporting, default-partition probe surfacing, and arg validation. `JobsRepo` mocks updated across the five files that implement it structurally.
- `bun test` for `apps/cloudrun-assets`: 436 pass / 0 fail; `typecheck` and `lint` clean; `check:repo-hygiene` and `verify:api-health-routes` pass; `terraform fmt -check` and `terraform validate` pass on 1.9.8.
- Verified end-to-end against a local PostgreSQL 16.6 (the version Cloud SQL runs): fresh apply of `0001`–`0011` yields 11 contiguous monthly partitions through `2027-04-01` with September/March inserts routing to monthly partitions; applying 0011 over a cron-pre-created `y2026m09` succeeds cleanly; a deliberately mis-bounded `y2026m08` makes the guard abort with a full rollback and no `schema_migrations` row. The real repo functions were also exercised against that database: create/exists/bound-mismatch outcomes, rejection of invalid identifiers, and the probe counting a covered-era fallthrough row while ignoring a pre-coverage one.

## Rollout note

The migration is the only part that closes the gap without depending on a deploy, and the boundary is 2026-09-01: `0011` should be applied to the staging and production databases promptly after merge (`DATABASE_URL=... ./db/apply.sh`). While the default partition is empty the new `CREATE`s are instant. After the first scheduled run, the job's `[createApiUsagePartitions] ok ...` line in Loki should list the migration's partitions under `existing`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
