### PR TITLE
Track the .env.example templates the setup docs reference

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,12 @@
+# Root environment for local scripts and database tooling.
+#
+#   cp .env.example .env.local
+#
+# The Next.js apps load their OWN config from apps/<app>/.env.local (see the
+# .env.example in each app directory). This root file is the shared layer that
+# local maintenance scripts read via scripts/_env.mjs.
+#
+# db/apply.sh reads DATABASE_URL from the environment rather than this file, so
+# pass it explicitly, e.g. `DATABASE_URL=postgres://... ./db/apply.sh`. The
+# value below matches the dockerized Postgres in scripts/dev-cloudrun-stack.sh.
+DATABASE_URL=postgres://tokens:tokens@localhost:54329/tokens

--- a/.gitignore
+++ b/.gitignore
@@ -74,3 +74,6 @@ tfplan
 terraform/**/tfplan*
 .vercel
 .env*
+# Keep committed .env.example templates (see README/CONTRIBUTING setup steps).
+!.env.example
+!**/.env.example

--- a/apps/admin/.env.example
+++ b/apps/admin/.env.example
@@ -1,0 +1,28 @@
+# apps/admin — authenticated maintainer curation tooling.
+#
+#   cp apps/admin/.env.example apps/admin/.env.local
+#
+# Uncommented values are working defaults for the local dev stack. Fill in the
+# blank secrets. This is an authenticated maintainer surface, not a public app.
+
+# --- Clerk auth (required) --------------------------------------------------
+# From your Clerk instance: https://dashboard.clerk.com.
+NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=pk_test_xxxxxxxxxxxxxxxxxxxxxxxx
+CLERK_SECRET_KEY=
+# CLERK_AUTHORIZED_PARTIES=http://localhost:3004
+
+# --- Cloud Run admin backend (required) -------------------------------------
+# Defaults match the local dev stack (admin service on 3013).
+TOKENS_CLOUDRUN_ADMIN_URL=http://localhost:3013
+TOKENS_CLOUDRUN_AUTH_TOKEN=dev-token
+# Optional assets service, for admin actions that reach it.
+# TOKENS_CLOUDRUN_ASSETS_URL=http://localhost:3010
+
+# --- Admin access control (required for any admin action) -------------------
+# Comma-separated Clerk user IDs allowed to use admin tooling. Empty = nobody
+# is admin. Set this to your own Clerk user ID for local development.
+TOKENS_ADMIN_CLERK_USER_IDS=
+
+# --- Misc (optional) --------------------------------------------------------
+# "Back to web app" nav link target (default https://tokens.xyz).
+# NEXT_PUBLIC_TOKENS_WEB_URL=http://localhost:3000

