### PR TITLE
test(api): expand unit coverage for health routes and helpers

### DIFF
--- a/apps/api/src/app/api/health/route.test.ts
+++ b/apps/api/src/app/api/health/route.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'bun:test';
+
+import { GET as healthGet } from './route';
+import { GET as v1HealthGet } from '../v1/health/route';
+
+async function assertPublicHealth(path: string, handler: (request: Request) => Response): Promise<void> {
+    const response = handler(new Request(`http://localhost${path}`));
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('Cache-Control')).toBe('no-store');
+
+    const requestId = response.headers.get('x-request-id');
+    expect(typeof requestId).toBe('string');
+    expect(requestId?.length ?? 0).toBeGreaterThan(0);
+
+    const payload = (await response.json()) as unknown;
+    expect(payload).toEqual({ ok: true });
+}
+
+describe('public health routes', () => {
+    it('serves /api/health with no-store caching and a request id', async () => {
+        await assertPublicHealth('/api/health', healthGet);
+    });
+
+    it('serves /api/v1/health with no-store caching and a request id', async () => {
+        await assertPublicHealth('/api/v1/health', v1HealthGet);
+    });
+
+    it('issues a unique x-request-id per call', () => {
+        const first = healthGet(new Request('http://localhost/api/health')).headers.get('x-request-id');
+        const second = healthGet(new Request('http://localhost/api/health')).headers.get('x-request-id');
+        expect(first).toBeTruthy();
+        expect(second).toBeTruthy();
+        expect(first).not.toBe(second);
+    });
+});

--- a/apps/api/src/app/api/v1/assets/_canonical-overrides.test.ts
+++ b/apps/api/src/app/api/v1/assets/_canonical-overrides.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'bun:test';
+
+import {
+    canonicalizeAsset,
+    canonicalizeAssetVariants,
+    SUI_ASSET_ID,
+    SUI_CANONICAL_MINT,
+    SUI_CANONICAL_NAME,
+    SUI_CANONICAL_SYMBOL,
+    SUI_LEGACY_MINT,
+} from './_canonical-overrides';
+
+describe('canonicalizeAssetVariants', () => {
+    it('leaves non-SUI assets untouched', () => {
+        const variants = [{ mint: 'abc', symbol: 'ABC', name: 'Abc' }];
+        expect(canonicalizeAssetVariants('solana', variants)).toBe(variants);
+    });
+
+    it('drops the legacy SUI mint and forces canonical identity on the primary mint', () => {
+        const variants = [
+            { mint: SUI_LEGACY_MINT, symbol: 'OLD', name: 'Old SUI' },
+            { mint: SUI_CANONICAL_MINT, symbol: 'wrong', name: 'wrong' },
+            { mint: 'other-mint', symbol: 'KEEP', name: 'Keep' },
+        ];
+
+        expect(canonicalizeAssetVariants(SUI_ASSET_ID, variants)).toEqual([
+            {
+                mint: SUI_CANONICAL_MINT,
+                symbol: SUI_CANONICAL_SYMBOL,
+                name: SUI_CANONICAL_NAME,
+            },
+            { mint: 'other-mint', symbol: 'KEEP', name: 'Keep' },
+        ]);
+    });
+});
+
+describe('canonicalizeAsset', () => {
+    it('forces SUI name/symbol and canonicalizes variants', () => {
+        const asset = {
+            assetId: SUI_ASSET_ID,
+            name: 'Wrong',
+            symbol: 'WRONG',
+            variants: [
+                { mint: SUI_LEGACY_MINT, symbol: 'OLD' },
+                { mint: SUI_CANONICAL_MINT, symbol: 'x', name: 'y' },
+            ],
+        };
+
+        expect(canonicalizeAsset(asset)).toEqual({
+            assetId: SUI_ASSET_ID,
+            name: SUI_CANONICAL_NAME,
+            symbol: SUI_CANONICAL_SYMBOL,
+            variants: [
+                {
+                    mint: SUI_CANONICAL_MINT,
+                    symbol: SUI_CANONICAL_SYMBOL,
+                    name: SUI_CANONICAL_NAME,
+                },
+            ],
+        });
+    });
+
+    it('returns other assets unchanged', () => {
+        const asset = {
+            assetId: 'solana',
+            name: 'Solana',
+            symbol: 'SOL',
+            variants: [{ mint: 'So11111111111111111111111111111111111111112' }],
+        };
+        expect(canonicalizeAsset(asset)).toBe(asset);
+    });
+});

