### PR TITLE
asset-registry: add display metadata for four PreStocks canonical entries

### DIFF
--- a/packages/asset-registry/src/data/equities.ts
+++ b/packages/asset-registry/src/data/equities.ts
@@ -42,14 +42,33 @@ const SK_HYNIX_ONDO_MINT = 'Huyb2fyDDjSuDKCRWsN9ci2rmcgPo6NFiLbx9ZDondo';
 const SK_HYNIX_XSTOCK_MINT = 'XsnhgGRQwhExfS2bmWzR6EYddKGPRGDEjeJsatkmKqU';
 const TAKE_TWO_BACKPACK_MINT = 'TTWofwAge91oFhZs7kpQdyrVRkmevgM88xijGvQFbKo';
 
+const ANTHROPIC_PRESTOCK_MINT = 'Pren1FvFX6J3E4kXhJuCiAD5aDmGEb7qJRncwA8Lkhw';
+const ANDURIL_PRESTOCK_MINT = 'PresTj4Yc2bAR197Er7wz4UUKSfqt6FryBEdAriBoQB';
+const POLYMARKET_PRESTOCK_MINT = 'Pre8AREmFPtoJFT8mQSXQLh56cwJmM7CFDRuoGBZiUP';
+const KALSHI_PRESTOCK_MINT = 'PreLWGkkeqG1s4HEfFZSy9moCrJ7btsHuUtfcCeoRua';
+
 const PRE_STOCK_MINTS: string[] = [
     SPACEX_PRESTOCK_MINT,
     OPENAI_PRESTOCK_MINT,
-    'Pren1FvFX6J3E4kXhJuCiAD5aDmGEb7qJRncwA8Lkhw',
-    'PresTj4Yc2bAR197Er7wz4UUKSfqt6FryBEdAriBoQB',
-    'Pre8AREmFPtoJFT8mQSXQLh56cwJmM7CFDRuoGBZiUP',
-    'PreLWGkkeqG1s4HEfFZSy9moCrJ7btsHuUtfcCeoRua',
+    ANTHROPIC_PRESTOCK_MINT,
+    ANDURIL_PRESTOCK_MINT,
+    POLYMARKET_PRESTOCK_MINT,
+    KALSHI_PRESTOCK_MINT,
 ];
+
+/**
+ * Display metadata for PreStocks mints that are not promoted to a hand-curated asset.
+ *
+ * Without this, `buildPreStockAssets` emits a canonical entry carrying only an address, so a
+ * consumer comparing a candidate mint against the canonical one has nothing to compare but the
+ * address itself. SpaceX and OpenAI already avoid this by being fully described above.
+ */
+const PRE_STOCK_METADATA: Record<string, { symbol: string; name: string }> = {
+    [ANTHROPIC_PRESTOCK_MINT]: { symbol: 'ANTHROPIC', name: 'Anthropic PreStocks' },
+    [ANDURIL_PRESTOCK_MINT]: { symbol: 'ANDURIL', name: 'Anduril PreStocks' },
+    [POLYMARKET_PRESTOCK_MINT]: { symbol: 'POLYMARKET', name: 'Polymarket PreStocks' },
+    [KALSHI_PRESTOCK_MINT]: { symbol: 'KALSHI', name: 'Kalshi PreStocks' },
+};
 
 const UNLISTED_STOCK_MINTS: string[] = [
     'B5KufqHkskgGYwMXtL8FSHgREAkMQvE3ykhH5Kmondo',
@@ -526,18 +545,22 @@ function buildSpecialEquityAssets(): CanonicalAsset[] {
 function buildPreStockAssets(existingMints: ReadonlySet<string>): CanonicalAsset[] {
     return PRE_STOCK_MINTS.filter(mint => !existingMints.has(mint) && !SPECIAL_EQUITY_MINTS.has(mint)).map(mint => {
         const assetId = preStockAssetId(mint);
+        const metadata = PRE_STOCK_METADATA[mint];
 
         return {
             assetId,
+            ...(metadata ? { name: metadata.name, symbol: metadata.symbol } : {}),
             category: 'equity',
-            aliases: uniqueStrings([assetId, mint]),
+            aliases: uniqueStrings([assetId, mint, ...(metadata ? [metadata.symbol, metadata.name] : [])]),
             variants: [
                 {
                     variantId: `${assetId}:mint`,
                     mint,
+                    ...(metadata ? { symbol: metadata.symbol, name: metadata.name } : {}),
                     kind: 'tokenized_equity',
                     trustTier: defaultTrustTier(),
-                    tags: ['curated:stocks'],
+                    tags: metadata ? ['curated:stocks', 'PreStocks'] : ['curated:stocks'],
+                    ...(metadata ? { label: 'PreStocks' } : {}),
                     stockVariantTier: 'not_redeemable',
                 },
             ],


### PR DESCRIPTION
## Problem

`buildPreStockAssets` emits canonical entries that carry only a mint address. Four PreStocks assets are registered as canonical with no `symbol`, no `name`, and no `label`:

```
pre-pren1fvf   equity   tags=["curated:stocks"]   Pren1FvFX6J3E4kXhJuCiAD5aDmGEb7qJRncwA8Lkhw
pre-prestj4y   equity   tags=["curated:stocks"]   PresTj4Yc2bAR197Er7wz4UUKSfqt6FryBEdAriBoQB
pre-pre8arem   equity   tags=["curated:stocks"]   Pre8AREmFPtoJFT8mQSXQLh56cwJmM7CFDRuoGBZiUP
pre-prelwgkk   equity   tags=["curated:stocks"]   PreLWGkkeqG1s4HEfFZSy9moCrJ7btsHuUtfcCeoRua
```

SpaceX and OpenAI are in the same cohort and are fully described, but only because they are promoted to hand-curated assets earlier in the file.

I understand `symbol` and `name` are optional by design and documented as "may be resolved dynamically", and this isn't a challenge to that. The narrower point is that these four are tagged `curated:*` while carrying nothing curation would normally supply, so a consumer comparing a candidate mint against the canonical record has only address equality available.

That has a practical consequence today: all four of these assets currently have mints on Solana using their ticker, and in one case a mint whose display name is byte-identical to a canonical registry entry. Method and data: https://github.com/nickisanders/mintcheck/blob/main/docs/PRESTOCKS-FINDINGS.md

## Change

- Named constants for the four mints, matching the existing `SPACEX_PRESTOCK_MINT` / `OPENAI_PRESTOCK_MINT` pattern
- A `PRE_STOCK_METADATA` map holding symbol and name
- `buildPreStockAssets` applies it when present; behaviour is unchanged for any mint absent from the map

Values were verified against on-chain token metadata.

One thing to flag: I also set `label: 'PreStocks'` and added the `PreStocks` tag on these entries, so they match how the existing SpaceX and OpenAI PreStocks variants are tagged and the cohort can be selected with a single rule rather than three. Happy to drop that half if you would rather keep the diff to `symbol` and `name` only.

## Verification

- `bun test src` in `packages/asset-registry`: 36 pass, 0 fail
- Canonical asset count unchanged at 549
- Entries with no symbol, no name and no label: 7 before, 3 after

## Not covered

Three `rwa-*` entries still carry no metadata (`rwa-9drppwyu`, `rwa-7lwanzte`, `rwa-5d3zuszj`). I could not resolve them from public token APIs, so I left them rather than guess.

## Unrelated, noting in passing

`CONTRIBUTING.md` instructs contributors to `cp .env.example .env.local` and similar for four apps, but `.gitignore:76` ignores `.env*`, so those templates are not present in the repo. Happy to open a separate issue if useful.