--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -1,0 +1,69 @@
+# apps/api — platform API (/v1) and internal helper routes.
+#
+#   cp apps/api/.env.example apps/api/.env.local
+#
+# The uncommented values below are working defaults for the local dev stack
+# (scripts/dev-cloudrun-stack.sh). Fill in the blank secrets; uncomment the
+# optional groups you need.
+
+# --- Clerk auth (required to serve authenticated routes) --------------------
+# From your Clerk instance: https://dashboard.clerk.com. The publishable key is
+# client-exposed by design; the secret key must stay private (leave blank here).
+NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=pk_test_xxxxxxxxxxxxxxxxxxxxxxxx
+CLERK_SECRET_KEY=
+# Optional: restrict Clerk authorized parties (comma-separated origins).
+# CLERK_AUTHORIZED_PARTIES=http://localhost:3000,http://localhost:3001
+
+# --- Cloud Run backend services (required) ----------------------------------
+# Base URLs of the cloudrun-* services. Defaults match the local dev stack
+# (assets=3010 prices=3011 usage=3012 admin=3013).
+TOKENS_CLOUDRUN_ASSETS_URL=http://localhost:3010
+TOKENS_CLOUDRUN_PRICES_URL=http://localhost:3011
+TOKENS_CLOUDRUN_USAGE_URL=http://localhost:3012
+# Shared bearer token the API uses to call the Cloud Run services. The local
+# dev stack defaults to "dev-token"; use a strong secret in production.
+TOKENS_CLOUDRUN_AUTH_TOKEN=dev-token
+# Optional admin service (IAM-locked in production) and request timeout (ms).
+# TOKENS_CLOUDRUN_ADMIN_URL=http://localhost:3013
+# TOKENS_CLOUDRUN_TIMEOUT_MS=15000
+
+# --- Redis: rate limiting, monthly quota, auth cache ------------------------
+# Backend selector: "upstash" (default) or "memorystore".
+# TOKENS_REDIS_TARGET=upstash
+#
+# Upstash REST credentials — set BOTH or NEITHER. With neither set, rate
+# limiting is disabled (fails open), which is fine for local dev.
+# UPSTASH_REDIS_REST_URL=
+# UPSTASH_REDIS_REST_TOKEN=
+#
+# Memorystore / self-hosted Redis (only when TOKENS_REDIS_TARGET=memorystore):
+# REDIS_HOST=127.0.0.1
+# REDIS_PORT=6379
+# REDIS_AUTH_STRING=
+# REDIS_TLS=false
+
+# --- External data providers (optional; related features degrade if unset) --
+# BIRDEYE_API_KEY=
+# COINGECKO_API_KEY=
+# OPENAI_API_KEY=
+# DD_API_KEY=
+# X / Twitter feed: set X_BEARER_TOKEN, or X_API_KEY + X_API_SECRET together.
+# X_BEARER_TOKEN=
+# X_API_KEY=
+# X_API_SECRET=
+
+# --- Internal shared secrets (optional) -------------------------------------
+# TOKENS_CACHE_WARM_SECRET=
+# TOKENS_USAGE_INGEST_SECRET=
+# HMAC secret for dashboard playground proxy auth; must match apps/app. In
+# non-production the API falls back to "dev-playground-proxy-secret" if unset.
+# TOKENS_PLAYGROUND_PROXY_SECRET=
+
+# --- Usage logging and default limits (optional; defaults shown) ------------
+# TOKENS_USAGE_LOG_MODE=aggregated          # raw | off | aggregated
+# TOKENS_USAGE_RAW_SAMPLE_RATE=0            # 0..1
+# TOKENS_AUTH_CACHE_TTL_SECONDS=60          # 0..300
+# TOKENS_USAGE_AGGREGATION_TTL_SECONDS=172800
+# TOKENS_DEFAULT_RATE_LIMIT_REQUESTS=100000
+# TOKENS_DEFAULT_RATE_LIMIT_WINDOW_SECONDS=10
+# TOKENS_DEFAULT_QUOTA_PER_MONTH=1000000000

--- a/apps/app/.env.example
+++ b/apps/app/.env.example
@@ -1,0 +1,32 @@
+# apps/app — first-party developer dashboard (projects, API keys, usage).
+#
+#   cp apps/app/.env.example apps/app/.env.local
+#
+# Uncommented values are working defaults for the local dev stack. Fill in the
+# blank secrets.
+
+# --- Clerk auth (required) --------------------------------------------------
+# From your Clerk instance: https://dashboard.clerk.com.
+NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=pk_test_xxxxxxxxxxxxxxxxxxxxxxxx
+CLERK_SECRET_KEY=
+# CLERK_AUTHORIZED_PARTIES=http://localhost:3001
+
+# --- Cloud Run usage backend (required) -------------------------------------
+# Defaults match the local dev stack (usage service on 3012).
+TOKENS_CLOUDRUN_USAGE_URL=http://localhost:3012
+TOKENS_CLOUDRUN_AUTH_TOKEN=dev-token
+# TOKENS_CLOUDRUN_TIMEOUT_MS=15000
+
+# --- Platform API (for the in-dashboard API playground) ---------------------
+# Origin the dashboard's /api/v1/* proxy forwards to. The proxy accepts, in
+# priority order, API_BASE_URL, TOKENS_API_ORIGIN, TOKENS_API_BASE_URL, then
+# NEXT_PUBLIC_API_BASE_URL; the client-side playground reads
+# NEXT_PUBLIC_API_BASE_URL specifically, so setting that one covers both.
+NEXT_PUBLIC_API_BASE_URL=http://localhost:3002
+# API_BASE_URL=http://localhost:3002
+# TOKENS_API_ORIGIN=http://localhost:3002
+# TOKENS_API_BASE_URL=http://localhost:3002
+# HMAC secret for signing playground proxy requests. Must match the API's
+# TOKENS_PLAYGROUND_PROXY_SECRET; the value below matches the API's default
+# non-production fallback so the playground works locally out of the box.
+TOKENS_PLAYGROUND_PROXY_SECRET=dev-playground-proxy-secret

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -1,0 +1,37 @@
+# apps/web — public website.
+#
+#   cp apps/web/.env.example apps/web/.env.local
+#
+# Fill in the platform API key; the rest have working local defaults or are
+# optional.
+
+# --- Platform API (required) ------------------------------------------------
+# Server-side key the web proxy injects as `x-api-key` when calling the API.
+# Create one from the dashboard (apps/app) once it is running.
+TOKENS_PLATFORM_API_KEY=
+# Origin the web proxy forwards to. In production one of these MUST be set; for
+# local dev it defaults to http://localhost:3002. API_BASE_URL wins if both set.
+API_BASE_URL=http://localhost:3002
+# TOKENS_API_ORIGIN=http://localhost:3002
+
+# --- Optional integrations --------------------------------------------------
+# If set, uses the CoinGecko Pro API; otherwise the free public API.
+# COINGECKO_API_KEY=
+# Extra hostnames allowed through the image/asset proxy (comma-separated).
+# TOKENS_IMAGE_PROXY_ALLOWED_HOSTS=
+
+# --- Status page (optional) -------------------------------------------------
+# The /status page queries Grafana Loki. All three are required to enable it;
+# otherwise it degrades gracefully. GRAFANA_LOKI_{URL,USER,TOKEN} are accepted
+# as aliases for each corresponding value.
+# TOKENS_STATUS_LOKI_URL=
+# TOKENS_STATUS_LOKI_USER=
+# TOKENS_STATUS_LOKI_TOKEN=
+# TOKENS_STATUS_LOKI_ENV=prd
+# TOKENS_STATUS_LOKI_TARGET=prod
+
+# --- Client analytics (optional; NEXT_PUBLIC_* are shipped to the browser) --
+# NEXT_PUBLIC_POSTHOG_KEY=
+# NEXT_PUBLIC_POSTHOG_DEBUG=false
+# Canonical site origin for OG/absolute URLs (default https://token.solana.com).
+# NEXT_PUBLIC_SITE_URL=http://localhost:3000


