### PR TITLE
fix(db): cascade api_keys on project delete instead of nulling project_id

### DIFF
--- a/db/migrations/0012_api_keys_cascade_on_project_delete.sql
+++ b/db/migrations/0012_api_keys_cascade_on_project_delete.sql
@@ -1,0 +1,26 @@
+-- api_keys.project_id used ON DELETE SET NULL, while project_members used
+-- ON DELETE CASCADE. The application already deletes keys explicitly before
+-- the project (deleteProjectCascade in apps/cloudrun-usage/src/db/dashboard.ts
+-- runs both DELETEs in one transaction, and its handler comment describes the
+-- operation as "cascades keys + memberships"), so the SET NULL branch never
+-- fires through the dashboard.
+--
+-- It matters because a NULL project_id is not treated as revoked. In
+-- authenticateApiKey (apps/cloudrun-usage/src/handlers/platformAuth.ts) a key
+-- with no project falls back to the owner's personal project and inherits that
+-- project's limits — a deliberate path for keys that never had a project, but
+-- indistinguishable from a key orphaned by a project deletion. Any deletion
+-- path that doesn't replicate the application's manual cleanup (a direct SQL
+-- fix, a future code path, a maintenance script) would therefore leave live
+-- keys silently re-pointed at a different project rather than revoked.
+--
+-- Align the constraint with the behaviour the application already implements.
+
+ALTER TABLE api_keys
+    DROP CONSTRAINT api_keys_project_id_fkey;
+
+ALTER TABLE api_keys
+    ADD CONSTRAINT api_keys_project_id_fkey
+    FOREIGN KEY (project_id) REFERENCES projects(id) ON DELETE CASCADE;
+
+INSERT INTO schema_migrations(version) VALUES ('0012_api_keys_cascade_on_project_delete');


### PR DESCRIPTION
`api_keys.project_id` uses `ON DELETE SET NULL` (`0002_auth.sql:47`) while `project_members.project_id` next to it uses `ON DELETE CASCADE` (`:34`).

A NULL `project_id` isn't treated as revoked. `authenticateApiKey` (`apps/cloudrun-usage/src/handlers/platformAuth.ts:141`) falls back to the owner's personal project and inherits that project's `limits`:

```ts
const projectId = key.projectId ?? (await repo.findPersonalProjectId(key.ownerClerkUserId));
if (!projectId) return null;
```

That fallback is deliberate for keys that never had a project, but `SET NULL` makes a key orphaned by a project deletion indistinguishable from one.

**The application path is already correct** — `deleteProjectCascade` deletes keys and project in one transaction, and its handler comment describes the operation as "cascades keys + memberships". So this isn't a live bug via the dashboard. It removes the reliance on every future deletion path (a manual SQL fix, a new code path, a maintenance script) repeating that cleanup, and makes the schema state the intent the code already has.

### Verified against PostgreSQL 14

Applied `0001`–`0011` to a fresh database, then:

```
-- before
conname                  | confdeltype
api_keys_project_id_fkey | n            (SET NULL)

-- seed project + key, DELETE the project:
id    | project_id | revoked_at
key_1 | <NULL>     | <NULL>       -- key still live, not revoked

-- after applying 0012
conname                  | confdeltype
api_keys_project_id_fkey | c            (CASCADE)

-- same sequence:
keys remaining -> 0
```

The constraint name is Postgres's default for the inline `REFERENCES` in `0002`; I confirmed it rather than assuming it. The `DROP CONSTRAINT` is deliberately not `IF EXISTS` so the migration fails loudly rather than silently leaving the old rule in place alongside a new one.

Also ran `bun run test` (9/9) and `bun run typecheck` (14/14).

Happy to add a `revoked_at` backfill for any already-orphaned rows if you have some in production — I left it out since I can't see whether any exist.