--- a/apps/api/src/app/api/v1/assets/_coingecko-id.test.ts
+++ b/apps/api/src/app/api/v1/assets/_coingecko-id.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'bun:test';
+
+import { normalizeCoinGeckoCoinIdForAsset } from './_coingecko-id';
+
+describe('normalizeCoinGeckoCoinIdForAsset', () => {
+    it('returns null for empty coin ids', () => {
+        expect(normalizeCoinGeckoCoinIdForAsset({ assetId: 'solana', coinId: null })).toBe(null);
+        expect(normalizeCoinGeckoCoinIdForAsset({ assetId: 'solana', coinId: '   ' })).toBe(null);
+    });
+
+    it('rewrites legacy bnb coin id to binancecoin', () => {
+        expect(normalizeCoinGeckoCoinIdForAsset({ assetId: 'bnb', coinId: 'bnb' })).toBe('binancecoin');
+    });
+
+    it('keeps canonical tron when a legacy xStock coin id is present', () => {
+        expect(normalizeCoinGeckoCoinIdForAsset({ assetId: 'tron', coinId: 'tron-xstock' })).toBe('tron');
+    });
+
+    it('drops the PreStocks CoinGecko listing for canonical spacex', () => {
+        expect(normalizeCoinGeckoCoinIdForAsset({ assetId: 'spacex', coinId: 'spacex-prestocks-2' })).toBe(null);
+    });
+
+    it('passes through unrelated coin ids unchanged', () => {
+        expect(normalizeCoinGeckoCoinIdForAsset({ assetId: 'solana', coinId: ' solana ' })).toBe('solana');
+        expect(normalizeCoinGeckoCoinIdForAsset({ assetId: 'bnb', coinId: 'binancecoin' })).toBe('binancecoin');
+    });
+});

--- a/apps/api/src/app/api/v1/assets/_protocol-tokens.test.ts
+++ b/apps/api/src/app/api/v1/assets/_protocol-tokens.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'bun:test';
+
+import { getProtocolTokenFallback, POOL_PROTOCOL_TOKENS } from './_protocol-tokens';
+
+describe('getProtocolTokenFallback', () => {
+    it('returns null for empty input', () => {
+        expect(getProtocolTokenFallback('')).toBe(null);
+        expect(getProtocolTokenFallback('   ')).toBe(null);
+    });
+
+    it('matches by protocol source name', () => {
+        expect(getProtocolTokenFallback('Orca Whirlpool')?.source).toBe('orca');
+        expect(getProtocolTokenFallback('raydium-clmm')?.symbol).toBe('RAY');
+        expect(getProtocolTokenFallback('Marindade Finance')?.source).toBe('marinade');
+    });
+
+    it('matches by known protocol mint address', () => {
+        const orca = POOL_PROTOCOL_TOKENS.find(token => token.source === 'orca');
+        expect(orca).toBeTruthy();
+        expect(getProtocolTokenFallback(orca!.address)?.symbol).toBe('ORCA');
+    });
+
+    it('returns null for unknown sources', () => {
+        expect(getProtocolTokenFallback('unknown-dex')).toBe(null);
+    });
+});

