### PR TITLE
chore(effect): dedupe mergeSignals, use Array.chunksOf, drop dead dep (A1)

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -16,7 +16,6 @@
   },
   "dependencies": {
     "@clerk/nextjs": "^6.39.5",
-    "@tanstack/pacer": "^0.19.0",
     "@tokens/asset-registry": "workspace:*",
     "@tokens/effect": "workspace:*",
     "@tokens/token-risk-helpers": "workspace:*",

--- a/apps/api/src/app/api/tokens/curated/seed-ohlcv/route.ts
+++ b/apps/api/src/app/api/tokens/curated/seed-ohlcv/route.ts
@@ -1,4 +1,4 @@
-import { Effect } from 'effect';
+import { Array as Arr, Effect } from 'effect';
 
 import { ohlcvBounds } from '@/lib/cloudrun';
 import { getTokenOHLCV, type TimeInterval } from '@/lib/birdeye';
@@ -39,12 +39,6 @@ function intervalToSeconds(interval: TimeInterval): number {
         default:
             return 60 * 60;
     }
-}
-
-function chunk<T>(items: readonly T[], size: number): T[][] {
-    const result: T[][] = [];
-    for (let i = 0; i < items.length; i += size) result.push(items.slice(i, i + size));
-    return result;
 }
 
 export const POST = route((request: Request) =>
@@ -136,7 +130,7 @@ export const POST = route((request: Request) =>
                     // Write path removed with Convex; add an `ohlcvUpsertMany`
                     // cloudrun-assets mutation and route through it when this
                     // endpoint needs to actually seed OHLCV again.
-                    for (const candlesChunk of chunk(candles, 500)) {
+                    for (const candlesChunk of Arr.chunksOf(candles, 500)) {
                         void candlesChunk;
                     }
                 }

--- a/apps/api/src/app/api/v1/assets/[assetId]/variant-top-markets/route.ts
+++ b/apps/api/src/app/api/v1/assets/[assetId]/variant-top-markets/route.ts
@@ -1,4 +1,4 @@
-import { Effect } from 'effect';
+import { Array as Arr, Effect } from 'effect';
 
 import { route } from '@/effect/next-route';
 import { decodeLimit, decodeOffset } from '@tokens/effect';
@@ -34,13 +34,6 @@ function scheduleMarketsWarm(mint: string): Effect.Effect<void, never> {
         minAgeMs: 0,
         label: 'assets.variantTopMarkets.scheduleWarm',
     });
-}
-
-function chunkArray<T>(items: ReadonlyArray<T>, chunkSize: number): Array<Array<T>> {
-    if (chunkSize <= 0) return [items.slice()];
-    const chunks: Array<Array<T>> = [];
-    for (let i = 0; i < items.length; i += chunkSize) chunks.push(items.slice(i, i + chunkSize));
-    return chunks;
 }
 
 export interface VariantTopMarketsResponse {
@@ -213,7 +206,7 @@ export const GET = route(
             }
 
             const mints = variants.map(v => v.mint);
-            const mintChunks = chunkArray(mints, 50);
+            const mintChunks = Arr.chunksOf(mints, 50);
             const chunkRows = yield* Effect.all(
                 mintChunks.map(chunk =>
                     Effect.tryPromise(() => tokenMarketsGetLatestByMints({ mints: chunk })),

--- a/apps/api/src/app/api/v1/assets/[assetId]/variants/route.ts
+++ b/apps/api/src/app/api/v1/assets/[assetId]/variants/route.ts
@@ -1,4 +1,4 @@
-import { Effect } from 'effect';
+import { Array as Arr, Effect } from 'effect';
 
 import { route } from '@/effect/next-route';
 import { BadRequestError, NotFoundError } from '@tokens/effect';
@@ -95,12 +95,6 @@ const TOKEN_MARKETS_CHUNK_SIZE = 50;
 const CLOUDRUN_BULK_QUERY_CONCURRENCY = 4;
 type SolanaVariantsForApiResult = ListSolanaVariantsForApiResult;
 
-function chunkArray<T>(items: T[], size: number): T[][] {
-    const chunks: T[][] = [];
-    for (let i = 0; i < items.length; i += size) chunks.push(items.slice(i, i + size));
-    return chunks;
-}
-
 function uniqueNonEmptyStrings(items: string[]): string[] {
     const seen = new Set<string>();
     for (const item of items) {
@@ -115,7 +109,7 @@ async function loadExecutionQualityByMints(mints: string[]): Promise<Map<string,
     if (uniqueMints.length === 0) return new Map();
 
     const out = new Map<string, VariantExecutionQualitySnapshot>();
-    for (const chunk of chunkArray(uniqueMints, 250)) {
+    for (const chunk of Arr.chunksOf(uniqueMints, 250)) {
         const rows = await variantFillQualityGetLatestByMints({ mints: chunk });
         for (const row of rows) {
             const snapshot = executionQualitySnapshotFromConvexFillQuality(row.fillQuality);
@@ -574,7 +568,7 @@ export const GET = route(
                 return { assetId: outAssetId, sortBy, variants: [] };
             }
 
-            const marketChunks = chunkArray(
+            const marketChunks = Arr.chunksOf(
                 filteredVariants.map(v => v.mint),
                 VARIANT_MARKETS_CHUNK_SIZE,
             );
@@ -668,7 +662,7 @@ export const GET = route(
                     const uniqueMints = uniqueNonEmptyStrings(mints);
                     if (uniqueMints.length === 0) return new Map<string, TokenMarketTopRow>();
 
-                    const tokenMarketChunks = chunkArray(uniqueMints, TOKEN_MARKETS_CHUNK_SIZE);
+                    const tokenMarketChunks = Arr.chunksOf(uniqueMints, TOKEN_MARKETS_CHUNK_SIZE);
                     const tokenMarketRowsByChunk = yield* Effect.all(
                         tokenMarketChunks.map(chunk =>
                             Effect.tryPromise(() =>

--- a/apps/api/src/app/api/v1/assets/curated/route.ts
+++ b/apps/api/src/app/api/v1/assets/curated/route.ts
@@ -1,4 +1,4 @@
-import { Effect, Schedule } from 'effect';
+import { Array as Arr, Effect, Schedule } from 'effect';
 
 import { route } from '@/effect/next-route';
 import { withStaleFallback } from '@/effect/stale-response-cache';
@@ -129,13 +129,6 @@ function uniqueStrings(values: readonly string[]): string[] {
 
 function normalizeRef(value: string): string {
     return value.trim().toLowerCase();
-}
-
-function chunkArray<T>(items: ReadonlyArray<T>, chunkSize: number): Array<Array<T>> {
-    if (chunkSize <= 0) return [items.slice()];
-    const chunks: Array<Array<T>> = [];
-    for (let i = 0; i < items.length; i += chunkSize) chunks.push(items.slice(i, i + chunkSize));
-    return chunks;
 }
 
 function assetForCanonicalPriceSelection(asset: CanonicalAsset): CanonicalAsset {
@@ -313,7 +306,7 @@ export const GET = route(
                 ? prefetch.deletedAssetRefs
                 : rawAssetIds.length > 0
                   ? (yield* Effect.all(
-                        chunkArray(rawAssetIds, 500).map(chunk =>
+                        Arr.chunksOf(rawAssetIds, 500).map(chunk =>
                             Effect.tryPromise(() =>
                                 listDeletedRefs({ refs: chunk }),
                             ).pipe(Effect.catch(() => Effect.succeed([] as string[]))),
@@ -891,7 +884,7 @@ export const GET = route(
                     )
                     .filter(Boolean),
             );
-            const priceChunks = chunkArray(coinIds, 50);
+            const priceChunks = Arr.chunksOf(coinIds, 50);
             const canonicalPriceRows: CoingeckoGetPriceLatestByCoinIdsResult = prefetch
                 ? prefetch.coingeckoPrices
                 : priceChunks.length > 0

--- a/apps/api/src/app/api/v1/assets/search/route.ts
+++ b/apps/api/src/app/api/v1/assets/search/route.ts
@@ -1,4 +1,4 @@
-import { Effect } from 'effect';
+import { Array as Arr, Effect } from 'effect';
 
 import { route } from '@/effect/next-route';
 import { BadRequestError } from '@tokens/effect';
@@ -95,13 +95,6 @@ function uniqueStrings(values: readonly string[]): string[] {
         out.push(value);
     }
     return out;
-}
-
-function chunkArray<T>(items: ReadonlyArray<T>, chunkSize: number): Array<Array<T>> {
-    if (chunkSize <= 0) return [items.slice()];
-    const chunks: Array<Array<T>> = [];
-    for (let i = 0; i < items.length; i += chunkSize) chunks.push(items.slice(i, i + chunkSize));
-    return chunks;
 }
 
 function scheduleCoinPriceWarm(coinId: string): Effect.Effect<void, never> {
@@ -945,7 +938,7 @@ export const GET = route(
                     )
                     .filter(Boolean),
             );
-            const priceChunks = chunkArray(coinIds, 50);
+            const priceChunks = Arr.chunksOf(coinIds, 50);
             const canonicalPriceRows = prefetch
                 ? prefetch.coingeckoPrices
                 : priceChunks.length > 0

--- a/apps/web/src/effect/api-client.ts
+++ b/apps/web/src/effect/api-client.ts
@@ -1,14 +1,9 @@
 'use client';
 
 import { Data, Effect } from 'effect';
-import { FetchFailedError, JsonParseError, type ApiErrorInfo, isApiErrorEnvelope } from '@tokens/effect';
+import { FetchFailedError, JsonParseError, mergeSignals, type ApiErrorInfo, isApiErrorEnvelope } from '@tokens/effect';
 
 type NextFetchInit = RequestInit & { next?: { revalidate?: number } };
-
-interface MergeSignalsResult {
-    signal: AbortSignal;
-    cleanup: () => void;
-}
 
 export class ApiResponseError extends Data.TaggedError('ApiResponseError')<{
     message: string;
@@ -31,36 +26,6 @@ export interface ApiJsonArgs {
      * Optional extra AbortSignal to merge with Effect's runtime signal.
      */
     signal?: AbortSignal;
-}
-
-function mergeSignals(primary: AbortSignal, secondary?: AbortSignal): MergeSignalsResult {
-    const noop = () => {};
-    if (!secondary) return { signal: primary, cleanup: noop };
-    const secondarySignal = secondary;
-
-    // Prefer native AbortSignal.any when available.
-    const anyFn = (AbortSignal as unknown as { any?: (signals: AbortSignal[]) => AbortSignal }).any;
-    if (typeof anyFn === 'function') return { signal: anyFn([primary, secondarySignal]), cleanup: noop };
-
-    if (primary.aborted) return { signal: primary, cleanup: noop };
-    if (secondarySignal.aborted) return { signal: secondarySignal, cleanup: noop };
-
-    const controller = new AbortController();
-
-    function onAbort() {
-        cleanup();
-        controller.abort();
-    }
-
-    primary.addEventListener('abort', onAbort, { once: true });
-    secondarySignal.addEventListener('abort', onAbort, { once: true });
-
-    function cleanup() {
-        primary.removeEventListener('abort', onAbort);
-        secondarySignal.removeEventListener('abort', onAbort);
-    }
-
-    return { signal: controller.signal, cleanup };
 }
 
 function safeJsonStringify(value: unknown): string | null {

--- a/bun.lock
+++ b/bun.lock
@@ -53,7 +53,6 @@
       "version": "0.0.0",
       "dependencies": {
         "@clerk/nextjs": "^6.39.5",
-        "@tanstack/pacer": "^0.19.0",
         "@tokens/asset-registry": "workspace:*",
         "@tokens/effect": "workspace:*",
         "@tokens/token-risk-helpers": "workspace:*",
@@ -935,10 +934,6 @@
 
     "@tailwindcss/vite": ["@tailwindcss/vite@4.2.2", "", { "dependencies": { "@tailwindcss/node": "4.2.2", "@tailwindcss/oxide": "4.2.2", "tailwindcss": "4.2.2" }, "peerDependencies": { "vite": "^5.2.0 || ^6 || ^7 || ^8" } }, "sha512-mEiF5HO1QqCLXoNEfXVA1Tzo+cYsrqV7w9Juj2wdUFyW07JRenqMG225MvPwr3ZD9N1bFQj46X7r33iHxLUW0w=="],
 
-    "@tanstack/devtools-event-client": ["@tanstack/devtools-event-client@0.4.3", "", { "bin": { "intent": "bin/intent.js" } }, "sha512-OZI6QyULw0FI0wjgmeYzCIfbgPsOEzwJtCpa69XrfLMtNXLGnz3d/dIabk7frg0TmHo+Ah49w5I4KC7Tufwsvw=="],
-
-    "@tanstack/pacer": ["@tanstack/pacer@0.19.0", "", { "dependencies": { "@tanstack/devtools-event-client": "^0.4.0", "@tanstack/store": "^0.8.1" } }, "sha512-MRXCiG8IcjrN/3LGu7Wy6lKZkbwOb5YelOBYtHxnxKYj2WlO2FrqASILSiJcwdES5Sz2QJEIeuvO5JY8cKaGQw=="],
-
     "@tanstack/query-core": ["@tanstack/query-core@5.90.20", "", {}, "sha512-OMD2HLpNouXEfZJWcKeVKUgQ5n+n3A2JFmBaScpNDUqSrQSjiveC7dKMe53uJUg1nDG16ttFPz2xfilz6i2uVg=="],
 
     "@tanstack/react-query": ["@tanstack/react-query@5.90.21", "", { "dependencies": { "@tanstack/query-core": "5.90.20" }, "peerDependencies": { "react": "^18 || ^19" } }, "sha512-0Lu6y5t+tvlTJMTO7oh5NSpJfpg/5D41LlThfepTixPYkJ0sE2Jj0m0f6yYqujBwIXlId87e234+MxG3D3g7kg=="],
@@ -946,8 +941,6 @@
     "@tanstack/react-table": ["@tanstack/react-table@8.21.3", "", { "dependencies": { "@tanstack/table-core": "8.21.3" }, "peerDependencies": { "react": ">=16.8", "react-dom": ">=16.8" } }, "sha512-5nNMTSETP4ykGegmVkhjcS8tTLW6Vl4axfEGQN3v0zdHYbK4UfoqfPChclTrJ4EoK9QynqAu9oUf8VEmrpZ5Ww=="],
 
     "@tanstack/react-virtual": ["@tanstack/react-virtual@3.13.23", "", { "dependencies": { "@tanstack/virtual-core": "3.13.23" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-XnMRnHQ23piOVj2bzJqHrRrLg4r+F86fuBcwteKfbIjJrtGxb4z7tIvPVAe4B+4UVwo9G4Giuz5fmapcrnZ0OQ=="],
-
-    "@tanstack/store": ["@tanstack/store@0.8.1", "", {}, "sha512-PtOisLjUZPz5VyPRSCGjNOlwTvabdTBQ2K80DpVL1chGVr35WRxfeavAPdNq6pm/t7F8GhoR2qtmkkqtCEtHYw=="],
 
     "@tanstack/table-core": ["@tanstack/table-core@8.21.3", "", {}, "sha512-ldZXEhOBb8Is7xLs01fR3YEc3DERiz5silj8tnGkFZytt1abEvl/GhUmCE0PMLaMPTa3Jk4HbKmRlHmu+gCftg=="],
 

--- a/packages/effect/package.json
+++ b/packages/effect/package.json
@@ -11,6 +11,7 @@
   "sideEffects": false,
   "exports": {
     ".": "./src/index.ts",
+    "./abort": "./src/abort.ts",
     "./api-errors": "./src/api-errors.ts",
     "./schema": "./src/schema.ts",
     "./fetch": "./src/fetch.ts",

--- a/packages/effect/src/abort.test.ts
+++ b/packages/effect/src/abort.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from 'bun:test';
+import { mergeSignals } from './abort';
+
+const SignalCtor = AbortSignal as unknown as { any?: (signals: AbortSignal[]) => AbortSignal };
+
+function withoutAbortSignalAny<T>(fn: () => T): T {
+    const original = SignalCtor.any;
+    // Force the manual-listener fallback path.
+    SignalCtor.any = undefined;
+    try {
+        return fn();
+    } finally {
+        SignalCtor.any = original;
+    }
+}
+
+describe('mergeSignals', () => {
+    it('returns the primary signal untouched when no secondary is given', () => {
+        const controller = new AbortController();
+        const merged = mergeSignals(controller.signal);
+        expect(merged.signal).toBe(controller.signal);
+    });
+
+    it('aborts when the primary aborts (AbortSignal.any path)', () => {
+        const primary = new AbortController();
+        const secondary = new AbortController();
+        const merged = mergeSignals(primary.signal, secondary.signal);
+        expect(merged.signal.aborted).toBe(false);
+        primary.abort();
+        expect(merged.signal.aborted).toBe(true);
+    });
+
+    it('aborts when the secondary aborts (AbortSignal.any path)', () => {
+        const primary = new AbortController();
+        const secondary = new AbortController();
+        const merged = mergeSignals(primary.signal, secondary.signal);
+        secondary.abort();
+        expect(merged.signal.aborted).toBe(true);
+    });
+
+    it('returns an already-aborted signal when the primary is pre-aborted (fallback path)', () => {
+        withoutAbortSignalAny(() => {
+            const primary = new AbortController();
+            primary.abort();
+            const secondary = new AbortController();
+            const merged = mergeSignals(primary.signal, secondary.signal);
+            expect(merged.signal.aborted).toBe(true);
+        });
+    });
+
+    it('returns an already-aborted signal when the secondary is pre-aborted (fallback path)', () => {
+        withoutAbortSignalAny(() => {
+            const primary = new AbortController();
+            const secondary = new AbortController();
+            secondary.abort();
+            const merged = mergeSignals(primary.signal, secondary.signal);
+            expect(merged.signal.aborted).toBe(true);
+        });
+    });
+
+    it('propagates aborts from either side on the fallback path', () => {
+        withoutAbortSignalAny(() => {
+            const primary = new AbortController();
+            const secondary = new AbortController();
+            const merged = mergeSignals(primary.signal, secondary.signal);
+            expect(merged.signal.aborted).toBe(false);
+            secondary.abort();
+            expect(merged.signal.aborted).toBe(true);
+        });
+    });
+
+    it('cleanup removes listeners so later aborts do not fire the merged signal (fallback path)', () => {
+        withoutAbortSignalAny(() => {
+            const primary = new AbortController();
+            const secondary = new AbortController();
+            const merged = mergeSignals(primary.signal, secondary.signal);
+            merged.cleanup();
+            primary.abort();
+            expect(merged.signal.aborted).toBe(false);
+        });
+    });
+});

--- a/packages/effect/src/abort.ts
+++ b/packages/effect/src/abort.ts
@@ -1,0 +1,38 @@
+export interface MergeSignalsResult {
+    signal: AbortSignal;
+    cleanup: () => void;
+}
+
+/**
+ * Merge two abort signals into one that fires when either does. Used to
+ * combine Effect's interruption signal with a caller-supplied request signal.
+ */
+export function mergeSignals(primary: AbortSignal, secondary?: AbortSignal): MergeSignalsResult {
+    const noop = () => {};
+    if (!secondary) return { signal: primary, cleanup: noop };
+    const secondarySignal = secondary;
+
+    // Prefer native AbortSignal.any when available.
+    const anyFn = (AbortSignal as unknown as { any?: (signals: AbortSignal[]) => AbortSignal }).any;
+    if (typeof anyFn === 'function') return { signal: anyFn([primary, secondarySignal]), cleanup: noop };
+
+    if (primary.aborted) return { signal: primary, cleanup: noop };
+    if (secondarySignal.aborted) return { signal: secondarySignal, cleanup: noop };
+
+    const controller = new AbortController();
+
+    function onAbort() {
+        cleanup();
+        controller.abort();
+    }
+
+    primary.addEventListener('abort', onAbort, { once: true });
+    secondarySignal.addEventListener('abort', onAbort, { once: true });
+
+    function cleanup() {
+        primary.removeEventListener('abort', onAbort);
+        secondarySignal.removeEventListener('abort', onAbort);
+    }
+
+    return { signal: controller.signal, cleanup };
+}

--- a/packages/effect/src/fetch.ts
+++ b/packages/effect/src/fetch.ts
@@ -1,4 +1,5 @@
 import { Duration, Effect, Schedule } from 'effect';
+import { mergeSignals } from './abort';
 import { FetchFailedError, JsonParseError, RateLimitedError, UpstreamHttpError } from './api-errors';
 
 type NextFetchInit = RequestInit & { next?: { revalidate?: number } };
@@ -8,41 +9,6 @@ export interface FetchJsonArgs {
     service: string;
     init?: NextFetchInit;
     signal?: AbortSignal;
-}
-
-interface MergeSignalsResult {
-    signal: AbortSignal;
-    cleanup: () => void;
-}
-
-function mergeSignals(primary: AbortSignal, secondary?: AbortSignal): MergeSignalsResult {
-    const noop = () => {};
-    if (!secondary) return { signal: primary, cleanup: noop };
-    const secondarySignal = secondary;
-
-    // Prefer native AbortSignal.any when available.
-    const anyFn = (AbortSignal as unknown as { any?: (signals: AbortSignal[]) => AbortSignal }).any;
-    if (typeof anyFn === 'function') return { signal: anyFn([primary, secondarySignal]), cleanup: noop };
-
-    if (primary.aborted) return { signal: primary, cleanup: noop };
-    if (secondarySignal.aborted) return { signal: secondarySignal, cleanup: noop };
-
-    const controller = new AbortController();
-
-    function onAbort() {
-        cleanup();
-        controller.abort();
-    }
-
-    primary.addEventListener('abort', onAbort, { once: true });
-    secondarySignal.addEventListener('abort', onAbort, { once: true });
-
-    function cleanup() {
-        primary.removeEventListener('abort', onAbort);
-        secondarySignal.removeEventListener('abort', onAbort);
-    }
-
-    return { signal: controller.signal, cleanup };
 }
 
 function parseRetryAfterMs(value: string | null): number | undefined {

--- a/packages/effect/src/index.ts
+++ b/packages/effect/src/index.ts
@@ -1,3 +1,6 @@
+// NOTE: this barrel is imported by apps/web and must stay browser-safe.
+// Server-only modules (e.g. job-runner) are exposed as subpath exports only.
+export * from './abort';
 export * from './api-errors';
 export * from './fetch';
 export * from './limits';


### PR DESCRIPTION
First PR of the Effect-deepening sequence (stacked on #48). Zero behavior change.

- **`mergeSignals` deduplicated**: was copy-pasted verbatim (~29 lines) between `packages/effect/src/fetch.ts` and `apps/web/src/effect/api-client.ts`; now lives once in `packages/effect/src/abort.ts` with unit tests covering both the native `AbortSignal.any` path and the manual-listener fallback.
- **`Array.chunksOf`**: replaces five copy-pasted local chunk helpers in `v1/assets/search`, `v1/assets/curated`, `v1/assets/[assetId]/variants`, `v1/assets/[assetId]/variant-top-markets`, and `tokens/curated/seed-ohlcv`. (`chunksOf` clamps size ≤ 0 to 1 — strictly safer than the locals.)
- **Dead dep**: `@tanstack/pacer` removed from `apps/api` (imported nowhere).

Verified: `bun test` + `tsc --noEmit` green in `packages/effect`, `apps/api`, `apps/web`; live smoke of `/api/v1/assets/search` and `/api/v1/assets/curated` (the chunked fan-out paths) both 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)