### PR TITLE
fix(api): remove hardcoded dev fallback for the playground proxy secret

### DIFF
--- a/apps/api/src/effect/playground-proxy-auth.ts
+++ b/apps/api/src/effect/playground-proxy-auth.ts
@@ -33,9 +33,7 @@ function timingSafeEqualString(a: string, b: string): boolean {
 
 function getPlaygroundProxySecret(): string | null {
     const secret = (process.env.TOKENS_PLAYGROUND_PROXY_SECRET ?? '').trim();
-    if (secret) return secret;
-    if (process.env.NODE_ENV !== 'production') return 'dev-playground-proxy-secret';
-    return null;
+    return secret || null;
 }
 
 async function hmacSha256Base64Url(value: string, secret: string): Promise<string> {


### PR DESCRIPTION
`getPlaygroundProxySecret()` in `apps/api/src/effect/playground-proxy-auth.ts` falls back to a literal constant whenever `NODE_ENV` isn't exactly `'production'`:

```ts
if (secret) return secret;
if (process.env.NODE_ENV !== 'production') return 'dev-playground-proxy-secret';
return null;
```

That constant is public in this repository, and it's the HMAC key for the `x-tokens-playground-auth` header. A valid signature establishes `apiKeyId`, `projectId`, `ownerClerkUserId`, `scopes` and `limits` (`verifyPlaygroundProxyAuthHeader`, same file), and `limits` is what drives rate-limit and quota enforcement in `next-route.ts:206-208`.

**I'm not reporting this as exploitable.** `next build`/`next start` set `NODE_ENV=production`, so a normal deploy takes the `return null` branch. The concern is that the guard is one env-var mistake away from failing open silently — `NODE_ENV=staging`, a custom entrypoint, a preview environment — and there'd be no signal that it had.

The asymmetry is what prompted the PR: the counterpart signer in `apps/app/src/app/api/v1/[...path]/route.ts:69-72` has no fallback and already does exactly what this changes it to. The two functions are now identical.

Local dev still fails loudly via the existing `'TOKENS_PLAYGROUND_PROXY_SECRET is required'` error in `signPlaygroundProxyAuthPayload`, so the only change is that a missing secret is now noisy instead of silently substituted.

Ran `bun run test` (9/9) and `bun run typecheck` (14/14).

If the dev fallback is load-bearing for someone's local workflow, an alternative is generating a random per-process value at startup — same convenience, no shared constant. Happy to switch to that if you'd prefer.