### PR TITLE
test(token-risk-helpers): cover the curated-list score floor

### DIFF
--- a/packages/token-risk-helpers/src/trusted-launch.test.ts
+++ b/packages/token-risk-helpers/src/trusted-launch.test.ts
@@ -1,0 +1,76 @@
+/**
+ * Coverage for the curated-list score floor in `computeMarketScore`.
+ *
+ * These assert current behaviour rather than a desired change: the floor at
+ * index.ts:475-476 raises any token on TRUSTED_LAUNCH_LISTS that is <= 21 days
+ * old to a score of 70, which is exactly the grade-B boundary, after all caps
+ * have been applied. See the discussion on issue #30.
+ */
+
+import { describe, expect, test } from 'bun:test';
+
+import { computeMarketScore, type MarketScoreInput } from './index';
+
+/** Real member of the curated `rwas` list, which is in TRUSTED_LAUNCH_LISTS. */
+const CURATED_RWA = '4MmJVdwYN8LwvbGeCowYjSx7KoEi6BJWg8XXnW4fDDp6';
+const UNCURATED = 'Zzz11111111111111111111111111111111111111111';
+
+/**
+ * Metrics that trip four independent hard caps:
+ *   whale-dominance (>80% top10), ghost-token (<20 holders),
+ *   dead-token (<$100 7d volume), new-token (<1 week old).
+ */
+const AWFUL = {
+    liquidityUsd: 5_000,
+    marketCapUsd: 2_000_000,
+    holderCount: 12,
+    top10HoldersPercent: 95,
+    volume24hUsd: 10,
+    volume7dUsd: 50,
+    tokenMintTime: new Date(Date.now() - 5 * 24 * 60 * 60 * 1000).toISOString(),
+} satisfies Omit<MarketScoreInput, 'tokenAddress'>;
+
+describe('trusted-launch score floor', () => {
+    test('control: an uncurated token with these metrics scores 17 / grade C', () => {
+        const r = computeMarketScore({ ...AWFUL, tokenAddress: UNCURATED });
+
+        expect(r.score).toBe(17);
+        expect(r.grade).toBe('C');
+        expect(r.tone).toBe('risk');
+    });
+
+    test('curated + age <= 21d: identical metrics are floored 17 -> 70, C -> B', () => {
+        const r = computeMarketScore({ ...AWFUL, tokenAddress: CURATED_RWA });
+
+        // +53 points, from curated-list membership alone.
+        expect(r.score).toBe(70);
+        expect(r.grade).toBe('B');
+        expect(r.tone).toBe('warning'); // not 'risk'
+        expect(r.isTrustedLaunch).toBe(true);
+        expect(r.label).toBe('Trusted Launch');
+
+        // Nothing in the payload explains the jump or flags the underlying risk:
+        // the caps never "applied" because the raw score was already below every
+        // cap ceiling, so a consumer sees a B with an empty caps array.
+        expect(r.caps).toEqual([]);
+        expect(r.borderlineSignals).toEqual([]);
+    });
+
+    test('one day past the window (22d) the same token collapses back to 17 / C', () => {
+        const r = computeMarketScore({
+            ...AWFUL,
+            tokenAddress: CURATED_RWA,
+            tokenMintTime: new Date(Date.now() - 22 * 24 * 60 * 60 * 1000).toISOString(),
+        });
+
+        expect(r.score).toBe(17);
+        expect(r.grade).toBe('C');
+    });
+
+    test('an unknown mint time disables the floor entirely', () => {
+        const r = computeMarketScore({ ...AWFUL, tokenAddress: CURATED_RWA, tokenMintTime: null });
+
+        expect(r.isTrustedLaunch).toBe(false);
+        expect(r.score).toBe(17);
+    });
+});


### PR DESCRIPTION
Follow-up to my comment on #30, where I offered these.

`packages/token-risk-helpers` is 556 lines of scoring logic with 2 tests, neither covering caps, borderline signals, or the curated-list floor at `index.ts:475-476`:

```ts
const isTrustedLaunch = isTrustedLaunchEligible(input.tokenAddress) && tokenAgeDays != null && tokenAgeDays <= 21;
if (isTrustedLaunch && score < 70) score = 70;
```

**These assert current behaviour — they don't change it.** The thresholds are a published product surface and the direction is yours to pick; the tests just pin down what happens today so any future change to that area is a visible diff.

Four cases, with only `tokenAddress` and `tokenMintTime` varying:

| case | score | grade | label |
|---|---|---|---|
| uncurated | 17 | C | Weak Metrics |
| curated, 5d old | **70** | **B** | **Trusted Launch** |
| curated, 22d old | 17 | C | Weak Metrics |
| curated, no mint time | 17 | C | Weak Metrics |

The inputs (12 holders, 95% top-10 concentration, $50 of 7d volume, $5K liquidity) trip `whale-dominance`, `ghost-token`, `dead-token` and `new-token`. The second row also asserts `caps` and `borderlineSignals` come back **empty** — they're empty because the raw score was already below every cap ceiling, so no cap "applied" per `index.ts:439-443`, which is the part a consumer can't currently detect.

Uses `4MmJVdwYN8LwvbGeCowYjSx7KoEi6BJWg8XXnW4fDDp6`, a real member of `rwas`. If you'd rather tests not depend on live registry membership I can switch to a fixture — that coupling is itself arguably worth avoiding, but it matches how the existing tests work.

`bun test` 6/6 in-package, `bun run lint` 10/10, `bun run typecheck` 14/14.