--- a/apps/api/src/app/api/v1/assets/_singleton-asset-id.test.ts
+++ b/apps/api/src/app/api/v1/assets/_singleton-asset-id.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'bun:test';
+
+import {
+    isSingletonAssetId,
+    looksLikeSolanaMintAddress,
+    mintToSingletonAssetId,
+    singletonAssetIdToMint,
+} from './_singleton-asset-id';
+
+const USDC_MINT = 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v';
+
+describe('looksLikeSolanaMintAddress', () => {
+    it('accepts common Solana mint lengths in base58', () => {
+        expect(looksLikeSolanaMintAddress(USDC_MINT)).toBe(true);
+        expect(looksLikeSolanaMintAddress('11111111111111111111111111111111')).toBe(true);
+    });
+
+    it('rejects empty, too-short, and non-base58 values', () => {
+        expect(looksLikeSolanaMintAddress('')).toBe(false);
+        expect(looksLikeSolanaMintAddress('abc')).toBe(false);
+        expect(looksLikeSolanaMintAddress('0'.repeat(32))).toBe(false);
+        expect(looksLikeSolanaMintAddress('O'.repeat(32))).toBe(false);
+    });
+});
+
+describe('singleton asset id helpers', () => {
+    it('builds a solana- prefixed singleton asset id', () => {
+        expect(mintToSingletonAssetId(` ${USDC_MINT} `)).toBe(`solana-${USDC_MINT}`);
+    });
+
+    it('round-trips mint ↔ singleton asset id', () => {
+        const assetId = mintToSingletonAssetId(USDC_MINT);
+        expect(singletonAssetIdToMint(assetId)).toBe(USDC_MINT);
+        expect(isSingletonAssetId(assetId)).toBe(true);
+    });
+
+    it('returns null for non-singleton or invalid mint suffixes', () => {
+        expect(singletonAssetIdToMint('usdc')).toBe(null);
+        expect(singletonAssetIdToMint('solana-not-a-mint')).toBe(null);
+        expect(isSingletonAssetId('solana-not-a-mint')).toBe(false);
+    });
+});

--- a/apps/api/src/lib/env.test.ts
+++ b/apps/api/src/lib/env.test.ts
@@ -1,11 +1,17 @@
 import { describe, expect, it } from 'bun:test';
 
-import { loadEnv, resetEnvForTests } from './env';
+import { assertCloudRunEnvOrThrow, loadEnv, resetEnvForTests } from './env';
 
 const ENV_KEYS = [
     'NODE_ENV',
     'VERCEL_ENV',
     'TOKENS_USAGE_LOG_MODE',
+    'UPSTASH_REDIS_REST_URL',
+    'UPSTASH_REDIS_REST_TOKEN',
+    'TOKENS_CLOUDRUN_AUTH_TOKEN',
+    'TOKENS_CLOUDRUN_ASSETS_URL',
+    'TOKENS_CLOUDRUN_PRICES_URL',
+    'TOKENS_CLOUDRUN_USAGE_URL',
 ] as const;
 
 function setEnv(key: string, value: string): void {
@@ -69,5 +75,62 @@ describe('loadEnv usage logging mode', () => {
                 expect(loadEnv().usageLogMode).toBe('aggregated');
             },
         );
+    });
+});
+
+describe('loadEnv Upstash pairing', () => {
+    it('allows both Upstash vars to be unset', () => {
+        withEnv({}, () => {
+            expect(loadEnv().upstash).toBe(null);
+        });
+    });
+
+    it('loads Upstash when both URL and token are set', () => {
+        withEnv(
+            {
+                UPSTASH_REDIS_REST_URL: ' https://example.upstash.io ',
+                UPSTASH_REDIS_REST_TOKEN: ' token ',
+            },
+            () => {
+                expect(loadEnv().upstash).toEqual({
+                    url: 'https://example.upstash.io',
+                    token: 'token',
+                });
+            },
+        );
+    });
+
+    it('rejects setting only one of the Upstash credentials', () => {
+        withEnv({ UPSTASH_REDIS_REST_URL: 'https://example.upstash.io' }, () => {
+            expect(() => loadEnv()).toThrow(/must be set together/);
+        });
+
+        withEnv({ UPSTASH_REDIS_REST_TOKEN: 'token' }, () => {
+            expect(() => loadEnv()).toThrow(/must be set together/);
+        });
+    });
+});
+
+describe('assertCloudRunEnvOrThrow', () => {
+    it('passes when required Cloud Run vars are present', () => {
+        withEnv(
+            {
+                TOKENS_CLOUDRUN_AUTH_TOKEN: 'dev',
+                TOKENS_CLOUDRUN_ASSETS_URL: 'https://assets.example',
+                TOKENS_CLOUDRUN_PRICES_URL: 'https://prices.example',
+                TOKENS_CLOUDRUN_USAGE_URL: 'https://usage.example',
+            },
+            () => {
+                expect(() => assertCloudRunEnvOrThrow()).not.toThrow();
+            },
+        );
+    });
+
+    it('lists every missing required Cloud Run var', () => {
+        withEnv({}, () => {
+            expect(() => assertCloudRunEnvOrThrow()).toThrow(
+                /TOKENS_CLOUDRUN_AUTH_TOKEN, TOKENS_CLOUDRUN_ASSETS_URL, TOKENS_CLOUDRUN_PRICES_URL, TOKENS_CLOUDRUN_USAGE_URL/,
+            );
+        });
     });
 });

