### PR TITLE
docs(testing): align TESTING.md with CI typecheck and unit tests

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -10,6 +10,8 @@ These run in CI and locally with no external accounts — this is the bar for a 
 bun run check:repo-hygiene
 bun run verify:api-health-routes
 bun run lint
+bun run typecheck
+bun run test
 bun run build
 bun run audit:deps
 ```
@@ -19,8 +21,16 @@ What these cover:
 - `check:repo-hygiene`: blocks tracked secret-bearing env files, assistant artifacts, and junk files such as `.DS_Store`
 - `verify:api-health-routes`: smoke-checks the public health route handlers and their cache/request-id behavior
 - `lint`: static analysis across the monorepo
+- `typecheck`: TypeScript checks across the workspaces in scope
+- `test`: unit tests (for example `apps/api` helpers, health routes, and other workspace `bun test` suites)
 - `build`: production builds for the workspaces in scope
 - `audit:deps`: dependency advisory scan
+
+Focused API unit tests (no credentials):
+
+```bash
+bun test apps/api/src
+```
 
 ## Environment-Dependent Checks (maintainers)
 
@@ -43,6 +53,8 @@ and a maintainer will run the data-dependent checks during review where relevant
 ## Testing Posture
 
 - Public API route smoke coverage exists but is intentionally narrow.
+- Prefer credential-free unit tests next to the code (`*.test.ts`) for helpers, env
+  validation, and public route behavior that can be exercised without staging.
 - Hosted and data-dependent behavior is verified against staging during review.
 - Operational apps (`apps/admin`, `apps/cloudrun-*`) are build-verified in CI, not
   comprehensively end-to-end tested here.


### PR DESCRIPTION
Document typecheck/test in the PR bar and point contributors at the credential-free apps/api unit suite.

## Summary

Describe what changed.

## Why

Explain the reason for the change.

## Risk / Impact

Call out user-facing, API, auth, dependency, or operational risk.

## Verification

Confirm the credential-free checks pass (see TESTING.md):

- [ ] `bun run check:repo-hygiene`
- [ ] `bun run verify:api-health-routes`
- [ ] `bun run lint`
- [ ] `bun run build`
- [ ] `bun run audit:deps`

## Docs / Tests

Note any docs updates, new checks, or reasons they were not added.

## Linked issue

Closes #
