### PR TITLE
Restrict external pull requests

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,3 +1,9 @@
+> [!IMPORTANT]
+> External pull requests are not accepted and will be closed automatically.
+> Please open an issue for bugs, data corrections, or suggestions. This template
+> is for maintainer-authored pull requests from within the organization. See the
+> [contribution policy](https://github.com/solana-foundation/tokens/blob/main/CONTRIBUTING.md).
+
 ## Summary
 
 Describe what changed.

--- a/.github/workflows/close-external-prs.yml
+++ b/.github/workflows/close-external-prs.yml
@@ -1,0 +1,33 @@
+name: Close external pull requests
+
+on:
+  pull_request_target:
+    types: [opened, reopened]
+  schedule:
+    - cron: "17 * * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  close-external-prs:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Close pull requests originating outside solana-foundation
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh api --paginate \
+            "/repos/${GITHUB_REPOSITORY}/pulls?state=open&per_page=100" \
+            --jq '.[] |
+              select(.head.repo.owner.login != "solana-foundation") |
+              .number' |
+          while read -r pr_number; do
+            echo "Closing external PR #${pr_number}"
+            gh api --method PATCH \
+              "/repos/${GITHUB_REPOSITORY}/pulls/${pr_number}" \
+              -f state=closed
+          done

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,10 +1,37 @@
 # Contributing to Tokens
 
-This repository is the live, multi-app monorepo behind Tokens, and contributions are welcome. Changes should preserve the separation between public product surfaces, the platform API, and authenticated operational tooling.
+Tokens welcomes issues and feedback, but we do not accept external pull
+requests. External pull requests are closed automatically without review.
 
-We triage issues and review pull requests on a regular cadence. We can't promise a fixed response time, but issues and PRs are read — please be patient and feel free to bump a stale thread. For anything security-sensitive, follow [SECURITY.md](SECURITY.md) instead of opening a public issue.
+The code is open source under the MIT license, but the hosted Tokens product,
+its frontend experience, and its curated token, venue, market, and metadata
+coverage remain operated and controlled by the Tokens team. Maintainers decide
+which reported issues and suggestions are incorporated into the hosted product.
 
-## Getting Started
+## Filing an Issue
+
+Before opening an issue, search existing issues to avoid duplicates. Include
+enough context for the maintainers to evaluate the report or suggestion.
+
+For bugs, include:
+
+- A clear description of the issue
+- Steps to reproduce it
+- Expected and actual behavior
+- Relevant environment details
+- Relevant logs or errors, with secrets redacted
+
+For data corrections or suggestions involving tokens, venues, markets, logos,
+metadata, or rankings, include reliable supporting sources. Filing an issue does
+not guarantee that the requested change or listing will be adopted.
+
+For security-sensitive reports, do not open a public issue. Follow
+[SECURITY.md](SECURITY.md).
+
+## Local Development
+
+You may fork and run the project for your own use under the terms of the MIT
+license.
 
 1. Fork and clone the repository.
 
@@ -36,12 +63,6 @@ cp apps/web/.env.example apps/web/.env.local
 bun dev
 ```
 
-6. Create a branch for your work.
-
-```bash
-git checkout -b feature/your-feature-name
-```
-
 ## Project Structure
 
 - `apps/web/`: public website
@@ -65,7 +86,7 @@ git checkout -b feature/your-feature-name
 - Do not treat `apps/admin` as a public anonymous surface. It is an authenticated maintainer tool.
 - Avoid adding vendored third-party assets unless redistribution terms are documented in `THIRD_PARTY_LICENSES.md`.
 
-## Before Submitting
+## Verifying Local Changes
 
 ```bash
 bun run check:repo-hygiene
@@ -80,27 +101,14 @@ If you touched dependency versions or security-sensitive paths, also run:
 bun run audit:deps
 ```
 
-## Pull Requests
+## Pull Request Policy
 
-- Explain what changed and why.
-- Link related issues when applicable.
-- Keep PRs focused and reviewable.
-- Update docs when behavior, setup, or public contracts change.
-- Call out security, auth, proxy, or dependency-risk changes explicitly.
-- Note whether tests or smoke checks were added or updated.
-
-## Bug Reports
-
-Include:
-
-- A clear description of the issue
-- Steps to reproduce
-- Expected vs actual behavior
-- Environment details
-- Relevant logs or errors, with secrets redacted
-
-For security reports, do not open a public issue. Follow [SECURITY.md](SECURITY.md).
+Only maintainer-authored pull requests originating from repositories within the
+`solana-foundation` GitHub organization are accepted. If you believe a change
+belongs in the hosted product, open an issue so the maintainers can evaluate and
+implement it.
 
 ## License
 
-By contributing, you agree that your contributions will be licensed under the MIT License.
+Use, modification, and redistribution of the repository code are governed by
+the MIT License.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,25 @@
 
 Tokens is the open-source monorepo for the Tokens website, API, docs, and services. This is the live repository the project is developed and deployed from — it is not a mirror or a snapshot.
 
-Issues and pull requests are welcome. See [CONTRIBUTING.md](CONTRIBUTING.md) to get started and [SECURITY.md](SECURITY.md) for reporting vulnerabilities.
+Issues are welcome; external pull requests are not accepted. See the contribution policy below and [SECURITY.md](SECURITY.md) for reporting vulnerabilities.
+
+## Contributions and Curation
+
+Tokens is open source, and you are free to inspect, use, and fork the code under
+the terms of the MIT license. The hosted Tokens product—including its frontend
+experience and its curated token, venue, market, and metadata coverage—remains
+operated and controlled by the Tokens team. Publishing the source does not make
+the hosted product or its listings community-managed.
+
+We do not accept external pull requests, including requests to add or update
+tokens, venues, markets, logos, metadata, rankings, or other product content.
+External pull requests are closed automatically without review.
+
+If you have found a relevant bug, data issue, or other improvement, please
+[open an issue](https://github.com/solana-foundation/tokens/issues) with enough
+context for the maintainers to evaluate it. Please report security
+vulnerabilities through the process in [SECURITY.md](SECURITY.md), not through a
+public issue.
 
 ## Scope
 
@@ -96,7 +114,7 @@ bun run audit:deps
 
 ## Verification And Releases
 
-- Read [TESTING.md](TESTING.md) for what CI runs and what to run locally before opening a PR.
+- Read [TESTING.md](TESTING.md) for CI and local verification guidance used by maintainers.
 - Read [RELEASING.md](RELEASING.md) for how changes promote from staging to production, and how to roll back.
 - Review [SECURITY.md](SECURITY.md) before reporting vulnerabilities.
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,12 +1,14 @@
-# Releasing
+# Releasing (Maintainers)
 
-How changes ship to staging and production, and how to roll back. There is no
-manual version/tag step — `main` is the release branch, and merging is the release.
+This is the internal maintainer workflow for shipping changes to staging and
+production and rolling them back. There is no manual version/tag step — `main`
+is the release branch, and merging is the release.
 
 ## How a change ships
 
-1. Open a PR. CI (`CI`, `Security`, `React Doctor`) runs on the PR; a `terraform/**`
-   change also posts a `terraform plan` comment.
+1. Open a maintainer PR from within the organization. CI (`CI`, `Security`,
+   `React Doctor`) runs on the PR; a `terraform/**` change also posts a
+   `terraform plan` comment.
 2. Merge to `main`. On push to `main`:
    - **`deploy.yml`** deploys the Vercel apps (`tokens-api`, `tokens-app`) to staging,
      runs a staging smoke check, then promotes to production and runs a production

--- a/TESTING.md
+++ b/TESTING.md
@@ -1,10 +1,14 @@
 # Testing
 
-What CI enforces, and what you can run locally before opening a PR. A PR is expected to pass the credential-free automated checks below; the environment-dependent checks are run by maintainers against staging.
+What CI enforces for maintainer-authored changes and what anyone can run
+locally. Maintainer pull requests are expected to pass the credential-free
+automated checks below; environment-dependent checks are run by maintainers
+against staging.
 
 ## Automated Checks (no credentials needed)
 
-These run in CI and locally with no external accounts — this is the bar for a PR:
+These run in CI and locally with no external accounts. They are the baseline for
+maintainer-authored changes:
 
 ```bash
 bun run check:repo-hygiene
@@ -25,7 +29,8 @@ What these cover:
 ## Environment-Dependent Checks (maintainers)
 
 Some verification requires real credentials, a seeded data environment, or a deployed API
-surface, so it is not part of the PR baseline and is run by maintainers against staging:
+surface, so it is not part of the credential-free baseline and is run by
+maintainers against staging:
 
 ```bash
 bun run verify:assets-api-v1
@@ -37,8 +42,8 @@ These require environment variables such as:
 - `API_BASE_URL` or `TOKENS_API_BASE_URL`
 - `API_KEY` or `TOKENS_API_KEY`
 
-You do not need these to contribute — open your PR against the credential-free checks above,
-and a maintainer will run the data-dependent checks during review where relevant.
+You do not need these credentials to run the public checks or work with a fork.
+Maintainers run the data-dependent checks during internal review where relevant.
 
 ## Testing Posture
 

--- a/apps/cloudrun-assets/README.md
+++ b/apps/cloudrun-assets/README.md
@@ -14,7 +14,8 @@ The query names match the corresponding Convex export names (e.g. `getByAssetId`
 | --- | --- | --- |
 | `getByAssetId` | query | template, parity with `convex/assets.ts:getByAssetId` minus the `imageStorageId` lookup (dropped during migration) |
 
-The remaining `assets.*`, `assetVariants.*`, `assetMarkets.*` etc. land in follow-up PRs.
+The remaining `assets.*`, `assetVariants.*`, `assetMarkets.*` functionality will
+be implemented incrementally by the maintainers.
 
 ## Env
 

--- a/apps/cloudrun-prices/README.md
+++ b/apps/cloudrun-prices/README.md
@@ -14,7 +14,9 @@ The query names match the corresponding Convex export names (e.g. `getLatestByCo
 | --- | --- | --- |
 | `getLatestByCoinId` | query | template, parity with `convex/coingeckoPrices.ts:getLatestByCoinId` |
 
-The remaining `coingeckoPrices.*`, `coingeckoCoins.*`, `coingeckoTickers.*`, `coingeckoOhlcv.*` etc. land in follow-up PRs.
+The remaining `coingeckoPrices.*`, `coingeckoCoins.*`, `coingeckoTickers.*`,
+`coingeckoOhlcv.*`, and related functionality will be implemented incrementally
+by the maintainers.
 
 ## Env
 

--- a/apps/cloudrun-usage/README.md
+++ b/apps/cloudrun-usage/README.md
@@ -20,7 +20,9 @@ Unlike the other `cloudrun-*` services, `usage` has `ingress = INGRESS_TRAFFIC_A
 | `logApiRequest` | mutation | parity with `convex/auth.ts:logApiRequest`. Best-effort insert into `api_request_events` (same ownership checks + latency clamping) and a deduped `api_keys.last_used_at` bump. Feeds the cloudrun-assets rollup job. |
 | `ingestUsageAggregates` | mutation | parity with `convex/apiUsageRollups.ts:ingestUsageAggregates`. Ingests usage buckets (daily + per-endpoint with latency histograms) into the rollup tables additively, in one transaction. Its original caller (the Upstash drain timer) is retired. |
 
-The dashboard queries/mutations (`users.*`, `projects.*`, `auth.getProjectUsage*`, key reset/reveal) land in follow-up PRs.
+The dashboard queries and mutations (`users.*`, `projects.*`,
+`auth.getProjectUsage*`, key reset/reveal) will be implemented incrementally by
+the maintainers.
 
 ## Env
 


### PR DESCRIPTION
## Summary

- add an organization-owned-source policy for pull requests
- close external pull requests when opened or reopened, with an hourly reconciliation run
- document that the hosted frontend and curated token, venue, market, and metadata experience remain maintainer-controlled
- direct bug reports, data corrections, and suggestions to issues
- align contribution, testing, release, service, and pull request documentation

## Behavior

The workflow does not check out or execute pull request code. It allows pull requests whose source repository owner is `solana-foundation` and automatically closes all others.

At the time of this change, the reconciliation job would close open pull requests #24, #25, #28, #29, #31, #35, #36, #39, #42, and #43.

## Verification

- `git diff --check`
- workflow YAML parsed successfully
- verified the GitHub API selection against the current open pull requests