### PR DESCRIPTION
Closes #27.

`README.md` and `CONTRIBUTING.md` instruct copying five `.env.example` files during setup, but none were tracked — `.gitignore`'s `.env*` rule matched them with no negation, so a clean clone did not contain them and the documented first-run failed on the first `cp`. This adds the templates and un-ignores them.

## Changes

- **`.gitignore`** — add `!.env.example` and `!**/.env.example` after `.env*`, so `.env.example` templates (root and nested) are committable while real `.env` / `.env*.local` files stay ignored. `scripts/check-repo-hygiene.mjs` already exempts `.env.example` from its tracked-secret check, so the templates pass hygiene.
- **Five `.env.example` templates** — root, `apps/api`, `apps/app`, `apps/admin`, `apps/web` (matching the paths the docs reference; `apps/docs` reads no env and is correctly omitted).

## How the templates were built

- Variable names are taken **only** from what each app's source actually reads (`process.env.*`, `apps/api/src/lib/env.ts`, and the Clerk middleware's implicit keys). Nothing is invented.
- **Secrets are left blank** (`CLERK_SECRET_KEY`, `TOKENS_PLATFORM_API_KEY`, provider API keys, HMAC/ingest secrets, Upstash token, `TOKENS_ADMIN_CLERK_USER_IDS`).
- **Non-secret infra wiring uses the local dev-stack defaults already present in `scripts/dev-cloudrun-stack.sh`** — Cloud Run service URLs on ports 3010-3013, `TOKENS_CLOUDRUN_AUTH_TOKEN=dev-token`, Postgres on `54329`, and `apps/app`'s playground secret set to the API's documented non-production fallback — so copying the templates yields a working local setup rather than a list of blanks. No real credential, production URL, GCP project ID, bucket, or Clerk instance ID appears anywhere; every concrete value is either `localhost`, a placeholder, or already public in the repo.
- Required variables are uncommented; optional ones are commented out with their defaults shown.

## Verification

- On a clean tree exported with `git archive HEAD`, the five documented `cp` commands **failed 5/5** before this change and **succeed 5/5** after it.
- `git check-ignore` confirms the five `.env.example` paths are now trackable while `.env`, `.env.local`, and `apps/*/.env.local` stay ignored; a `git add -A` dry run stages only the templates and `.gitignore`, never a secret-bearing file.
- `bun run check:repo-hygiene`, `bun run verify:api-health-routes`, and the full `bun run test` suite pass. The change touches no application or test code.

## Note (out of scope for this PR)

Following the README's Getting Started literally still leaves the backend unconfigured until `scripts/dev-cloudrun-stack.sh` is started (which provides the `:3010-3013` services these templates default to). The templates reference that script in their comments, but the README's Getting Started section does not mention it. That's a separate documentation gap from the missing templates; happy to follow up if a README step for the local backend stack would be welcome.
