### PR TITLE
ci: add least-privilege permissions to ci.yml and security.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,9 @@ on:
   push:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   build-and-lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -6,6 +6,9 @@ on:
   schedule:
     - cron: '0 8 * * 1'
 
+permissions:
+  contents: read
+
 jobs:
   secret-scan:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Closes #40.

`ci.yml` and `security.yml` were the only two workflows without a `permissions:` block, so their `GITHUB_TOKEN` fell back to the repository default. The other six all declare one explicitly.

Adds `permissions: contents: read` to both, placed after `on:` to match the existing convention.

Neither workflow needs a write scope:

- `ci.yml` runs `check:repo-hygiene`, `verify:api-health-routes`, `lint`, `typecheck`, `test`, `build`
- `security.yml` runs gitleaks (with `fetch-depth: 0`) and `audit:deps`

Neither writes to the repo, comments on PRs, or uploads SARIF.

**Checks run locally:** `bun run lint` (10/10), `bun run typecheck` (14/14), `bun run test` (9/9). Both files verified to still parse as valid workflow YAML with `permissions` resolving to `{contents: read}` and jobs unchanged.

No behaviour change expected — `actions/checkout` only requires `contents: read`.