--- a/apps/api/src/lib/http-metrics.test.ts
+++ b/apps/api/src/lib/http-metrics.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'bun:test';
+
+import { normalizeEndpointPath, shouldSkipHttpMetrics } from './http-metrics';
+
+describe('shouldSkipHttpMetrics', () => {
+    it('skips both public health endpoints', () => {
+        expect(shouldSkipHttpMetrics('/api/health')).toBe(true);
+        expect(shouldSkipHttpMetrics('/api/v1/health')).toBe(true);
+    });
+
+    it('does not skip authenticated or asset routes', () => {
+        expect(shouldSkipHttpMetrics('/api/v1/whoami')).toBe(false);
+        expect(shouldSkipHttpMetrics('/api/v1/assets/solana')).toBe(false);
+    });
+});
+
+describe('normalizeEndpointPath', () => {
+    it('collapses asset detail paths onto parameterized templates', () => {
+        expect(normalizeEndpointPath('/api/v1/assets/solana')).toBe('/api/v1/assets/:assetId');
+        expect(normalizeEndpointPath('/api/v1/assets/solana/ohlcv')).toBe('/api/v1/assets/:assetId/ohlcv');
+        expect(normalizeEndpointPath('/api/v1/assets/solana/risk-summary')).toBe(
+            '/api/v1/assets/:assetId/risk-summary',
+        );
+    });
+
+    it('keeps named collection routes concrete', () => {
+        expect(normalizeEndpointPath('/api/v1/assets/search')).toBe('/api/v1/assets/search');
+        expect(normalizeEndpointPath('/api/v1/assets/curated')).toBe('/api/v1/assets/curated');
+        expect(normalizeEndpointPath('/api/v1/assets')).toBe('/api/v1/assets');
+        expect(normalizeEndpointPath('/api/v1/whoami')).toBe('/api/v1/whoami');
+        expect(normalizeEndpointPath('/api/v1/health')).toBe('/api/v1/health');
+    });
+
+    it('normalizes legacy token and coingecko routes', () => {
+        expect(normalizeEndpointPath('/api/token/So11111111111111111111111111111111111111112')).toBe(
+            '/api/token/:address',
+        );
+        expect(
+            normalizeEndpointPath('/api/token/So11111111111111111111111111111111111111112/markets'),
+        ).toBe('/api/token/:address/markets');
+        expect(normalizeEndpointPath('/api/coingecko/coins/bitcoin')).toBe('/api/coingecko/coins/:id');
+        expect(normalizeEndpointPath('/api/coingecko/coins/search')).toBe('/api/coingecko/coins/search');
+    });
+
+    it('returns unrecognized paths unchanged', () => {
+        expect(normalizeEndpointPath('/custom/path')).toBe('/custom/path');
+    });
+});


### PR DESCRIPTION
Add credential-free tests for public health handlers, asset id/coingecko/ protocol helpers, HTTP metrics path normalization, and env validation.

## Summary

Describe what changed.

## Why

Explain the reason for the change.

## Risk / Impact

Call out user-facing, API, auth, dependency, or operational risk.

## Verification

Confirm the credential-free checks pass (see TESTING.md):

- [ ] `bun run check:repo-hygiene`
- [ ] `bun run verify:api-health-routes`
- [ ] `bun run lint`
- [ ] `bun run build`
- [ ] `bun run audit:deps`

## Docs / Tests

Note any docs updates, new checks, or reasons they were not added.

## Linked issue

Closes #
