### PR TITLE
Fix primary-variant NaN tie-break & ClickHouse asOf unit mismatch

### DIFF
--- a/apps/cloudrun-assets/src/handlers/marketSourceSelection.ts
+++ b/apps/cloudrun-assets/src/handlers/marketSourceSelection.ts
@@ -217,7 +217,11 @@ function isUsableClickhouseSnapshot(snapshot: ProviderMarketMetrics | null): boo
     const asOf = finiteNumber(snapshot.asOf);
     const lastFetchedAt = finiteNumber(snapshot.lastFetchedAt);
     if (asOf === undefined || lastFetchedAt === undefined) return true;
-    return lastFetchedAt - asOf <= MAX_CLICKHOUSE_AS_OF_AGE_MS;
+    // snapshots.asOf is stored in epoch-seconds (see crons.clickhouse.ts), while
+    // lastFetchedAt is epoch-ms (deps.now()). Convert asOf to ms before comparing
+    // so a just-fetched snapshot is never mistaken for stale (previously the ms-
+    // seconds difference (~1.75e12) always exceeded the 600s budget).
+    return lastFetchedAt - asOf * 1000 <= MAX_CLICKHOUSE_AS_OF_AGE_MS;
 }
 
 function demoteStaleSnapshots(snapshots: Array<ProviderMarketMetrics | null>): Array<ProviderMarketMetrics | null> {

--- a/packages/asset-registry/src/primary-variant-ranking.test.ts
+++ b/packages/asset-registry/src/primary-variant-ranking.test.ts
@@ -269,6 +269,20 @@ describe('pickPrimaryVariantWithRanking', () => {
         expect(result.variant?.mint).toBe(MINT_C < MINT_B ? MINT_C : MINT_B);
     });
 
+    it('lexical tie-break wins over array order when both variants are uncurated', () => {
+        // MINT_B is first in the array but lexically LARGER than MINT_C, so the
+        // correct lexical answer (MINT_C) differs from the buggy "first candidate"
+        // result that an unreachable lexical branch would keep.
+        const result = pickPrimaryVariantWithRanking({
+            asset: asset([variant(MINT_B, 'tesla:b'), variant(MINT_C, 'tesla:c')]),
+            mintRank: new Map(),
+            marketByMint: new Map(),
+            options: { nowSeconds: NOW, lexicalTieBreak: true },
+        });
+
+        expect(result.variant?.mint).toBe(MINT_C);
+    });
+
     it('stock-redeemability strategy picks a share-redeemable variant within the liquidity cap', () => {
         const selected = pick({
             strategy: 'stock_redeemability',

--- a/packages/asset-registry/src/primary-variant-ranking.ts
+++ b/packages/asset-registry/src/primary-variant-ranking.ts
@@ -212,7 +212,12 @@ function comparePrimaryVariantCandidates(params: {
     if (volumeDelta !== 0) return { isBetter: volumeDelta > 0, reason: 'volume24h' };
 
     const rankDelta = getMintRank(params.mintRank, params.next.mint) - getMintRank(params.mintRank, params.best.mint);
-    if (rankDelta !== 0) return { isBetter: rankDelta < 0, reason: 'curated_rank' };
+    // rankDelta is NaN when neither mint is curated (Infinity - Infinity). Skip
+    // the curated-rank decision then so we fall through to the lexical tie-break
+    // instead of mislabeling the result 'curated_rank' and ignoring array order.
+    if (!Number.isNaN(rankDelta) && rankDelta !== 0) {
+        return { isBetter: rankDelta < 0, reason: 'curated_rank' };
+    }
 
     if (params.lexicalTieBreak) {
         return {


### PR DESCRIPTION
Closes #38

Two small fixes.

**asset-registry (primary-variant ranking).** Comparing two mints with no
curated rank produced `Infinity - Infinity = NaN`, and `NaN !== 0` is true, so
the comparator returned a bogus `curated_rank` decision and never reached the
`lexicalTieBreak` branch. Selection for uncurated assets was array-order
dependent. Guard the `curated_rank` branch against `NaN`.

**cloudrun-assets (ClickHouse freshness).** `isUsableClickhouseSnapshot`
compared `lastFetchedAt` (ms) against `asOf` (seconds, as written by the
ClickHouse crons), so every `clickhouse_trades` snapshot looked stale and that
source was never used. Convert `asOf` to ms at the comparison site; stored
units unchanged.

Verification:
- asset-registry `bun test` pass; added a regression test that fails on the
  old code and passes with the fix.
- cloudrun-assets `tsc --noEmit` clean and existing tests pass.
- lint, repo-hygiene, api-health-routes, audit, and full build pass.

No data model or API shape changes.