### PR TITLE
refactor(cloudrun): final cron sweep — misc/seed/prestocks (C4d)

### DIFF
--- a/apps/api/src/app/api/v1/news/feed/route.ts
+++ b/apps/api/src/app/api/v1/news/feed/route.ts
@@ -2,6 +2,7 @@ import { Effect } from 'effect';
 
 import { fetchJsonWithRetry, tapErrorAndDefault } from '@tokens/effect';
 import { route } from '@/effect/next-route';
+import { resolveXBearerToken, runXRequest } from '@/lib/x-auth';
 import { buildMediaByKey, getPostImage, type XMedia, type XPostMediaAttachment } from '@/lib/x-media';
 import {
     articleMatchesTerms,
@@ -69,12 +70,6 @@ const MAX_X_RESULTS = 100;
 const MAX_COINGECKO_NEWS_PER_PAGE = 20;
 const MAX_COINGECKO_NEWS_PAGES = 20;
 
-let cachedBearerToken: string | null = null;
-
-function invalidateCachedBearerToken(): void {
-    cachedBearerToken = null;
-}
-
 function parseTerms(url: URL): string[] {
     const values = [
         ...url.searchParams.getAll('term'),
@@ -116,46 +111,6 @@ function cleanPostText(value: string): string {
 
 function buildXPostUrl(username: string, postId: string): string {
     return `https://x.com/${encodeURIComponent(username)}/status/${encodeURIComponent(postId)}`;
-}
-
-async function runXRequest<T>(request: Effect.Effect<T, unknown, never>): Promise<T> {
-    try {
-        return await Effect.runPromise(request);
-    } catch (error) {
-        invalidateCachedBearerToken();
-        throw error;
-    }
-}
-
-async function resolveXBearerToken(): Promise<string | null> {
-    const existingBearerToken = process.env.X_BEARER_TOKEN?.trim();
-    if (existingBearerToken) return existingBearerToken;
-    if (cachedBearerToken) return cachedBearerToken;
-
-    const apiKey = process.env.X_API_KEY?.trim();
-    const apiSecret = process.env.X_API_SECRET?.trim();
-    if (!apiKey || !apiSecret) return null;
-
-    const credentials = `${encodeURIComponent(apiKey)}:${encodeURIComponent(apiSecret)}`;
-    const authorization = Buffer.from(credentials).toString('base64');
-    const response = await fetch('https://api.x.com/oauth2/token', {
-        method: 'POST',
-        headers: {
-            Authorization: `Basic ${authorization}`,
-            'Content-Type': 'application/x-www-form-urlencoded;charset=UTF-8',
-        },
-        body: 'grant_type=client_credentials',
-    });
-
-    if (!response.ok) throw new Error(`Failed to resolve X bearer token (${response.status})`);
-
-    const data = (await response.json()) as { token_type?: string; access_token?: string };
-    if (data.token_type?.toLowerCase() !== 'bearer' || !data.access_token) {
-        throw new Error('X bearer token response was invalid');
-    }
-
-    cachedBearerToken = data.access_token;
-    return cachedBearerToken;
 }
 
 function mapCoinGeckoNewsArticle(article: CoinGeckoNewsArticle): FeedArticle {
@@ -247,7 +202,7 @@ function getCandidateFetchCounts(params: { limit: number; tweetReserve: number; 
 }
 
 async function fetchTokensFeed(limit: number): Promise<FeedArticle[]> {
-    const bearerToken = await resolveXBearerToken();
+    const bearerToken = await Effect.runPromise(resolveXBearerToken());
     if (!bearerToken) return [];
 
     const authHeaders = {
@@ -258,7 +213,7 @@ async function fetchTokensFeed(limit: number): Promise<FeedArticle[]> {
     const userUrl = new URL(`https://api.x.com/2/users/by/username/${X_USERNAME}`);
     userUrl.searchParams.set('user.fields', 'id,name,username,profile_image_url');
 
-    const userResponse = await runXRequest(fetchJsonWithRetry<XUserLookupResponse>({
+    const userResponse = await Effect.runPromise(runXRequest(fetchJsonWithRetry<XUserLookupResponse>({
         url: userUrl.toString(),
         service: 'x',
         init: {
@@ -266,7 +221,7 @@ async function fetchTokensFeed(limit: number): Promise<FeedArticle[]> {
             next: { revalidate: 60 },
         },
         maxRetries: 2,
-    }));
+    })));
 
     const user = userResponse.data;
     if (!user?.id) return [];
@@ -278,7 +233,7 @@ async function fetchTokensFeed(limit: number): Promise<FeedArticle[]> {
     postsUrl.searchParams.set('expansions', 'attachments.media_keys');
     postsUrl.searchParams.set('media.fields', 'media_key,preview_image_url,type,url');
 
-    const postsResponse = await runXRequest(fetchJsonWithRetry<XUserPostsResponse>({
+    const postsResponse = await Effect.runPromise(runXRequest(fetchJsonWithRetry<XUserPostsResponse>({
         url: postsUrl.toString(),
         service: 'x',
         init: {
@@ -286,7 +241,7 @@ async function fetchTokensFeed(limit: number): Promise<FeedArticle[]> {
             next: { revalidate: 60 },
         },
         maxRetries: 2,
-    }));
+    })));
     const mediaByKey = buildMediaByKey(postsResponse.includes?.media);
 
     return (postsResponse.data ?? [])

--- a/apps/api/src/app/api/x/tokens-feed/route.ts
+++ b/apps/api/src/app/api/x/tokens-feed/route.ts
@@ -2,6 +2,7 @@ import { Effect } from 'effect';
 
 import { fetchJsonWithRetry, tapErrorAndDefault } from '@tokens/effect';
 import { route } from '@/effect/next-route';
+import { resolveXBearerToken, runXRequest } from '@/lib/x-auth';
 import { buildMediaByKey, getPostImage, type XMedia, type XPostMediaAttachment } from '@/lib/x-media';
 
 interface NewsFeedArticle {
@@ -54,12 +55,6 @@ const DEFAULT_POST_LIMIT = 10;
 const MIN_X_RESULTS = 5;
 const MAX_X_RESULTS = 20;
 
-let cachedBearerToken: string | null = null;
-
-function invalidateCachedBearerToken(): void {
-    cachedBearerToken = null;
-}
-
 function parseLimit(value: string | null): number {
     const parsed = Number.parseInt(value ?? '', 10);
     if (!Number.isFinite(parsed) || parsed < 1) return DEFAULT_POST_LIMIT;
@@ -77,50 +72,8 @@ function cleanPostText(value: string): string {
         .trim();
 }
 
-async function resolveXBearerToken(): Promise<string | null> {
-    const existingBearerToken = process.env.X_BEARER_TOKEN?.trim();
-    if (existingBearerToken) return existingBearerToken;
-    if (cachedBearerToken) return cachedBearerToken;
-
-    const apiKey = process.env.X_API_KEY?.trim();
-    const apiSecret = process.env.X_API_SECRET?.trim();
-    if (!apiKey || !apiSecret) return null;
-
-    const credentials = `${encodeURIComponent(apiKey)}:${encodeURIComponent(apiSecret)}`;
-    const authorization = Buffer.from(credentials).toString('base64');
-    const response = await fetch('https://api.x.com/oauth2/token', {
-        method: 'POST',
-        headers: {
-            Authorization: `Basic ${authorization}`,
-            'Content-Type': 'application/x-www-form-urlencoded;charset=UTF-8',
-        },
-        body: 'grant_type=client_credentials',
-    });
-
-    if (!response.ok) {
-        throw new Error(`Failed to resolve X bearer token (${response.status})`);
-    }
-
-    const data = (await response.json()) as { token_type?: string; access_token?: string };
-    if (data.token_type?.toLowerCase() !== 'bearer' || !data.access_token) {
-        throw new Error('X bearer token response was invalid');
-    }
-
-    cachedBearerToken = data.access_token;
-    return cachedBearerToken;
-}
-
 function buildXPostUrl(username: string, postId: string): string {
     return `https://x.com/${encodeURIComponent(username)}/status/${encodeURIComponent(postId)}`;
-}
-
-async function runXRequest<T>(request: Effect.Effect<T, unknown, never>): Promise<T> {
-    try {
-        return await Effect.runPromise(request);
-    } catch (error) {
-        invalidateCachedBearerToken();
-        throw error;
-    }
 }
 
 export const GET = route(
@@ -129,7 +82,7 @@ export const GET = route(
             const requestUrl = new URL(request.url);
             const limit = parseLimit(requestUrl.searchParams.get('limit'));
 
-            const bearerToken = yield* Effect.tryPromise(() => resolveXBearerToken()).pipe(
+            const bearerToken = yield* resolveXBearerToken().pipe(
                 tapErrorAndDefault('x.tokensFeed.resolveBearerToken', null),
             );
             if (!bearerToken) return [] satisfies NewsFeedArticle[];
@@ -142,8 +95,8 @@ export const GET = route(
             const userUrl = new URL(`https://api.x.com/2/users/by/username/${X_USERNAME}`);
             userUrl.searchParams.set('user.fields', 'id,name,username,profile_image_url');
 
-            const userResponse: XUserLookupResponse = yield* Effect.tryPromise(() =>
-                runXRequest(fetchJsonWithRetry<XUserLookupResponse>({
+            const userResponse: XUserLookupResponse = yield* runXRequest(
+                fetchJsonWithRetry<XUserLookupResponse>({
                     url: userUrl.toString(),
                     service: 'x',
                     init: {
@@ -151,7 +104,7 @@ export const GET = route(
                         next: { revalidate: 60 },
                     },
                     maxRetries: 2,
-                })),
+                }),
             ).pipe(tapErrorAndDefault('x.tokensFeed.userLookup', {} as XUserLookupResponse));
 
             const user = userResponse.data;
@@ -164,8 +117,8 @@ export const GET = route(
             postsUrl.searchParams.set('expansions', 'attachments.media_keys');
             postsUrl.searchParams.set('media.fields', 'media_key,preview_image_url,type,url');
 
-            const postsResponse: XUserPostsResponse = yield* Effect.tryPromise(() =>
-                runXRequest(fetchJsonWithRetry<XUserPostsResponse>({
+            const postsResponse: XUserPostsResponse = yield* runXRequest(
+                fetchJsonWithRetry<XUserPostsResponse>({
                     url: postsUrl.toString(),
                     service: 'x',
                     init: {
@@ -173,7 +126,7 @@ export const GET = route(
                         next: { revalidate: 60 },
                     },
                     maxRetries: 2,
-                })),
+                }),
             ).pipe(tapErrorAndDefault('x.tokensFeed.userPosts', {} as XUserPostsResponse));
             const mediaByKey = buildMediaByKey(postsResponse.includes?.media);
 

--- a/apps/api/src/effect/after-response.ts
+++ b/apps/api/src/effect/after-response.ts
@@ -1,0 +1,16 @@
+import { after } from 'next/server';
+import { Effect } from 'effect';
+
+/**
+ * The single sanctioned Effect -> Promise boundary for post-response work.
+ * Runs the effect after the response is sent (Next's `after()`); failures are
+ * swallowed — post-response work must never surface into the request.
+ */
+export function runAfterResponse(effect: Effect.Effect<void, never>): void {
+    try {
+        after(() => Effect.runPromise(effect).catch(() => undefined));
+    } catch {
+        // `after()` throws outside a Next request scope (e.g. bare bun tests);
+        // post-response work is best-effort by definition.
+    }
+}

--- a/apps/api/src/effect/next-route.test.ts
+++ b/apps/api/src/effect/next-route.test.ts
@@ -1,0 +1,159 @@
+import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test';
+import { Effect } from 'effect';
+
+mock.module('server-only', () => ({}));
+
+const { __resetCloudRunClientForTesting } = await import('@/lib/cloudrun/client');
+const { resetEnvForTests } = await import('@/lib/env');
+const { BadRequestError, NotFoundError } = await import('@tokens/effect');
+const { signPlaygroundProxyAuthPayload } = await import('./playground-proxy-auth');
+const { route } = await import('./next-route');
+
+const ORIGINAL_FETCH = globalThis.fetch;
+const ENV_KEYS = [
+    'UPSTASH_REDIS_REST_URL',
+    'UPSTASH_REDIS_REST_TOKEN',
+    'TOKENS_REDIS_TARGET',
+    'TOKENS_CLOUDRUN_AUTH_TOKEN',
+    'TOKENS_CLOUDRUN_ASSETS_URL',
+    'TOKENS_CLOUDRUN_PRICES_URL',
+    'TOKENS_CLOUDRUN_USAGE_URL',
+    'TOKENS_PLAYGROUND_PROXY_SECRET',
+] as const;
+const savedEnv: Record<string, string | undefined> = {};
+
+let logs: string[] = [];
+const originalLog = console.log;
+
+beforeEach(() => {
+    for (const key of ENV_KEYS) {
+        savedEnv[key] = process.env[key];
+        delete process.env[key];
+    }
+    // Cloud Run env present (auth service reachable through the faked fetch);
+    // Redis env deliberately ABSENT so the limits path exercises fail-open.
+    process.env.TOKENS_CLOUDRUN_AUTH_TOKEN = 'tok';
+    process.env.TOKENS_CLOUDRUN_ASSETS_URL = 'https://assets.example.run.app';
+    process.env.TOKENS_CLOUDRUN_PRICES_URL = 'https://prices.example.run.app';
+    process.env.TOKENS_CLOUDRUN_USAGE_URL = 'https://usage.example.run.app';
+    resetEnvForTests();
+    __resetCloudRunClientForTesting();
+    logs = [];
+    console.log = (...args: unknown[]) => {
+        logs.push(String(args[0]));
+    };
+});
+
+afterEach(() => {
+    globalThis.fetch = ORIGINAL_FETCH;
+    console.log = originalLog;
+    for (const key of ENV_KEYS) {
+        if (savedEnv[key] === undefined) delete process.env[key];
+        else process.env[key] = savedEnv[key];
+    }
+    resetEnvForTests();
+    __resetCloudRunClientForTesting();
+});
+
+function fakeAuthFetch(authResult: unknown): void {
+    globalThis.fetch = (async (input: string | URL | Request) => {
+        const url = String(input);
+        if (url.includes('/query/apiKeysAuthenticate')) {
+            return new Response(JSON.stringify(authResult), {
+                status: 200,
+                headers: { 'content-type': 'application/json' },
+            });
+        }
+        return new Response('null', { status: 200, headers: { 'content-type': 'application/json' } });
+    }) as typeof fetch;
+}
+
+async function playgroundHeader(scopes: string[]): Promise<string> {
+    const now = Date.now();
+    return signPlaygroundProxyAuthPayload({
+        apiKeyId: 'k',
+        keyPrefix: 'tk_test',
+        projectId: 'p',
+        ownerClerkUserId: 'u',
+        scopes,
+        iat: now,
+        exp: now + 60_000,
+    });
+}
+
+const okHandler = route(() => Effect.succeed({ hello: 'world' }), {
+    platform: { requiredScopes: ['assets:read'] },
+});
+
+function request(headers: Record<string, string> = {}): Request {
+    return new Request('https://api.example.test/api/v1/assets/thing', { headers });
+}
+
+type Envelope = { error: { _tag: string; message: string } };
+
+describe('route() auth/limits matrices', () => {
+    it('401 with the envelope when no credentials are presented', async () => {
+        const res = await okHandler(request(), {} as never);
+        expect(res.status).toBe(401);
+        const body = (await res.json()) as Envelope;
+        expect(body.error._tag).toBe('UnauthorizedError');
+        expect(body.error.message).toBe('Missing API key');
+        expect(res.headers.get('x-request-id')).not.toBeNull();
+    });
+
+    it('401 when the API key does not authenticate', async () => {
+        fakeAuthFetch(null);
+        const res = await okHandler(request({ 'x-api-key': 'tk_bogus' }), {} as never);
+        expect(res.status).toBe(401);
+        const body = (await res.json()) as Envelope;
+        expect(body.error._tag).toBe('UnauthorizedError');
+        expect(body.error.message).toBe('Invalid API key');
+    });
+
+    it('403 when the key lacks a required scope', async () => {
+        const header = await playgroundHeader(['tokens:read']);
+        const res = await okHandler(request({ 'x-tokens-playground-auth': header }), {} as never);
+        expect(res.status).toBe(403);
+        const body = (await res.json()) as Envelope;
+        expect(body.error._tag).toBe('ForbiddenError');
+    });
+
+    it('200 fail-open when Redis is unconfigured, logging rate_limit_degraded', async () => {
+        const header = await playgroundHeader(['assets:read']);
+        const res = await okHandler(request({ 'x-tokens-playground-auth': header }), {} as never);
+        expect(res.status).toBe(200);
+        expect(await res.json()).toEqual({ hello: 'world' });
+        const degraded = logs.filter(line => line.includes('rate_limit_degraded'));
+        expect(degraded.length).toBe(1);
+    });
+
+    it('maps handler BadRequestError to a 400 envelope', async () => {
+        const handler = route(() => Effect.fail(new BadRequestError({ message: 'bad limit' })), {
+            platform: { requiredScopes: ['assets:read'] },
+        });
+        const header = await playgroundHeader(['assets:read']);
+        const res = await handler(request({ 'x-tokens-playground-auth': header }), {} as never);
+        expect(res.status).toBe(400);
+        const body = (await res.json()) as Envelope;
+        expect(body.error._tag).toBe('BadRequestError');
+        expect(body.error.message).toBe('bad limit');
+    });
+
+    it('maps handler NotFoundError to a 404 envelope', async () => {
+        const handler = route(() => Effect.fail(new NotFoundError({ message: 'nope' })), {
+            platform: { requiredScopes: ['assets:read'] },
+        });
+        const header = await playgroundHeader(['assets:read']);
+        const res = await handler(request({ 'x-tokens-playground-auth': header }), {} as never);
+        expect(res.status).toBe(404);
+    });
+
+    it('maps unknown failures to a 500 envelope', async () => {
+        const handler = route(() => Effect.fail(new Error('kaboom')), {
+            platform: { requiredScopes: ['assets:read'] },
+        });
+        const header = await playgroundHeader(['assets:read']);
+        const res = await handler(request({ 'x-tokens-playground-auth': header }), {} as never);
+        expect(res.status).toBe(500);
+    });
+});

--- a/apps/api/src/effect/next-route.ts
+++ b/apps/api/src/effect/next-route.ts
@@ -1,7 +1,9 @@
 import 'server-only';
 
 import { Cause, Effect } from 'effect';
-import { after, NextResponse } from 'next/server';
+import { NextResponse } from 'next/server';
+
+import { runAfterResponse } from './after-response';
 
 import { authenticateApiKey, logApiRequest } from '@/lib/cloudrun';
 import { loadEnv } from '@/lib/env';
@@ -23,6 +25,7 @@ import {
     toApiErrorInfo,
     toErrorEnvelope,
     UnauthorizedError,
+    CurrentRequestId,
 } from '@tokens/effect';
 
 export type RouteHandlerEffect<T> = Effect.Effect<T, unknown, never>;
@@ -131,22 +134,28 @@ function isPlatformAuthContext(value: unknown): value is PlatformAuthContext {
     );
 }
 
-async function getCachedPlatformAuth(keyHash: string): Promise<PlatformAuthContext | null> {
-    const ttl = loadEnv().authCacheTtlSeconds;
-    if (ttl <= 0) return null;
+function getCachedPlatformAuth(keyHash: string): Effect.Effect<PlatformAuthContext | null, unknown> {
+    return Effect.gen(function* () {
+        const ttl = loadEnv().authCacheTtlSeconds;
+        if (ttl <= 0) return null;
 
-    const redis = await Effect.runPromise(getRedisClientEffect());
-    const cached = await redis.get<string | PlatformAuthContext>(`api-auth:v1:${keyHash}`);
-    const value = typeof cached === 'string' ? JSON.parse(cached) : cached;
-    return isPlatformAuthContext(value) ? value : null;
+        const redis = yield* getRedisClientEffect();
+        const cached = yield* Effect.tryPromise(() =>
+            redis.get<string | PlatformAuthContext>(`api-auth:v1:${keyHash}`),
+        );
+        const value = typeof cached === 'string' ? JSON.parse(cached) : cached;
+        return isPlatformAuthContext(value) ? value : null;
+    });
 }
 
-async function cachePlatformAuth(keyHash: string, auth: PlatformAuthContext): Promise<void> {
-    const ttl = loadEnv().authCacheTtlSeconds;
-    if (ttl <= 0) return;
+function cachePlatformAuth(keyHash: string, auth: PlatformAuthContext): Effect.Effect<void, unknown> {
+    return Effect.gen(function* () {
+        const ttl = loadEnv().authCacheTtlSeconds;
+        if (ttl <= 0) return;
 
-    const redis = await Effect.runPromise(getRedisClientEffect());
-    await redis.set(`api-auth:v1:${keyHash}`, JSON.stringify(auth), { ex: ttl });
+        const redis = yield* getRedisClientEffect();
+        yield* Effect.tryPromise(() => redis.set(`api-auth:v1:${keyHash}`, JSON.stringify(auth), { ex: ttl }));
+    });
 }
 
 function requirePlatformAuth(request: Request) {
@@ -155,7 +164,7 @@ function requirePlatformAuth(request: Request) {
 
         if (rawKey) {
             const keyHash = yield* Effect.tryPromise(() => sha256Hex(rawKey));
-            const cachedAuth = yield* Effect.tryPromise(() => getCachedPlatformAuth(keyHash)).pipe(
+            const cachedAuth = yield* getCachedPlatformAuth(keyHash).pipe(
                 Effect.catch(() => Effect.succeed(null)),
             );
             if (cachedAuth) return cachedAuth;
@@ -174,7 +183,7 @@ function requirePlatformAuth(request: Request) {
                 ...(auth.limits ? { limits: auth.limits } : {}),
             } satisfies PlatformAuthContext;
 
-            yield* Effect.tryPromise(() => cachePlatformAuth(keyHash, authContext)).pipe(
+            yield* cachePlatformAuth(keyHash, authContext).pipe(
                 Effect.catch(() => Effect.succeed(undefined)),
             );
 
@@ -217,19 +226,14 @@ function enforceUpstashLimits(auth: PlatformAuthContext) {
         // Trade-off: rate-limited (429) requests still increment the quota.
         const [rate, [used]] = yield* Effect.all(
             [
-                Effect.tryPromise(() =>
-                    Promise.race([
-                        slidingWindowLimit({
-                            redis,
-                            identifier: `key:${auth.apiKeyId}`,
-                            tokens: rateLimitCfg.requests,
-                            windowSeconds: rateLimitCfg.windowSeconds,
-                        }),
-                        new Promise<never>((_, reject) =>
-                            setTimeout(() => reject(new Error('rate_limit_timeout')), 1_000),
-                        ),
-                    ]),
-                ),
+                slidingWindowLimit({
+                    redis,
+                    identifier: `key:${auth.apiKeyId}`,
+                    tokens: rateLimitCfg.requests,
+                    windowSeconds: rateLimitCfg.windowSeconds,
+                    // A hung Redis must not hold the request hostage; TimeoutError
+                    // falls into the caller's fail-open catch (only RateLimitedError blocks).
+                }).pipe(Effect.timeout('1 second')),
                 Effect.tryPromise(() =>
                     redis
                         .pipeline()
@@ -341,7 +345,7 @@ async function tryLogRequest(params: {
     }
 }
 
-async function recordUsageAggregate(params: {
+function recordUsageAggregate(params: {
     requestId: string;
     platformAuth: PlatformAuthContext;
     method: string;
@@ -349,12 +353,13 @@ async function recordUsageAggregate(params: {
     status: number;
     latencyMs: number;
     ts: number;
-}): Promise<void> {
+}): Effect.Effect<void, unknown> {
+    return Effect.gen(function* () {
     const env = loadEnv();
-    const redis = await Effect.runPromise(getRedisClientEffect());
+    const redis = yield* getRedisClientEffect();
     const endpoint = normalizeEndpointPath(params.path);
     const day = dateKeyUtc(params.ts);
-    const endpointHash = await sha256Hex(endpoint);
+    const endpointHash = yield* Effect.tryPromise(() => sha256Hex(endpoint));
     const ttl = env.usageAggregationTtlSeconds;
     const dayKey = `usage:v1:day:${day}:${params.platformAuth.projectId}`;
     const endpointKey = `usage:v1:endpoint:${day}:${params.platformAuth.projectId}:${endpointHash}`;
@@ -365,22 +370,25 @@ async function recordUsageAggregate(params: {
     const statusField = statusClassField(params.status);
     const histogramField = `hist:${binLatencyMs(latencyMs)}`;
 
-    await redis
-        .pipeline()
-        .hincrby(dayKey, 'totalCalls', 1)
-        .hincrby(dayKey, 'assetCalls', assetCallDelta)
-        .hincrby(dayKey, 'successCalls', successDelta)
-        .hincrby(dayKey, 'sumLatencyMs', latencyMs)
-        .hincrby(dayKey, statusField, 1)
-        .expire(dayKey, ttl)
-        .hincrby(endpointKey, 'calls', 1)
-        .hincrby(endpointKey, 'successCalls', successDelta)
-        .hincrby(endpointKey, 'sumLatencyMs', latencyMs)
-        .hincrby(endpointKey, statusField, 1)
-        .hincrby(endpointKey, histogramField, 1)
-        .expire(endpointKey, ttl)
-        .set(endpointNameKey, endpoint, { ex: ttl })
-        .exec();
+    yield* Effect.tryPromise(() =>
+        redis
+            .pipeline()
+            .hincrby(dayKey, 'totalCalls', 1)
+            .hincrby(dayKey, 'assetCalls', assetCallDelta)
+            .hincrby(dayKey, 'successCalls', successDelta)
+            .hincrby(dayKey, 'sumLatencyMs', latencyMs)
+            .hincrby(dayKey, statusField, 1)
+            .expire(dayKey, ttl)
+            .hincrby(endpointKey, 'calls', 1)
+            .hincrby(endpointKey, 'successCalls', successDelta)
+            .hincrby(endpointKey, 'sumLatencyMs', latencyMs)
+            .hincrby(endpointKey, statusField, 1)
+            .hincrby(endpointKey, histogramField, 1)
+            .expire(endpointKey, ttl)
+            .set(endpointNameKey, endpoint, { ex: ttl })
+            .exec(),
+    );
+    });
 }
 
 async function recordApiRequestUsage(params: {
@@ -398,7 +406,7 @@ async function recordApiRequestUsage(params: {
 
     if (env.usageLogMode === 'aggregated') {
         try {
-            await recordUsageAggregate(params);
+            await Effect.runPromise(recordUsageAggregate(params));
         } catch (error) {
             logUsageAggregationDegraded({
                 requestId: params.requestId,
@@ -425,17 +433,19 @@ function scheduleUsageRecording(params: {
     errorTag?: string;
 }): void {
     if (!params.platformAuth || !params.path) return;
-    after(() =>
-        recordApiRequestUsage({
-            requestId: params.requestId,
-            platformAuth: params.platformAuth as PlatformAuthContext,
-            method: params.method,
-            path: params.path as string,
-            status: params.status,
-            latencyMs: params.latencyMs,
-            ts: params.ts,
-            ...(params.errorTag ? { errorTag: params.errorTag } : {}),
-        }),
+    runAfterResponse(
+        Effect.tryPromise(() =>
+            recordApiRequestUsage({
+                requestId: params.requestId,
+                platformAuth: params.platformAuth as PlatformAuthContext,
+                method: params.method,
+                path: params.path as string,
+                status: params.status,
+                latencyMs: params.latencyMs,
+                ts: params.ts,
+                ...(params.errorTag ? { errorTag: params.errorTag } : {}),
+            }),
+        ).pipe(Effect.catch(() => Effect.void)),
     );
 }
 
@@ -506,7 +516,10 @@ export function route<T, Ctx = unknown>(
               )
             : handler(request, ctx as Ctx);
 
-        const exit = await Effect.runPromiseExit(effect, { signal: request.signal });
+        const exit = await Effect.runPromiseExit(
+            effect.pipe(Effect.provideService(CurrentRequestId, requestId)),
+            { signal: request.signal },
+        );
 
         const latencyMs = Date.now() - startedAt;
         const url = (() => {
@@ -691,3 +704,11 @@ export function route<T, Ctx = unknown>(
         });
     };
 }
+
+/** @internal test-only exports for the auth/limits hot-path matrices. */
+export const __internals = {
+    requirePlatformAuth,
+    enforceUpstashLimits,
+    getCachedPlatformAuth,
+    cachePlatformAuth,
+};

--- a/apps/api/src/effect/oauth-token-cache.test.ts
+++ b/apps/api/src/effect/oauth-token-cache.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'bun:test';
+import { Effect } from 'effect';
+
+import { makeOAuth2TokenCache } from './oauth-token-cache';
+
+describe('makeOAuth2TokenCache', () => {
+    it('fetches once and serves subsequent gets from the cache', async () => {
+        let fetches = 0;
+        const cache = makeOAuth2TokenCache(
+            Effect.sync(() => {
+                fetches += 1;
+                return `token-${fetches}`;
+            }),
+        );
+
+        expect(await Effect.runPromise(cache.get)).toBe('token-1');
+        expect(await Effect.runPromise(cache.get)).toBe('token-1');
+        expect(fetches).toBe(1);
+    });
+
+    it('dedupes concurrent cold gets into a single fetch', async () => {
+        let fetches = 0;
+        const cache = makeOAuth2TokenCache(
+            Effect.promise(async () => {
+                fetches += 1;
+                await new Promise(resolve => setTimeout(resolve, 10));
+                return 'token';
+            }),
+        );
+
+        const results = await Promise.all([
+            Effect.runPromise(cache.get),
+            Effect.runPromise(cache.get),
+            Effect.runPromise(cache.get),
+        ]);
+        expect(results).toEqual(['token', 'token', 'token']);
+        expect(fetches).toBe(1);
+    });
+
+    it('re-fetches after invalidate', async () => {
+        let fetches = 0;
+        const cache = makeOAuth2TokenCache(
+            Effect.sync(() => {
+                fetches += 1;
+                return `token-${fetches}`;
+            }),
+        );
+
+        expect(await Effect.runPromise(cache.get)).toBe('token-1');
+        await Effect.runPromise(cache.invalidate);
+        expect(await Effect.runPromise(cache.get)).toBe('token-2');
+        expect(fetches).toBe(2);
+    });
+
+    it('does not cache failures', async () => {
+        let fetches = 0;
+        const cache = makeOAuth2TokenCache(
+            Effect.suspend(() => {
+                fetches += 1;
+                return fetches === 1 ? Effect.fail(new Error('boom')) : Effect.succeed('token');
+            }),
+        );
+
+        let threw = false;
+        try {
+            await Effect.runPromise(cache.get);
+        } catch {
+            threw = true;
+        }
+        expect(threw).toBe(true);
+        expect(await Effect.runPromise(cache.get)).toBe('token');
+    });
+});

--- a/apps/api/src/effect/oauth-token-cache.ts
+++ b/apps/api/src/effect/oauth-token-cache.ts
@@ -1,0 +1,27 @@
+import { Duration, Effect } from 'effect';
+
+export interface TokenCache<E> {
+    /** Resolve the token, fetching (and caching) when cold or expired. Concurrent gets share one fetch. */
+    readonly get: Effect.Effect<string, E>;
+    /** Drop the cached token so the next `get` re-fetches (e.g. after a 401). */
+    readonly invalidate: Effect.Effect<void>;
+}
+
+/**
+ * TTL'd OAuth bearer-token cache. Replaces the module-level
+ * `let cachedBearerToken` pattern, which cached tokens forever and only
+ * dropped them when a request happened to fail.
+ */
+export function makeOAuth2TokenCache<E>(
+    fetchToken: Effect.Effect<string, E>,
+    ttl: Duration.Input = '55 minutes',
+): TokenCache<E> {
+    // Constructing the cached pair is pure; module-scope runSync matches the
+    // repo's singleton style.
+    const [cachedGet, invalidate] = Effect.runSync(Effect.cachedInvalidateWithTTL(fetchToken, ttl));
+    // cachedInvalidateWithTTL caches failed exits for the TTL too — a transient
+    // OAuth outage must not pin a failure for 55 minutes, so drop the cache
+    // entry whenever a get fails (the failing wave still shares one fetch).
+    const get = cachedGet.pipe(Effect.tapError(() => invalidate));
+    return { get, invalidate };
+}

--- a/apps/api/src/effect/sliding-window-rate-limit.test.ts
+++ b/apps/api/src/effect/sliding-window-rate-limit.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'bun:test';
+import { Effect } from 'effect';
 
 import type { RedisClient, RedisPipeline } from '@/lib/redis';
 import { SLIDING_WINDOW_LIMIT_SCRIPT } from '@/lib/redis/lua';
@@ -63,13 +64,13 @@ describe('slidingWindowLimit', () => {
             onCall: () => [10, 100] as [number, number],
         });
 
-        const result = await slidingWindowLimit({
+        const result = await Effect.runPromise(slidingWindowLimit({
             redis,
             identifier: 'key:abc',
             tokens: 100,
             windowSeconds: 10,
             now: 30_000, // currentWindow = 30000/10000 = 3
-        });
+        }));
 
         expect(calls.length).toBe(1);
         const call = calls[0]!;
@@ -103,13 +104,13 @@ describe('slidingWindowLimit', () => {
             },
         });
 
-        const result = await slidingWindowLimit({
+        const result = await Effect.runPromise(slidingWindowLimit({
             redis,
             identifier: 'key:zzz',
             tokens: 50,
             windowSeconds: 1,
             now: 5_500,
-        });
+        }));
 
         expect(calls.length).toBe(2);
         expect(calls[0]!.method).toBe('evalsha');
@@ -125,13 +126,13 @@ describe('slidingWindowLimit', () => {
             onCall: () => [-1, 10] as [number, number],
         });
 
-        const result = await slidingWindowLimit({
+        const result = await Effect.runPromise(slidingWindowLimit({
             redis,
             identifier: 'key:x',
             tokens: 10,
             windowSeconds: 5,
             now: 1_000,
-        });
+        }));
 
         expect(result.success).toBe(false);
         expect(result.remaining).toBe(0); // clamped to >= 0
@@ -146,15 +147,18 @@ describe('slidingWindowLimit', () => {
 
         let threw = false;
         try {
-            await slidingWindowLimit({
+            await Effect.runPromise(slidingWindowLimit({
                 redis,
                 identifier: 'key:y',
                 tokens: 1,
                 windowSeconds: 1,
-            });
+            }));
         } catch (err) {
             threw = true;
-            expect((err as Error).message).toBe('ECONNREFUSED');
+            const redisError = err as { _tag: string; command: string; cause?: string };
+            expect(redisError._tag).toBe('RedisCommandError');
+            expect(redisError.command).toBe('evalsha');
+            expect(redisError.cause).toBe('ECONNREFUSED');
         }
         expect(threw).toBe(true);
         expect(calls.length).toBe(1); // single EVALSHA attempt, no EVAL fallback

--- a/apps/api/src/effect/sliding-window-rate-limit.ts
+++ b/apps/api/src/effect/sliding-window-rate-limit.ts
@@ -1,4 +1,5 @@
-import type { RedisClient } from '@/lib/redis';
+import { Effect } from 'effect';
+import { RedisCommandError, type RedisClient } from '@/lib/redis';
 import { SLIDING_WINDOW_LIMIT_SCRIPT } from '@/lib/redis/lua';
 
 /**
@@ -35,63 +36,85 @@ const PREFIX = 'ratelimit';
  * Upstash contract: KEYS = [currentKey, previousKey, dynamicLimitKey],
  * ARGV = [tokens, nowMs, windowMs, incrementBy].
  */
-export async function slidingWindowLimit(params: {
+export function slidingWindowLimit(params: {
     redis: RedisClient;
     identifier: string;
     tokens: number;
     windowSeconds: number;
     incrementBy?: number;
     now?: number;
-}): Promise<SlidingWindowLimitResult> {
-    const { redis, identifier, tokens, windowSeconds } = params;
-    const incrementBy = params.incrementBy ?? 1;
-    const now = params.now ?? Date.now();
+}): Effect.Effect<SlidingWindowLimitResult, RedisCommandError> {
+    return Effect.suspend(() => {
+        const { redis, identifier, tokens, windowSeconds } = params;
+        const incrementBy = params.incrementBy ?? 1;
+        const now = params.now ?? Date.now();
 
-    const windowMs = windowSeconds * 1000;
-    const currentWindow = Math.floor(now / windowMs);
-    const previousWindow = currentWindow - 1;
+        const windowMs = windowSeconds * 1000;
+        const currentWindow = Math.floor(now / windowMs);
+        const previousWindow = currentWindow - 1;
 
-    const base = `${PREFIX}:${identifier}`;
-    const currentKey = `${base}:${currentWindow}`;
-    const previousKey = `${base}:${previousWindow}`;
-    // We don't use dynamic limits; pass an empty string per the script's
-    // contract (the Lua treats "" as "no dynamic limit configured").
-    const dynamicLimitKey = '';
+        const base = `${PREFIX}:${identifier}`;
+        const currentKey = `${base}:${currentWindow}`;
+        const previousKey = `${base}:${previousWindow}`;
+        // We don't use dynamic limits; pass an empty string per the script's
+        // contract (the Lua treats "" as "no dynamic limit configured").
+        const dynamicLimitKey = '';
 
-    const keys = [currentKey, previousKey, dynamicLimitKey];
-    const args = [tokens, now, windowMs, incrementBy];
+        const keys = [currentKey, previousKey, dynamicLimitKey];
+        const args = [tokens, now, windowMs, incrementBy];
 
-    const result = await evalWithFallback<[number, number]>(redis, keys, args);
-    const remainingTokens = Number(result[0]);
-    const effectiveLimit = Number(result[1]);
-    const success = remainingTokens >= 0;
-    const reset = (currentWindow + 1) * windowMs;
+        return evalWithFallback<[number, number]>(redis, keys, args).pipe(
+            Effect.map(result => {
+                const remainingTokens = Number(result[0]);
+                const effectiveLimit = Number(result[1]);
+                const success = remainingTokens >= 0;
+                const reset = (currentWindow + 1) * windowMs;
 
-    return {
-        success,
-        limit: effectiveLimit,
-        remaining: Math.max(0, remainingTokens),
-        reset,
-    };
+                return {
+                    success,
+                    limit: effectiveLimit,
+                    remaining: Math.max(0, remainingTokens),
+                    reset,
+                };
+            }),
+        );
+    });
 }
 
-async function evalWithFallback<T>(
+function evalWithFallback<T>(
     redis: RedisClient,
     keys: string[],
     args: Array<string | number>,
-): Promise<T> {
-    try {
-        return await redis.evalsha<T>(SLIDING_WINDOW_LIMIT_SCRIPT.sha1, keys, args);
-    } catch (err) {
-        if (isNoScriptError(err)) {
-            return await redis.eval<T>(SLIDING_WINDOW_LIMIT_SCRIPT.script, keys, args);
-        }
-        throw err;
-    }
+): Effect.Effect<T, RedisCommandError> {
+    return Effect.tryPromise({
+        try: () => redis.evalsha<T>(SLIDING_WINDOW_LIMIT_SCRIPT.sha1, keys, args),
+        catch: err =>
+            new RedisCommandError({
+                message: 'sliding-window EVALSHA failed',
+                command: 'evalsha',
+                cause: errorMessage(err),
+            }),
+    }).pipe(
+        Effect.catchIf(
+            error => isNoScriptError(error.cause),
+            () =>
+                Effect.tryPromise({
+                    try: () => redis.eval<T>(SLIDING_WINDOW_LIMIT_SCRIPT.script, keys, args),
+                    catch: err =>
+                        new RedisCommandError({
+                            message: 'sliding-window EVAL failed',
+                            command: 'eval',
+                            cause: errorMessage(err),
+                        }),
+                }),
+        ),
+    );
 }
 
-function isNoScriptError(err: unknown): boolean {
-    const message =
-        err instanceof Error ? err.message : typeof err === 'string' ? err : String(err);
-    return message.includes('NOSCRIPT');
+function errorMessage(err: unknown): string {
+    return err instanceof Error ? err.message : typeof err === 'string' ? err : String(err);
+}
+
+function isNoScriptError(message: string | undefined): boolean {
+    return message?.includes('NOSCRIPT') === true;
 }

--- a/apps/api/src/lib/birdeye.schemas.ts
+++ b/apps/api/src/lib/birdeye.schemas.ts
@@ -1,0 +1,45 @@
+import { Schema } from 'effect';
+
+/**
+ * Lenient shadow-mode schemas for Birdeye responses: only the fields we
+ * consume, everything optional — wired via fetchJson's `schema` option in
+ * 'warn' mode, so mismatches log `upstream_decode_failed` without changing
+ * behavior. Flip to decodeMode: 'fail' once the event is quiet in logs.
+ */
+
+const TokenExtensionsSchema = Schema.Struct({
+    coingeckoId: Schema.optionalKey(Schema.NullishOr(Schema.String)),
+    website: Schema.optionalKey(Schema.NullishOr(Schema.String)),
+    twitter: Schema.optionalKey(Schema.NullishOr(Schema.String)),
+    discord: Schema.optionalKey(Schema.NullishOr(Schema.String)),
+    telegram: Schema.optionalKey(Schema.NullishOr(Schema.String)),
+    description: Schema.optionalKey(Schema.NullishOr(Schema.String)),
+    github: Schema.optionalKey(Schema.NullishOr(Schema.String)),
+});
+
+export const BirdeyeOverviewResponseSchema = Schema.Struct({
+    success: Schema.optionalKey(Schema.Boolean),
+    data: Schema.optionalKey(
+        Schema.NullishOr(
+            Schema.Struct({
+                address: Schema.optionalKey(Schema.String),
+                name: Schema.optionalKey(Schema.String),
+                symbol: Schema.optionalKey(Schema.String),
+                decimals: Schema.optionalKey(Schema.Number),
+                logoURI: Schema.optionalKey(Schema.NullishOr(Schema.String)),
+                extensions: Schema.optionalKey(Schema.NullishOr(TokenExtensionsSchema)),
+                price: Schema.optionalKey(Schema.NullishOr(Schema.Number)),
+                priceChange24hPercent: Schema.optionalKey(Schema.NullishOr(Schema.Number)),
+                marketCap: Schema.optionalKey(Schema.NullishOr(Schema.Number)),
+                fdv: Schema.optionalKey(Schema.NullishOr(Schema.Number)),
+                liquidity: Schema.optionalKey(Schema.NullishOr(Schema.Number)),
+                v24h: Schema.optionalKey(Schema.NullishOr(Schema.Number)),
+                v24hUSD: Schema.optionalKey(Schema.NullishOr(Schema.Number)),
+                holder: Schema.optionalKey(Schema.NullishOr(Schema.Number)),
+                totalSupply: Schema.optionalKey(Schema.NullishOr(Schema.Number)),
+                circulatingSupply: Schema.optionalKey(Schema.NullishOr(Schema.Number)),
+                lastTradeHumanTime: Schema.optionalKey(Schema.NullishOr(Schema.String)),
+            }),
+        ),
+    ),
+});

--- a/apps/api/src/lib/birdeye.ts
+++ b/apps/api/src/lib/birdeye.ts
@@ -3,6 +3,7 @@ import { Effect } from 'effect';
 
 import { BadRequestError } from '@tokens/effect';
 import { fetchJsonWithRetry } from '@tokens/effect';
+import { BirdeyeOverviewResponseSchema } from './birdeye.schemas';
 import type { MarketStats, Token } from '@/lib/types';
 import { cleanTokenName, getTokenLogoURL } from '@/lib/logo-overrides';
 
@@ -62,6 +63,7 @@ interface BirdeyeOverviewResponse {
 
 function fetchTokenOverview(apiKey: string, address: string) {
     return fetchJsonWithRetry<BirdeyeOverviewResponse>({
+        schema: BirdeyeOverviewResponseSchema,
         url: `${BIRDEYE_API_URL}/defi/token_overview?address=${address}`,
         service: 'birdeye',
         init: {

--- a/apps/api/src/lib/cloudrun/assetMarkets.ts
+++ b/apps/api/src/lib/cloudrun/assetMarkets.ts
@@ -3,25 +3,56 @@ import type {
     GetLatestByAssetIdsEntry,
 } from '../../../../cloudrun-assets/src/handlers/assetMarkets';
 
-import type { Effect } from 'effect';
+import { Schema, type Effect } from 'effect';
 
 import { cloudRunQuery } from './client';
 import type { CloudRunError } from './errors';
+
+
+const AssetMarketAggregateSchema = Schema.Struct({
+    assetId: Schema.String,
+    liquidity: Schema.Number,
+    volume24hUSD: Schema.Number,
+    volume30dUSD: Schema.optionalKey(Schema.NullOr(Schema.Number)),
+    primaryMint: Schema.optionalKey(Schema.String),
+    lastComputedAt: Schema.Number,
+    minVariantLastFetchedAt: Schema.optionalKey(Schema.Number),
+    maxVariantLastFetchedAt: Schema.optionalKey(Schema.Number),
+});
+
+const GetLatestByAssetIdResultSchema = Schema.NullOr(AssetMarketAggregateSchema);
+const GetLatestByAssetIdsResultSchema = Schema.Array(
+    Schema.Struct({
+        assetId: Schema.String,
+        market: Schema.NullOr(AssetMarketAggregateSchema),
+    }),
+);
+
+type AssertAssignable<_A extends B, B> = never;
+type _AggregateDrift = AssertAssignable<Schema.Schema.Type<typeof AssetMarketAggregateSchema>, AssetMarketAggregate>;
+// Element-wise (Schema.Array decodes to readonly arrays; the wire payload is identical).
+type _EntryDrift = AssertAssignable<Schema.Schema.Type<typeof GetLatestByAssetIdsResultSchema>[number], GetLatestByAssetIdsResult[number]>;
 
 export type GetLatestByAssetIdArgs = { assetId: string };
 export type GetLatestByAssetIdResult = AssetMarketAggregate | null;
 
 export function getLatestByAssetId(args: GetLatestByAssetIdArgs): Effect.Effect<GetLatestByAssetIdResult, CloudRunError> {
-    return cloudRunQuery<GetLatestByAssetIdResult>('assets', 'assetMarketsGetLatestByAssetId', {
-        ...args,
-    });
+    return cloudRunQuery<GetLatestByAssetIdResult>(
+        'assets',
+        'assetMarketsGetLatestByAssetId',
+        { ...args },
+        { schema: GetLatestByAssetIdResultSchema },
+    );
 }
 
 export type GetLatestByAssetIdsArgs = { assetIds: string[] };
 export type GetLatestByAssetIdsResult = GetLatestByAssetIdsEntry[];
 
 export function getLatestByAssetIds(args: GetLatestByAssetIdsArgs): Effect.Effect<GetLatestByAssetIdsResult, CloudRunError> {
-    return cloudRunQuery<GetLatestByAssetIdsResult>('assets', 'assetMarketsGetLatestByAssetIds', {
-        ...args,
-    });
+    return cloudRunQuery<GetLatestByAssetIdsResult>(
+        'assets',
+        'assetMarketsGetLatestByAssetIds',
+        { ...args },
+        { schema: GetLatestByAssetIdsResultSchema },
+    );
 }

--- a/apps/api/src/lib/cloudrun/cacheWarm.ts
+++ b/apps/api/src/lib/cloudrun/cacheWarm.ts
@@ -12,7 +12,7 @@
  */
 
 import { Effect } from 'effect';
-import { after } from 'next/server';
+import { runAfterResponse } from '@/effect/after-response';
 
 import { tapErrorAndDefault } from '@tokens/effect';
 import type { TimeInterval } from '@/lib/birdeye';
@@ -24,7 +24,7 @@ import { cloudRunMutation } from './client';
  */
 export function deferUntilAfterResponse(effect: Effect.Effect<void, never>): Effect.Effect<void, never> {
     return Effect.sync(() => {
-        after(() => Effect.runPromise(effect).catch(() => undefined));
+        runAfterResponse(effect);
     });
 }
 

--- a/apps/api/src/lib/cloudrun/client.ts
+++ b/apps/api/src/lib/cloudrun/client.ts
@@ -7,8 +7,9 @@
  * interrupts in-flight backend calls.
  */
 
-import { Duration, Effect, Schedule } from 'effect';
-import { MissingEnvError } from '@tokens/effect';
+import { Duration, Effect, Schedule, type Schema } from 'effect';
+import { CurrentRequestId, MissingEnvError, type UpstreamDataError, decodeUpstreamOrFail, emitEvent } from '@tokens/effect';
+import { loadEnv, resetEnvForTests } from '../env';
 import {
     CloudRunHttpError,
     CloudRunTimeoutError,
@@ -28,6 +29,12 @@ export interface CloudRunCallerIdentity {
 
 export interface CloudRunCallOptions {
     identity?: CloudRunCallerIdentity;
+    /**
+     * Optional response schema, decoded STRICTLY (our own contract; excess
+     * keys are dropped, so additive upstream deploys never break us). A
+     * mismatch fails with a tagged UpstreamDataError (500).
+     */
+    schema?: Schema.ConstraintDecoder<unknown>;
     /** Per-call timeout override in ms. Defaults to the client-level timeout (15s). */
     timeoutMs?: number;
     /**
@@ -88,6 +95,7 @@ export function makeCloudRunCaller(cfg: CloudRunClientConfig): CloudRunCaller {
         args: Record<string, unknown>,
         timeoutMs: number,
         identity: CloudRunCallerIdentity | undefined,
+        schema: Schema.ConstraintDecoder<unknown> | undefined,
     ): Effect.Effect<T, CloudRunError> {
         const url = `${base.replace(/\/$/, '')}/${kind}/${encodeURIComponent(name)}`;
         const headers: Record<string, string> = {
@@ -144,7 +152,14 @@ export function makeCloudRunCaller(cfg: CloudRunClientConfig): CloudRunCaller {
                             callName: name,
                             cause: err instanceof Error ? err.message : String(err),
                         }),
-                });
+                }).pipe(
+                    Effect.flatMap(payload => {
+                        if (!schema) return Effect.succeed(payload);
+                        return decodeUpstreamOrFail(schema, `cloudrun:${service}.${name}`)(
+                            payload,
+                        ) as Effect.Effect<T, UpstreamDataError, never>;
+                    }),
+                );
             }),
             Effect.timeout(Duration.millis(timeoutMs)),
             Effect.catchTag('TimeoutError', () =>
@@ -180,7 +195,7 @@ export function makeCloudRunCaller(cfg: CloudRunClientConfig): CloudRunCaller {
             }
 
             const timeoutMs = options.timeoutMs ?? defaultTimeoutMs;
-            const attempt = callOnce<T>(base, service, kind, name, args, timeoutMs, options.identity);
+            const attempt = callOnce<T>(base, service, kind, name, args, timeoutMs, options.identity, options.schema);
 
             // Mutations are never retried regardless of options — replaying a
             // non-idempotent call is worse than failing it.
@@ -195,13 +210,53 @@ export function makeCloudRunCaller(cfg: CloudRunClientConfig): CloudRunCaller {
                 times: maxRetries,
                 schedule: Schedule.exponential(Duration.millis(Math.max(1, retryDelayMs))).pipe(Schedule.jittered),
             });
-        });
+        }).pipe(withCloudRunTelemetry(service, kind, name));
     }
 
     return {
         query: (service, name, args = {}, options = {}) => call(service, 'query', name, args, options),
         mutation: (service, name, args = {}, options = {}) => call(service, 'mutation', name, args, options),
     };
+}
+
+
+/** True unless TOKENS_LOG_CLOUDRUN_CALLS=false — cloudrun calls were previously invisible in logs. */
+function shouldLogCloudRunCalls(): boolean {
+    return (process.env.TOKENS_LOG_CLOUDRUN_CALLS ?? 'true').trim().toLowerCase() !== 'false';
+}
+
+function withCloudRunTelemetry(service: CloudRunService, kind: CloudRunCallKind, name: string) {
+    return <A, E>(effect: Effect.Effect<A, E>): Effect.Effect<A, E> =>
+        Effect.suspend(() => {
+            if (!shouldLogCloudRunCalls()) {
+                return effect.pipe(Effect.withSpan(`cloudrun.${service}.${name}`));
+            }
+            const startedAt = Date.now();
+            const emit = (ok: boolean, status: number | null, errorTag?: string) =>
+                Effect.service(CurrentRequestId).pipe(
+                    Effect.map(requestId =>
+                        emitEvent({
+                            event: 'external_call',
+                            provider: `cloudrun:${service}`,
+                            endpoint: name,
+                            status,
+                            duration_ms: Date.now() - startedAt,
+                            ok,
+                            ...(errorTag ? { error_tag: errorTag } : {}),
+                            ...(requestId ? { request_id: requestId } : {}),
+                        }),
+                    ),
+                );
+            return effect.pipe(
+                Effect.tap(() => emit(true, null)),
+                Effect.tapError(error => {
+                    const tagged = error as { _tag?: string; status?: number };
+                    return emit(false, typeof tagged.status === 'number' ? tagged.status : null, tagged._tag);
+                }),
+                // Spans are inert without a tracer — near-zero cost future-proofing.
+                Effect.withSpan(`cloudrun.${service}.${name}`, { attributes: { 'cloudrun.kind': kind } }),
+            );
+        });
 }
 
 // -----------------------------------------------------------------------------
@@ -212,33 +267,29 @@ let cachedConfig: CloudRunClientConfig | null = null;
 let cachedCaller: CloudRunCaller | null = null;
 
 function readConfigFromEnv(): CloudRunClientConfig | MissingEnvError {
-    const read = (name: string): string | MissingEnvError => {
-        const v = process.env[name]?.trim();
-        if (!v) return new MissingEnvError({ message: `CloudRun client: missing required env var ${name}`, name });
-        return v;
-    };
-
-    const assets = read('TOKENS_CLOUDRUN_ASSETS_URL');
-    if (typeof assets !== 'string') return assets;
-    const prices = read('TOKENS_CLOUDRUN_PRICES_URL');
-    if (typeof prices !== 'string') return prices;
-    const usage = read('TOKENS_CLOUDRUN_USAGE_URL');
-    if (typeof usage !== 'string') return usage;
-    const authToken = read('TOKENS_CLOUDRUN_AUTH_TOKEN');
-    if (typeof authToken !== 'string') return authToken;
-
-    const adminUrl = process.env.TOKENS_CLOUDRUN_ADMIN_URL?.trim();
-    const timeout = Number(process.env.TOKENS_CLOUDRUN_TIMEOUT_MS) || undefined;
+    const cloudRun = loadEnv().cloudRun;
+    if (cloudRun === null) {
+        const missing = [
+            'TOKENS_CLOUDRUN_AUTH_TOKEN',
+            'TOKENS_CLOUDRUN_ASSETS_URL',
+            'TOKENS_CLOUDRUN_PRICES_URL',
+            'TOKENS_CLOUDRUN_USAGE_URL',
+        ].find(name => !process.env[name]?.trim());
+        return new MissingEnvError({
+            message: `CloudRun client: missing required env var ${missing ?? 'TOKENS_CLOUDRUN_AUTH_TOKEN'}`,
+            name: missing ?? 'TOKENS_CLOUDRUN_AUTH_TOKEN',
+        });
+    }
 
     return {
         baseUrls: {
-            assets,
-            prices,
-            usage,
-            ...(adminUrl ? { admin: adminUrl } : {}),
+            assets: cloudRun.urls.assets,
+            prices: cloudRun.urls.prices,
+            usage: cloudRun.urls.usage,
+            ...(cloudRun.urls.admin ? { admin: cloudRun.urls.admin } : {}),
         },
-        authToken,
-        ...(timeout !== undefined ? { timeoutMs: timeout } : {}),
+        authToken: cloudRun.authToken,
+        ...(cloudRun.timeoutMs !== undefined ? { timeoutMs: cloudRun.timeoutMs } : {}),
     };
 }
 
@@ -299,4 +350,6 @@ export function cloudRunMutation<TResult = unknown>(
 export function __resetCloudRunClientForTesting() {
     cachedConfig = null;
     cachedCaller = null;
+    // Config now flows through loadEnv(); tests that toggle env need both caches cleared.
+    resetEnvForTests();
 }

--- a/apps/api/src/lib/cloudrun/errors.ts
+++ b/apps/api/src/lib/cloudrun/errors.ts
@@ -1,5 +1,5 @@
 import { Data } from 'effect';
-import type { MissingEnvError } from '@tokens/effect';
+import type { MissingEnvError, UpstreamDataError } from '@tokens/effect';
 import type { CloudRunCallKind, CloudRunService } from './client';
 
 /** Upstream responded with a non-2xx status. */
@@ -30,7 +30,12 @@ export class CloudRunTransportError extends Data.TaggedError('CloudRunTransportE
     cause?: string;
 }> {}
 
-export type CloudRunError = CloudRunHttpError | CloudRunTimeoutError | CloudRunTransportError | MissingEnvError;
+export type CloudRunError =
+    | CloudRunHttpError
+    | CloudRunTimeoutError
+    | CloudRunTransportError
+    | MissingEnvError
+    | UpstreamDataError;
 
 /** Timeouts and network failures are transient; upstream 5xx is transient-shaped. 4xx is caller/data-dependent. */
 export function isRetryableCloudRunError(error: CloudRunError): boolean {
@@ -41,6 +46,7 @@ export function isRetryableCloudRunError(error: CloudRunError): boolean {
         case 'CloudRunHttpError':
             return error.status >= 500;
         case 'MissingEnvError':
+        case 'UpstreamDataError':
             return false;
     }
 }

--- a/apps/api/src/lib/cloudrun/tokensReads.ts
+++ b/apps/api/src/lib/cloudrun/tokensReads.ts
@@ -8,27 +8,88 @@ import type {
     TokenDescriptionSummaryDoc,
 } from '../../../../cloudrun-assets/src/handlers/tokensReads';
 
-import type { Effect } from 'effect';
+import { Schema, type Effect } from 'effect';
 
 import { cloudRunQuery } from './client';
 import type { CloudRunError } from './errors';
+
+
+// -----------------------------------------------------------------------------
+// Response schemas (strict decode of our own contract; excess keys dropped, so
+// additive cloudrun-assets deploys never break us). The compile-time asserts
+// below turn drift between schema and the imported handler types into build
+// failures. Remaining result types adopt incrementally via the `schema` option.
+// -----------------------------------------------------------------------------
+
+const TokenDocSchema = Schema.Struct({
+    _id: Schema.String,
+    _creationTime: Schema.Number,
+    address: Schema.String,
+    symbol: Schema.String,
+    name: Schema.String,
+    decimals: Schema.Number,
+    logoUri: Schema.optionalKey(Schema.String),
+    coingeckoId: Schema.optionalKey(Schema.String),
+    description: Schema.optionalKey(Schema.String),
+    website: Schema.optionalKey(Schema.String),
+    twitter: Schema.optionalKey(Schema.String),
+    discord: Schema.optionalKey(Schema.String),
+    telegram: Schema.optionalKey(Schema.String),
+    reddit: Schema.optionalKey(Schema.String),
+    github: Schema.optionalKey(Schema.String),
+    price: Schema.optionalKey(Schema.Number),
+    priceChange24hPercent: Schema.optionalKey(Schema.Number),
+    priceChange1hPercent: Schema.optionalKey(Schema.Number),
+    volume24hUSD: Schema.optionalKey(Schema.Number),
+    liquidity: Schema.optionalKey(Schema.Number),
+    marketCap: Schema.optionalKey(Schema.Number),
+    lastFetchedAt: Schema.Number,
+});
+
+const TokenSearchTokenSchema = Schema.Struct({
+    address: Schema.String,
+    symbol: Schema.String,
+    name: Schema.String,
+    decimals: Schema.Number,
+    logoURI: Schema.optionalKey(Schema.String),
+    liquidity: Schema.Number,
+    volume24hUSD: Schema.Number,
+    price: Schema.Number,
+    priceChange24hPercent: Schema.Number,
+    priceChange1hPercent: Schema.optionalKey(Schema.Number),
+    marketCap: Schema.Number,
+});
+
+const TokensGetByAddressResultSchema = Schema.NullOr(TokenDocSchema);
+const TokensSearchTokensResultSchema = Schema.Array(TokenSearchTokenSchema);
+
+type AssertAssignable<_A extends B, B> = never;
+// Drift guards: the schema's decoded type must satisfy the handler contract.
+type _TokenDocDrift = AssertAssignable<Schema.Schema.Type<typeof TokenDocSchema>, TokenDoc>;
+type _TokenSearchTokenDrift = AssertAssignable<Schema.Schema.Type<typeof TokenSearchTokenSchema>, TokenSearchToken>;
 
 export type TokensGetByAddressArgs = { address: string };
 export type TokensGetByAddressResult = TokenDoc | null;
 
 export function tokensGetByAddress(args: TokensGetByAddressArgs): Effect.Effect<TokensGetByAddressResult, CloudRunError> {
-    return cloudRunQuery<TokensGetByAddressResult>('assets', 'tokensGetByAddress', {
-        ...args,
-    });
+    return cloudRunQuery<TokensGetByAddressResult>(
+        'assets',
+        'tokensGetByAddress',
+        { ...args },
+        { schema: TokensGetByAddressResultSchema },
+    );
 }
 
 export type TokensSearchTokensArgs = { query: string; limit?: number };
 export type TokensSearchTokensResult = TokenSearchToken[];
 
 export function tokensSearchTokens(args: TokensSearchTokensArgs): Effect.Effect<TokensSearchTokensResult, CloudRunError> {
-    return cloudRunQuery<TokensSearchTokensResult>('assets', 'tokensSearchTokens', {
-        ...args,
-    });
+    return cloudRunQuery<TokensSearchTokensResult>(
+        'assets',
+        'tokensSearchTokens',
+        { ...args },
+        { schema: TokensSearchTokensResultSchema },
+    );
 }
 
 export type TokensGetSearchTokensByAddressesArgs = { addresses: string[] };

--- a/apps/api/src/lib/coingecko.schemas.ts
+++ b/apps/api/src/lib/coingecko.schemas.ts
@@ -1,0 +1,46 @@
+import { Schema } from 'effect';
+
+/**
+ * Lenient shadow-mode schema for the CoinGecko coin response: only consumed
+ * fields, everything optional/nullable — wired in 'warn' mode so mismatches
+ * log `upstream_decode_failed` without changing behavior.
+ */
+
+const UsdNumberSchema = Schema.Struct({ usd: Schema.optionalKey(Schema.NullishOr(Schema.Number)) });
+const UsdStringSchema = Schema.Struct({ usd: Schema.optionalKey(Schema.NullishOr(Schema.String)) });
+
+export const CoinGeckoResponseSchema = Schema.Struct({
+    id: Schema.optionalKey(Schema.String),
+    symbol: Schema.optionalKey(Schema.String),
+    name: Schema.optionalKey(Schema.String),
+    description: Schema.optionalKey(
+        Schema.NullishOr(Schema.Struct({ en: Schema.optionalKey(Schema.NullishOr(Schema.String)) })),
+    ),
+    links: Schema.optionalKey(
+        Schema.NullishOr(
+            Schema.Struct({
+                homepage: Schema.optionalKey(Schema.NullishOr(Schema.Array(Schema.String))),
+                twitter_screen_name: Schema.optionalKey(Schema.NullishOr(Schema.String)),
+                telegram_channel_identifier: Schema.optionalKey(Schema.NullishOr(Schema.String)),
+                subreddit_url: Schema.optionalKey(Schema.NullishOr(Schema.String)),
+                chat_url: Schema.optionalKey(Schema.NullishOr(Schema.Array(Schema.String))),
+                official_forum_url: Schema.optionalKey(Schema.NullishOr(Schema.Array(Schema.String))),
+            }),
+        ),
+    ),
+    market_data: Schema.optionalKey(
+        Schema.NullishOr(
+            Schema.Struct({
+                current_price: Schema.optionalKey(Schema.NullishOr(UsdNumberSchema)),
+                market_cap: Schema.optionalKey(Schema.NullishOr(UsdNumberSchema)),
+                fully_diluted_valuation: Schema.optionalKey(Schema.NullishOr(UsdNumberSchema)),
+                total_volume: Schema.optionalKey(Schema.NullishOr(UsdNumberSchema)),
+                circulating_supply: Schema.optionalKey(Schema.NullishOr(Schema.Number)),
+                total_supply: Schema.optionalKey(Schema.NullishOr(Schema.Number)),
+                price_change_percentage_24h: Schema.optionalKey(Schema.NullishOr(Schema.Number)),
+                ath: Schema.optionalKey(Schema.NullishOr(UsdNumberSchema)),
+                ath_date: Schema.optionalKey(Schema.NullishOr(UsdStringSchema)),
+            }),
+        ),
+    ),
+});

--- a/apps/api/src/lib/coingecko.ts
+++ b/apps/api/src/lib/coingecko.ts
@@ -3,6 +3,7 @@ import { Effect } from 'effect';
 
 import { UpstreamHttpError } from '@tokens/effect';
 import { fetchJsonWithRetry } from '@tokens/effect';
+import { CoinGeckoResponseSchema } from './coingecko.schemas';
 import { buildXProfileUrl } from './social-links';
 
 const COINGECKO_PUBLIC_API_URL = 'https://api.coingecko.com/api/v3';
@@ -117,6 +118,7 @@ async function getGlobalTokenStatsImpl(coingeckoId: string): Promise<GlobalToken
         fetchJsonWithRetry<CoinGeckoResponse>({
             url,
             service: 'coingecko',
+            schema: CoinGeckoResponseSchema,
             init: { headers, next: { revalidate: 300 } }, // Cache for 5 minutes
             maxRetries: 2,
         }).pipe(

--- a/apps/api/src/lib/env.test.ts
+++ b/apps/api/src/lib/env.test.ts
@@ -6,6 +6,13 @@ const ENV_KEYS = [
     'NODE_ENV',
     'VERCEL_ENV',
     'TOKENS_USAGE_LOG_MODE',
+    'TOKENS_USAGE_RAW_SAMPLE_RATE',
+    'TOKENS_CLOUDRUN_AUTH_TOKEN',
+    'TOKENS_CLOUDRUN_ASSETS_URL',
+    'TOKENS_CLOUDRUN_PRICES_URL',
+    'TOKENS_CLOUDRUN_USAGE_URL',
+    'TOKENS_CLOUDRUN_ADMIN_URL',
+    'TOKENS_CLOUDRUN_TIMEOUT_MS',
 ] as const;
 
 function setEnv(key: string, value: string): void {
@@ -14,6 +21,19 @@ function setEnv(key: string, value: string): void {
 
 function deleteEnv(key: string): void {
     delete (process.env as Record<string, string | undefined>)[key];
+}
+
+function withCapturedWarnings(fn: (warnings: string[]) => void): void {
+    const warnings: string[] = [];
+    const original = console.warn;
+    console.warn = (...args: unknown[]) => {
+        warnings.push(String(args[0]));
+    };
+    try {
+        fn(warnings);
+    } finally {
+        console.warn = original;
+    }
 }
 
 function withEnv(overrides: Partial<Record<(typeof ENV_KEYS)[number], string>>, fn: () => void): void {
@@ -67,6 +87,71 @@ describe('loadEnv usage logging mode', () => {
             },
             () => {
                 expect(loadEnv().usageLogMode).toBe('aggregated');
+            },
+        );
+    });
+});
+
+
+describe('loadEnv invalid numeric values', () => {
+    it('warns loudly when a numeric env is not a number, then uses the fallback', () => {
+        withEnv({ TOKENS_USAGE_RAW_SAMPLE_RATE: 'abc' }, () => {
+            withCapturedWarnings(warnings => {
+                const env = loadEnv();
+                expect(env.usageRawSampleRate).toBe(0);
+                const events = warnings
+                    .map(line => JSON.parse(line) as Record<string, unknown>)
+                    .filter(event => event.event === 'env_invalid_value');
+                expect(events.length).toBe(1);
+                expect(events[0]!.name).toBe('TOKENS_USAGE_RAW_SAMPLE_RATE');
+                expect(events[0]!.raw).toBe('abc');
+            });
+        });
+    });
+
+    it('warns when a numeric env is clamped', () => {
+        withEnv({ TOKENS_USAGE_RAW_SAMPLE_RATE: '7' }, () => {
+            withCapturedWarnings(warnings => {
+                const env = loadEnv();
+                expect(env.usageRawSampleRate).toBe(1);
+                expect(warnings.length).toBe(1);
+            });
+        });
+    });
+
+    it('stays silent for valid values', () => {
+        withEnv({ TOKENS_USAGE_RAW_SAMPLE_RATE: '0.5' }, () => {
+            withCapturedWarnings(warnings => {
+                expect(loadEnv().usageRawSampleRate).toBe(0.5);
+                expect(warnings.length).toBe(0);
+            });
+        });
+    });
+});
+
+describe('loadEnv cloudRun section', () => {
+    const CLOUDRUN_VARS = {
+        TOKENS_CLOUDRUN_AUTH_TOKEN: 'tok',
+        TOKENS_CLOUDRUN_ASSETS_URL: 'https://assets.example.run.app',
+        TOKENS_CLOUDRUN_PRICES_URL: 'https://prices.example.run.app',
+        TOKENS_CLOUDRUN_USAGE_URL: 'https://usage.example.run.app',
+    };
+
+    it('is null when any required var is missing', () => {
+        withEnv({ ...CLOUDRUN_VARS, TOKENS_CLOUDRUN_USAGE_URL: undefined }, () => {
+            expect(loadEnv().cloudRun).toBeNull();
+        });
+    });
+
+    it('resolves the full section including optional admin URL and timeout', () => {
+        withEnv(
+            { ...CLOUDRUN_VARS, TOKENS_CLOUDRUN_ADMIN_URL: 'https://admin.example.run.app', TOKENS_CLOUDRUN_TIMEOUT_MS: '20000' },
+            () => {
+                const cloudRun = loadEnv().cloudRun;
+                expect(cloudRun).not.toBeNull();
+                expect(cloudRun!.authToken).toBe('tok');
+                expect(cloudRun!.urls.admin).toBe('https://admin.example.run.app');
+                expect(cloudRun!.timeoutMs).toBe(20000);
             },
         );
     });

--- a/apps/api/src/lib/env.ts
+++ b/apps/api/src/lib/env.ts
@@ -9,6 +9,12 @@
 export interface ApiEnv {
     /** Upstash Redis REST credentials — both set, or null (rate limiting disabled / fail-open). */
     upstash: { url: string; token: string } | null;
+    /** Cloud Run backend — all required vars set, or null (asserted at boot). */
+    cloudRun: {
+        authToken: string;
+        urls: { assets: string; prices: string; usage: string; admin?: string };
+        timeoutMs?: number;
+    } | null;
     // Optional integrations — absence disables the corresponding feature.
     birdeyeApiKey: string | null;
     coingeckoApiKey: string | null;
@@ -42,8 +48,17 @@ function readNumber(name: string, fallback: number, min: number, max: number): n
     const raw = readTrimmed(name);
     if (raw === null) return fallback;
     const value = Number(raw);
-    if (!Number.isFinite(value)) return fallback;
-    return Math.min(max, Math.max(min, value));
+    if (!Number.isFinite(value)) {
+        // A typo'd value silently becoming the fallback is how misconfiguration
+        // hides for months — say so once, loudly, then proceed with the fallback.
+        console.warn(JSON.stringify({ event: 'env_invalid_value', name, raw, used: fallback }));
+        return fallback;
+    }
+    const clamped = Math.min(max, Math.max(min, value));
+    if (clamped !== value) {
+        console.warn(JSON.stringify({ event: 'env_invalid_value', name, raw, used: clamped }));
+    }
+    return clamped;
 }
 
 function getDefaultUsageLogMode(): ApiEnv['usageLogMode'] {
@@ -61,6 +76,24 @@ function readUsageLogMode(): ApiEnv['usageLogMode'] {
     const raw = (readTrimmed('TOKENS_USAGE_LOG_MODE') ?? getDefaultUsageLogMode()).toLowerCase();
     if (raw === 'raw' || raw === 'off' || raw === 'aggregated') return raw;
     return getDefaultUsageLogMode();
+}
+
+function readCloudRunEnv(): ApiEnv['cloudRun'] {
+    const authToken = readTrimmed('TOKENS_CLOUDRUN_AUTH_TOKEN');
+    const assets = readTrimmed('TOKENS_CLOUDRUN_ASSETS_URL');
+    const prices = readTrimmed('TOKENS_CLOUDRUN_PRICES_URL');
+    const usage = readTrimmed('TOKENS_CLOUDRUN_USAGE_URL');
+    if (!authToken || !assets || !prices || !usage) return null;
+
+    const admin = readTrimmed('TOKENS_CLOUDRUN_ADMIN_URL');
+    const timeoutRaw = readTrimmed('TOKENS_CLOUDRUN_TIMEOUT_MS');
+    const timeout = timeoutRaw !== null ? Number(timeoutRaw) : Number.NaN;
+
+    return {
+        authToken,
+        urls: { assets, prices, usage, ...(admin ? { admin } : {}) },
+        ...(Number.isFinite(timeout) && timeout > 0 ? { timeoutMs: timeout } : {}),
+    };
 }
 
 let cached: ApiEnv | null = null;
@@ -82,6 +115,7 @@ export function loadEnv(): ApiEnv {
 
     cached = {
         upstash: upstashUrl && upstashToken ? { url: upstashUrl, token: upstashToken } : null,
+        cloudRun: readCloudRunEnv(),
         birdeyeApiKey: readTrimmed('BIRDEYE_API_KEY'),
         coingeckoApiKey: readTrimmed('COINGECKO_API_KEY'),
         openaiApiKey: readTrimmed('OPENAI_API_KEY'),
@@ -115,6 +149,7 @@ export function resetEnvForTests(): void {
 
 /** Boot-only assertion that Cloud Run env is complete. */
 export function assertCloudRunEnvOrThrow(): void {
+    if (loadEnv().cloudRun !== null) return;
     const missing = (
         [
             'TOKENS_CLOUDRUN_AUTH_TOKEN',
@@ -123,9 +158,7 @@ export function assertCloudRunEnvOrThrow(): void {
             'TOKENS_CLOUDRUN_USAGE_URL',
         ] as const
     ).filter(name => readTrimmed(name) === null);
-    if (missing.length > 0) {
-        throw new Error(
-            `[env] required Cloud Run vars missing: ${missing.join(', ')}. TOKENS_CLOUDRUN_ADMIN_URL is optional (admin service stays IAM-locked).`,
-        );
-    }
+    throw new Error(
+        `[env] required Cloud Run vars missing: ${missing.join(', ')}. TOKENS_CLOUDRUN_ADMIN_URL is optional (admin service stays IAM-locked).`,
+    );
 }

--- a/apps/api/src/lib/http-metrics.ts
+++ b/apps/api/src/lib/http-metrics.ts
@@ -1,3 +1,4 @@
+import { emitEvent } from '@tokens/effect';
 const SLOW_REQUEST_THRESHOLD_MS = 1_000;
 
 export function shouldSkipHttpMetrics(pathname: string): boolean {
@@ -70,7 +71,7 @@ export function normalizeEndpointPath(pathname: string): string {
 }
 
 function log(entry: Record<string, unknown>) {
-    console.log(JSON.stringify(entry));
+    emitEvent(entry);
 }
 
 export function logHttpRequest(params: {

--- a/apps/api/src/lib/redis/index.ts
+++ b/apps/api/src/lib/redis/index.ts
@@ -1,3 +1,4 @@
+import { Data } from 'effect';
 import { Redis as UpstashRedis } from '@upstash/redis';
 
 import {
@@ -21,6 +22,13 @@ export {
     type RedisSetOptions,
     type RedisTarget,
 } from './client';
+/** A Redis command failed (network, script, or server error). */
+export class RedisCommandError extends Data.TaggedError('RedisCommandError')<{
+    message: string;
+    command: string;
+    cause?: string;
+}> {}
+
 export { MemorystoreClient } from './memorystore';
 export { UpstashRedisClientAdapter } from './upstash-adapter';
 

--- a/apps/api/src/lib/webacy.ts
+++ b/apps/api/src/lib/webacy.ts
@@ -1,3 +1,4 @@
+import { loadEnv } from './env';
 import { Effect } from 'effect';
 
 import { fetchJsonWithRetry } from '@tokens/effect';
@@ -180,7 +181,7 @@ export async function getWebacyToken(
     tokenAddress: string,
     chain: string = 'sol',
 ): Promise<WebacyApiResult<WebacyTokenResponse>> {
-    const apiKey = process.env.DD_API_KEY;
+    const apiKey = loadEnv().ddApiKey;
 
     if (!apiKey) {
         return {
@@ -261,7 +262,7 @@ export async function getWebacyHolderAnalysis(
     tokenAddress: string,
     chain: string = 'sol',
 ): Promise<WebacyApiResult<WebacyHolderAnalysisResponse>> {
-    const apiKey = process.env.DD_API_KEY;
+    const apiKey = loadEnv().ddApiKey;
 
     if (!apiKey) {
         return {
@@ -312,7 +313,7 @@ export async function getWebacyTradingLite(
     tokenAddress: string,
     chain: string = 'sol',
 ): Promise<WebacyApiResult<WebacyTradingLiteResponse>> {
-    const apiKey = process.env.DD_API_KEY;
+    const apiKey = loadEnv().ddApiKey;
 
     if (!apiKey) {
         return {

--- a/apps/api/src/lib/x-auth.ts
+++ b/apps/api/src/lib/x-auth.ts
@@ -1,0 +1,83 @@
+import { Effect } from 'effect';
+import { UpstreamHttpError, fetchJson } from '@tokens/effect';
+import { makeOAuth2TokenCache } from '@/effect/oauth-token-cache';
+
+/**
+ * Shared X (Twitter) API auth: OAuth2 client-credentials exchange with a
+ * TTL'd token cache. Previously duplicated (with a forever-cache) in the
+ * news/feed and x/tokens-feed routes.
+ */
+
+interface XOAuthTokenResponse {
+    token_type?: string;
+    access_token?: string;
+}
+
+const fetchXBearerToken: Effect.Effect<string, unknown> = Effect.suspend(() => {
+    const apiKey = process.env.X_API_KEY?.trim();
+    const apiSecret = process.env.X_API_SECRET?.trim();
+    if (!apiKey || !apiSecret) {
+        return Effect.fail(new Error('X_API_KEY / X_API_SECRET are not set'));
+    }
+
+    const credentials = `${encodeURIComponent(apiKey)}:${encodeURIComponent(apiSecret)}`;
+    const authorization = Buffer.from(credentials).toString('base64');
+
+    return fetchJson<XOAuthTokenResponse>({
+        url: 'https://api.x.com/oauth2/token',
+        service: 'x-oauth',
+        init: {
+            method: 'POST',
+            headers: {
+                Authorization: `Basic ${authorization}`,
+                'Content-Type': 'application/x-www-form-urlencoded;charset=UTF-8',
+            },
+            body: 'grant_type=client_credentials',
+        },
+    }).pipe(
+        Effect.flatMap(data => {
+            if (data.token_type?.toLowerCase() !== 'bearer' || !data.access_token) {
+                return Effect.fail(new Error('X bearer token response was invalid'));
+            }
+            return Effect.succeed(data.access_token);
+        }),
+    );
+});
+
+const tokenCache = makeOAuth2TokenCache(fetchXBearerToken);
+
+/**
+ * Resolve a bearer token for the X API: a static X_BEARER_TOKEN env wins;
+ * otherwise the cached client-credentials token. `null` means X integration
+ * is not configured (feature disabled), matching the historical contract.
+ */
+export function resolveXBearerToken(): Effect.Effect<string | null, unknown> {
+    return Effect.suspend(() => {
+        const existingBearerToken = process.env.X_BEARER_TOKEN?.trim();
+        if (existingBearerToken) return Effect.succeed(existingBearerToken);
+
+        const apiKey = process.env.X_API_KEY?.trim();
+        const apiSecret = process.env.X_API_SECRET?.trim();
+        if (!apiKey || !apiSecret) return Effect.succeed<string | null>(null);
+
+        return tokenCache.get;
+    });
+}
+
+function isAuthFailure(error: unknown): boolean {
+    return error instanceof UpstreamHttpError && (error.status === 401 || error.status === 403);
+}
+
+/**
+ * Run an X API request; on an auth failure (401/403) the cached token is
+ * invalidated so the next call re-fetches. (Tightened from the historical
+ * behavior of invalidating on ANY error.)
+ */
+export function runXRequest<T>(request: Effect.Effect<T, unknown>): Effect.Effect<T, unknown> {
+    return request.pipe(
+        Effect.tapError(error => (isAuthFailure(error) ? tokenCache.invalidate : Effect.void)),
+    );
+}
+
+/** Test seam. */
+export const __xAuthInternals = { tokenCache };

--- a/apps/api/src/types/bun-test.d.ts
+++ b/apps/api/src/types/bun-test.d.ts
@@ -4,6 +4,9 @@ declare module 'bun:test' {
     export const test: typeof it;
     export function beforeEach(fn: () => void | Promise<void>): void;
     export function afterEach(fn: () => void | Promise<void>): void;
+    export const mock: {
+        module(specifier: string, factory: () => unknown): void;
+    };
     export function expect<T>(value: T): {
         toBe(expected: unknown): void;
         toBeCloseTo(expected: number, numDigits?: number): void;

--- a/apps/cloudrun-admin/src/handlers/errors.ts
+++ b/apps/cloudrun-admin/src/handlers/errors.ts
@@ -1,25 +1,5 @@
-/** Shared handler error types, mapped to HTTP statuses by the server dispatcher. */
-
-/** Malformed/invalid arguments (or Convex-parity handler errors) → 400 `invalid_args`. */
-export class InvalidArgsError extends Error {
-    constructor(message: string) {
-        super(message);
-        this.name = 'InvalidArgsError';
-    }
-}
-
-/** Handler requires a caller identity (`x-tokens-identity`) and none was sent → 401 `identity_required`. */
-export class IdentityRequiredError extends Error {
-    constructor(message = 'caller identity required') {
-        super(message);
-        this.name = 'IdentityRequiredError';
-    }
-}
-
-/** Caller identity failed an authorization check (admin allowlist) → 403 `unauthorized`. */
-export class UnauthorizedError extends Error {
-    constructor(message = 'Unauthorized') {
-        super(message);
-        this.name = 'UnauthorizedError';
-    }
-}
+/**
+ * Shared handler error types live in @tokens/cloudrun-shutdown/http-errors;
+ * re-exported here so existing imports keep working.
+ */
+export { IdentityRequiredError, InvalidArgsError, UnauthorizedError } from '@tokens/cloudrun-shutdown/http-errors';

--- a/apps/cloudrun-admin/src/server.ts
+++ b/apps/cloudrun-admin/src/server.ts
@@ -10,6 +10,7 @@ import type { AdminMutationsRepo } from './handlers/curatedTokensMutations';
 import * as reads from './handlers/curatedTokensReads';
 import type { AdminReadsRepo } from './handlers/curatedTokensReads';
 import { IdentityRequiredError, InvalidArgsError, UnauthorizedError } from './handlers/errors';
+import { dispatchErrorResponse } from '@tokens/cloudrun-shutdown/http-errors';
 import * as hardDeleteHandlers from './handlers/hardDelete';
 import type { HardDeleteRepo } from './handlers/hardDelete';
 import * as logoUploadsHandlers from './handlers/logoUploads';
@@ -57,19 +58,6 @@ export function decodeIdentityHeader(raw: string | undefined): CallerIdentity | 
     }
 }
 
-function errorResponse(err: unknown, kind: string, name: string) {
-    if (err instanceof InvalidArgsError) {
-        return { body: { error: 'invalid_args', message: err.message }, status: 400 as const };
-    }
-    if (err instanceof IdentityRequiredError) {
-        return { body: { error: 'identity_required' }, status: 401 as const };
-    }
-    if (err instanceof UnauthorizedError) {
-        return { body: { error: 'unauthorized' }, status: 403 as const };
-    }
-    console.error(`[cloudrun-admin] ${kind} ${name} threw`, err);
-    return { body: { error: 'handler_error' }, status: 500 as const };
-}
 
 export function createApp(deps: ServerDeps) {
     const app = new Hono();
@@ -151,7 +139,7 @@ export function createApp(deps: ServerDeps) {
         try {
             return c.json(await handler(args, identity));
         } catch (err) {
-            const { body: errBody, status } = errorResponse(err, kind, name);
+            const { body: errBody, status } = dispatchErrorResponse('cloudrun-admin', err, kind, name);
             return c.json(errBody, status);
         }
     };

--- a/apps/cloudrun-assets/src/clients.ts
+++ b/apps/cloudrun-assets/src/clients.ts
@@ -1,3 +1,6 @@
+import { Effect, Schema } from 'effect';
+import { fetchJsonWithRetry } from '@tokens/effect';
+import { decodeUpstreamOrWarn } from '@tokens/effect/schema';
 import { withExternalTiming } from './externalTiming';
 import type {
     BirdeyeClient,
@@ -29,6 +32,19 @@ import type {
 import type { BirdeyeMarketsClient, TokenMarketEntry } from './handlers/crons.misc';
 import type { PreStocksApiSnapshot, PreStocksClient } from './handlers/crons.prestocks';
 
+// Shadow-mode envelope schemas (warn on mismatch, pass through) — the two
+// highest-traffic blind casts. Row shapes stay unknown/T on purpose.
+const BirdeyeEnvelopeSchema = Schema.Struct({
+    success: Schema.optionalKey(Schema.Unknown),
+    data: Schema.optionalKey(Schema.NullishOr(Schema.Record(Schema.String, Schema.Unknown))),
+});
+
+const EXTERNAL_FETCH_TIMEOUT_MS = 30_000;
+
+const GatewayEnvelopeSchema = Schema.Struct({
+    data: Schema.optionalKey(Schema.NullishOr(Schema.Array(Schema.Unknown))),
+});
+
 interface MakeBirdeyeOptions {
     apiKey: string;
     origin?: string;
@@ -49,11 +65,21 @@ export function makeBirdeyeClient(opts: MakeBirdeyeOptions): BirdeyeClient {
     return {
         async fetchTokenOverview(mint: string): Promise<BirdeyeOverview | null> {
             const url = `${baseUrl}/defi/token_overview?address=${encodeURIComponent(mint)}`;
-            const res = await withExternalTiming('birdeye', url, () => fetch(url, { headers }));
-            const json = (await res.json().catch(() => null)) as
-                | { success?: unknown; data?: BirdeyeOverview }
-                | null;
-            if (!res.ok || !json || json.success !== true || !json.data) return null;
+            const json = await Effect.runPromise(
+                fetchJsonWithRetry<{ success?: unknown; data?: BirdeyeOverview } | null>({
+                    url,
+                    service: 'birdeye',
+                    init: { headers },
+                    maxRetries: 2,
+                    timeout: '15 seconds',
+                    schema: BirdeyeEnvelopeSchema,
+                }).pipe(
+                    // Non-2xx keeps the historical null-degrade contract; network
+                    // failures / timeouts still throw (tagged) after retries.
+                    Effect.catchTag('UpstreamHttpError', () => Effect.succeed(null)),
+                ),
+            );
+            if (!json || json.success !== true || !json.data) return null;
             return json.data;
         },
     };
@@ -116,11 +142,16 @@ export function makeBirdeyeOhlcvClient(opts: MakeBirdeyeOhlcvOptions): BirdeyeOh
                 time_to: String(args.to),
             });
             const url = `${baseUrl}/defi/v3/ohlcv?${params.toString()}`;
-            const res = await withExternalTiming('birdeye', url, () => fetch(url, { headers }));
-            const json = (await res.json().catch(() => null)) as
-                | { success?: unknown; data?: { items?: unknown[] } }
-                | null;
-            if (!res.ok || !json || json.success !== true || !json.data || !Array.isArray(json.data.items)) {
+            const json = await Effect.runPromise(
+                fetchJsonWithRetry<{ success?: unknown; data?: { items?: unknown[] } } | null>({
+                    url,
+                    service: 'birdeye',
+                    init: { headers },
+                    maxRetries: 2,
+                    timeout: '30 seconds',
+                }).pipe(Effect.catchTag('UpstreamHttpError', () => Effect.succeed(null))),
+            );
+            if (!json || json.success !== true || !json.data || !Array.isArray(json.data.items)) {
                 return [];
             }
             const out: OhlcvCandle[] = [];
@@ -151,11 +182,14 @@ export function makeSanctumClient(opts: MakeSanctumOptions): SanctumClient {
             };
             let res: Response;
             try {
-                res = await withExternalTiming('sanctum', url.toString(), () => fetch(url, { headers: primaryHeaders }));
+                res = await withExternalTiming('sanctum', url.toString(), () =>
+                    fetch(url, { headers: primaryHeaders, signal: AbortSignal.timeout(EXTERNAL_FETCH_TIMEOUT_MS) }),
+                );
                 if (!res.ok && (res.status === 400 || res.status === 401 || res.status === 403)) {
                     res = await withExternalTiming('sanctum', url.toString(), () =>
                         fetch(url, {
                             headers: { Accept: 'application/json', Authorization: `Bearer ${apiKey}` },
+                            signal: AbortSignal.timeout(EXTERNAL_FETCH_TIMEOUT_MS),
                         }),
                     );
                 }
@@ -163,7 +197,10 @@ export function makeSanctumClient(opts: MakeSanctumOptions): SanctumClient {
                     const fallback = new URL(url.toString());
                     fallback.searchParams.set('apiKey', apiKey);
                     res = await withExternalTiming('sanctum', fallback.toString(), () =>
-                        fetch(fallback, { headers: { Accept: 'application/json' } }),
+                        fetch(fallback, {
+                            headers: { Accept: 'application/json' },
+                            signal: AbortSignal.timeout(EXTERNAL_FETCH_TIMEOUT_MS),
+                        }),
                     );
                 }
             } catch (err) {
@@ -197,7 +234,10 @@ export function makeWebacyClient(opts: MakeWebacyOptions): WebacyClient {
         if (!apiKey) return { ok: false, status: 0, message: 'WEBACY_API_KEY not configured' };
         try {
             const res = await withExternalTiming('webacy', url, () =>
-                fetch(url, { headers: { 'x-api-key': apiKey, Accept: 'application/json' } }),
+                fetch(url, {
+                    headers: { 'x-api-key': apiKey, Accept: 'application/json' },
+                    signal: AbortSignal.timeout(EXTERNAL_FETCH_TIMEOUT_MS),
+                }),
             );
             const json = await res.json().catch(() => null);
             if (!res.ok || !json) {
@@ -301,13 +341,18 @@ export function makeCoingeckoClient(opts: MakeCoingeckoOptions): CoingeckoClient
     if (apiKey) headers['x-cg-pro-api-key'] = apiKey;
 
     async function fetchJson(url: URL | string): Promise<unknown> {
-        const res = await withExternalTiming('coingecko', url.toString(), () => fetch(url, { headers }));
-        const json: unknown = await res.json().catch(() => null);
-        if (!res.ok) {
-            const body = json ? JSON.stringify(json) : '(no json body)';
-            throw new Error(`CoinGecko ${url.toString()} failed: HTTP ${res.status} ${res.statusText} ${body}`.trim());
-        }
-        return json;
+        // Tagged failures (UpstreamHttpError / RateLimitedError / FetchFailedError)
+        // propagate to per-item catches; adds 429/5xx retry + a timeout, which
+        // these calls previously lacked entirely.
+        return Effect.runPromise(
+            fetchJsonWithRetry<unknown>({
+                url: url.toString(),
+                service: 'coingecko',
+                init: { headers },
+                maxRetries: 2,
+                timeout: '30 seconds',
+            }),
+        );
     }
 
     return {
@@ -524,8 +569,11 @@ export function makeClickhouseClient(opts: MakeClickhouseOptions): ClickhouseCli
             const text = await res.text().catch(() => '');
             throw new ClickhouseApiError(`clickhouse-api HTTP ${res.status}: ${text.slice(0, 500)}`, res.status);
         }
-        const payload = (await res.json()) as { data?: T[] };
-        return payload.data ?? [];
+        const payload: unknown = await res.json();
+        const decoded = await Effect.runPromise(
+            decodeUpstreamOrWarn(GatewayEnvelopeSchema, 'clickhouse-api')(payload),
+        );
+        return ((decoded as { data?: T[] }).data ?? []) as T[];
     }
 
     return {
@@ -961,13 +1009,15 @@ export function makeRwaXyzClient(opts: MakeRwaXyzOptions): RwaXyzClient {
 
     async function fetchJson(path: string): Promise<unknown> {
         const url = `${baseUrl}/${apiVersion}${path}`;
-        const res = await withExternalTiming('rwaxyz', url, () => fetch(url, { headers }));
-        const json = await res.json().catch(() => null);
-        if (!res.ok || !json) {
-            const body = json ? JSON.stringify(json) : '(no json body)';
-            throw new Error(`RWA.xyz request failed: HTTP ${res.status} ${res.statusText} ${body}`);
-        }
-        return json;
+        return Effect.runPromise(
+            fetchJsonWithRetry<unknown>({
+                url,
+                service: 'rwaxyz',
+                init: { headers },
+                maxRetries: 2,
+                timeout: '30 seconds',
+            }),
+        );
     }
 
     async function fetchTokenByMint(mint: string): Promise<RwaXyzTokenRaw | null> {

--- a/apps/cloudrun-assets/src/handlers/adminActions.ts
+++ b/apps/cloudrun-assets/src/handlers/adminActions.ts
@@ -859,7 +859,7 @@ async function runBestEffort(label: string, fn: () => Promise<void>): Promise<vo
     try {
         await fn();
     } catch (err) {
-        console.error(`[adminActions] ${label} failed`, err instanceof Error ? err.message : String(err));
+        console.error(`[adminActions] ${label} failed`, err);
     }
 }
 

--- a/apps/cloudrun-assets/src/handlers/assets.ts
+++ b/apps/cloudrun-assets/src/handlers/assets.ts
@@ -132,12 +132,8 @@ export function rowToResult(row: AssetRow): AssetResult {
     return result;
 }
 
-export class InvalidArgsError extends Error {
-    constructor(message: string) {
-        super(message);
-        this.name = 'InvalidArgsError';
-    }
-}
+export { InvalidArgsError } from '@tokens/cloudrun-shutdown/http-errors';
+import { InvalidArgsError } from '@tokens/cloudrun-shutdown/http-errors';
 
 function isAssetCategory(value: unknown): value is AssetCategory {
     return typeof value === 'string' && (ASSET_CATEGORIES as readonly string[]).includes(value);

--- a/apps/cloudrun-assets/src/handlers/cacheWarm.ts
+++ b/apps/cloudrun-assets/src/handlers/cacheWarm.ts
@@ -191,7 +191,7 @@ async function runRefresh(label: string, fn: () => Promise<CronResult>): Promise
     try {
         await fn();
     } catch (err) {
-        console.error(`[cacheWarm] ${label} refresh failed`, err instanceof Error ? err.message : String(err));
+        console.error(`[cacheWarm] ${label} refresh failed`, err);
     }
 }
 

--- a/apps/cloudrun-assets/src/handlers/crons.misc.ts
+++ b/apps/cloudrun-assets/src/handlers/crons.misc.ts
@@ -1,3 +1,6 @@
+import { Effect } from 'effect';
+import { isShuttingDown } from '@tokens/cloudrun-shutdown';
+import { runJobPool } from '@tokens/effect/job-runner';
 import type { CronDeps, CronResult } from './crons';
 import { InvalidArgsError, parseExplicitTargets } from './crons';
 
@@ -70,11 +73,6 @@ export interface MiscCronDeps {
 }
 
 export type MiscJobHandler = (deps: MiscCronDeps, args: unknown) => Promise<CronResult>;
-
-function sleep(ms: number): Promise<void> {
-    if (ms <= 0) return Promise.resolve();
-    return new Promise(resolve => setTimeout(resolve, ms));
-}
 
 function asObject(raw: unknown): Record<string, unknown> {
     if (raw === undefined || raw === null) return {};
@@ -164,62 +162,57 @@ export async function refreshStaleTokens(deps: MiscCronDeps, rawArgs: unknown): 
     const minAgeMs = clampInt(args.minAgeMs, 60_000, 10_000, 24 * 60 * 60_000);
     const concurrency = clampInt(args.concurrency, 2, 1, 5);
     const delayMs = clampInt(args.delayMs, 200, 0, 5_000);
+    const budgetMs = clampInt(args.budgetMs, 0, 0, 3_600_000);
 
     const start = deps.base.now();
     const beforeLastFetchedAt = start - minAgeMs;
     const addresses = await deps.repo.listStaleTokenAddresses(beforeLastFetchedAt, maxTokens);
 
     let refreshed = 0;
-    let failed = 0;
+    let softFailed = 0;
 
     if (addresses.length === 0) {
-        return { ok: true, processed: 0, durationMs: deps.base.now() - start, refreshed, failed };
+        return { ok: true, processed: 0, durationMs: deps.base.now() - start, refreshed, failed: 0 };
     }
 
-    let nextIndex = 0;
-    async function worker(): Promise<void> {
-        while (true) {
-            const idx = nextIndex;
-            if (idx >= addresses.length) return;
-            nextIndex += 1;
-            const address = addresses[idx]!;
-            try {
-                const overview = await deps.base.birdeye.fetchTokenOverview(address);
-                if (!overview) {
-                    failed += 1;
-                    continue;
-                }
-                const upsert = birdeyeOverviewToTokenUpsert(
-                    address,
-                    overview as unknown as Record<string, unknown>,
-                    start,
-                );
-                if (!upsert) {
-                    failed += 1;
-                    continue;
-                }
-                await deps.repo.upsertTokenFromBirdeye(upsert);
-                refreshed += 1;
-            } catch (err) {
-                failed += 1;
-                console.error(
-                    `[refreshStaleTokens] address=${address}`,
-                    err instanceof Error ? err.message : String(err),
-                );
-            } finally {
-                await sleep(delayMs);
-            }
-        }
-    }
+    const summary = await Effect.runPromise(
+        runJobPool({
+            label: 'refreshStaleTokens',
+            items: addresses,
+            concurrency,
+            delayMs,
+            ...(budgetMs > 0 ? { budgetMs } : {}),
+            shouldStop: isShuttingDown,
+            process: address =>
+                Effect.tryPromise(async () => {
+                    const overview = await deps.base.birdeye.fetchTokenOverview(address);
+                    if (!overview) {
+                        softFailed += 1;
+                        return;
+                    }
+                    const upsert = birdeyeOverviewToTokenUpsert(
+                        address,
+                        overview as unknown as Record<string, unknown>,
+                        start,
+                    );
+                    if (!upsert) {
+                        softFailed += 1;
+                        return;
+                    }
+                    await deps.repo.upsertTokenFromBirdeye(upsert);
+                    refreshed += 1;
+                }),
+        }),
+    );
 
-    await Promise.all(Array.from({ length: Math.min(concurrency, addresses.length) }, () => worker()));
-
+    const failed = softFailed + summary.failed;
     return {
-        ok: true,
+        ok: !(summary.attempted > 0 && refreshed === 0 && failed >= summary.attempted),
         processed: addresses.length,
         durationMs: deps.base.now() - start,
         refreshed,
         failed,
+        ...(summary.partial ? { partial: true } : {}),
     };
 }
 
@@ -232,6 +225,7 @@ export async function refreshCuratedTokenMarkets(deps: MiscCronDeps, rawArgs: un
     const delayMs = clampInt(args.delayMs, 200, 0, 5_000);
     const maxMarketsPerMint = clampInt(args.maxMarketsPerMint, 20, 1, 20);
     const selectionWindowMs = clampInt(args.selectionWindowMs, 60_000, 10_000, 24 * 60 * 60_000);
+    const budgetMs = clampInt(args.budgetMs, 0, 0, 3_600_000);
 
     const explicitMints = parseExplicitTargets(args.mints, 'mints');
 
@@ -248,57 +242,46 @@ export async function refreshCuratedTokenMarkets(deps: MiscCronDeps, rawArgs: un
 
     let refreshed = 0;
     let skipped = 0;
-    let failed = 0;
 
     if (mints.length === 0) {
-        return { ok: true, processed: 0, durationMs: deps.base.now() - start, refreshed, skipped, failed };
+        return { ok: true, processed: 0, durationMs: deps.base.now() - start, refreshed, skipped, failed: 0 };
     }
 
-    let nextIndex = 0;
-    async function worker(): Promise<void> {
-        while (true) {
-            const idx = nextIndex;
-            if (idx >= mints.length) return;
-            nextIndex += 1;
-            const mint = mints[idx]!;
-            try {
-                const last = await deps.repo.getTokenMarketsLastFetchedAtByMint(mint);
-                if (last !== null && start - last < minAgeMs) {
-                    skipped += 1;
-                    continue;
-                }
-                const markets = await deps.birdeyeMarkets.fetchTokenMarkets({
-                    address: mint,
-                    limit: maxMarketsPerMint,
-                });
-                await deps.repo.upsertTokenMarketsLatest({ mint, markets, lastFetchedAt: start });
-                refreshed += 1;
-            } catch (err) {
-                failed += 1;
-                console.error(
-                    `[refreshCuratedTokenMarkets] mint=${mint}`,
-                    err instanceof Error ? err.message : String(err),
-                );
-                try {
-                    await deps.repo.touchTokenMarketsLatest(mint, start);
-                } catch {
-                    void 0;
-                }
-            } finally {
-                await sleep(delayMs);
-            }
-        }
-    }
-
-    await Promise.all(Array.from({ length: Math.min(concurrency, mints.length) }, () => worker()));
+    const summary = await Effect.runPromise(
+        runJobPool({
+            label: 'refreshCuratedTokenMarkets',
+            items: mints,
+            concurrency,
+            delayMs,
+            ...(budgetMs > 0 ? { budgetMs } : {}),
+            shouldStop: isShuttingDown,
+            process: mint =>
+                Effect.tryPromise(async () => {
+                    const last = await deps.repo.getTokenMarketsLastFetchedAtByMint(mint);
+                    if (last !== null && start - last < minAgeMs) {
+                        skipped += 1;
+                        return;
+                    }
+                    const markets = await deps.birdeyeMarkets.fetchTokenMarkets({
+                        address: mint,
+                        limit: maxMarketsPerMint,
+                    });
+                    await deps.repo.upsertTokenMarketsLatest({ mint, markets, lastFetchedAt: start });
+                    refreshed += 1;
+                }),
+            onItemError: mint =>
+                Effect.tryPromise(() => deps.repo.touchTokenMarketsLatest(mint, start)),
+        }),
+    );
 
     return {
-        ok: true,
+        ok: !(summary.attempted > 0 && refreshed === 0 && skipped === 0 && summary.failed >= summary.attempted),
         processed: mints.length,
         durationMs: deps.base.now() - start,
         refreshed,
         skipped,
-        failed,
+        failed: summary.failed,
+        ...(summary.partial ? { partial: true } : {}),
     };
 }
 

--- a/apps/cloudrun-assets/src/handlers/crons.prestocks.ts
+++ b/apps/cloudrun-assets/src/handlers/crons.prestocks.ts
@@ -112,7 +112,7 @@ export async function refreshPrestocksPrices(
     }
 
     return {
-        ok: true,
+        ok: !(listings.length > 0 && succeeded === 0 && failed >= listings.length),
         processed: succeeded + failed,
         durationMs: deps.now() - start,
         requested: listings.length,

--- a/apps/cloudrun-assets/src/handlers/crons.seed.ts
+++ b/apps/cloudrun-assets/src/handlers/crons.seed.ts
@@ -1,3 +1,6 @@
+import { Effect } from 'effect';
+import { isShuttingDown } from '@tokens/cloudrun-shutdown';
+import { runJobPool } from '@tokens/effect/job-runner';
 import type { CanonicalAsset, TrustTier } from '@tokens/asset-registry';
 import { listAssets } from '@tokens/asset-registry';
 import {
@@ -398,11 +401,6 @@ export function deriveFallbackName(asset: CanonicalAsset, symbol: string | null)
     return symbol;
 }
 
-function sleep(ms: number): Promise<void> {
-    if (ms <= 0) return Promise.resolve();
-    return new Promise(resolve => setTimeout(resolve, ms));
-}
-
 function chunkArray<T>(items: readonly T[], size: number): T[][] {
     const out: T[][] = [];
     for (let i = 0; i < items.length; i += size) {
@@ -491,29 +489,29 @@ export async function backfillMissingAssetIdentity(
 
     let updated = 0;
     let skipped = 0;
-    let failed = 0;
     const errors: Array<{ assetId: string; message: string }> = [];
 
-    let nextIndex = 0;
-    async function worker(): Promise<void> {
-        while (true) {
-            const idx = nextIndex;
-            if (idx >= requestedAssetIds.length) return;
-            nextIndex += 1;
-            const assetId = requestedAssetIds[idx]!;
-            try {
+    const summary = await Effect.runPromise(
+        runJobPool({
+            label: 'backfillMissingAssetIdentity',
+            items: requestedAssetIds,
+            concurrency,
+            delayMs,
+            shouldStop: isShuttingDown,
+            process: assetId =>
+                Effect.tryPromise(async () => {
                 const asset = assetById.get(assetId);
                 const registryAsset = registryById.get(assetId);
                 const mint = preferredMintByAssetId.get(assetId);
                 if (!asset || !registryAsset || !mint) {
                     skipped += 1;
-                    continue;
+                    return;
                 }
                 const hasSymbol = typeof asset.symbol === 'string' && asset.symbol.trim().length > 0;
                 const hasName = typeof asset.name === 'string' && asset.name.trim().length > 0;
                 if (!force && hasSymbol && hasName) {
                     skipped += 1;
-                    continue;
+                    return;
                 }
                 const marketIdentity = marketIdentityByMint.get(mint);
                 const marketSymbol = marketIdentity?.symbol ?? null;
@@ -526,7 +524,7 @@ export async function backfillMissingAssetIdentity(
                         force,
                     });
                     updated += 1;
-                    continue;
+                    return;
                 }
                 if (deps.birdeyeIdentity) {
                     const birdeye = await deps.birdeyeIdentity.fetchIdentityByMint(mint);
@@ -538,7 +536,7 @@ export async function backfillMissingAssetIdentity(
                             force,
                         });
                         updated += 1;
-                        continue;
+                        return;
                     }
                 }
                 const fallbackSymbol = deriveFallbackSymbol(registryAsset);
@@ -551,34 +549,30 @@ export async function backfillMissingAssetIdentity(
                         force,
                     });
                     updated += 1;
-                    continue;
+                    return;
                 }
                 skipped += 1;
-            } catch (error) {
-                failed += 1;
-                errors.push({
-                    assetId,
-                    message: error instanceof Error ? error.message : String(error),
-                });
-            } finally {
-                if (delayMs > 0) await sleep(delayMs);
-            }
-        }
-    }
-
-    await Promise.all(
-        Array.from({ length: Math.min(concurrency, requestedAssetIds.length) }, () => worker()),
+                }),
+            onItemError: (assetId, error) =>
+                Effect.sync(() => {
+                    errors.push({
+                        assetId,
+                        message: error instanceof Error ? error.message : String(error),
+                    });
+                }),
+        }),
     );
 
     return {
-        ok: true,
+        ok: !(summary.attempted > 0 && updated === 0 && skipped === 0 && summary.failed >= summary.attempted),
         processed: requestedAssetIds.length,
         durationMs: deps.now() - start,
         requested: requestedAssetIds.length,
         updated,
         skipped,
-        failed,
+        failed: summary.failed,
         errors: errors.slice(0, 100),
+        ...(summary.partial ? { partial: true } : {}),
     };
 }
 

--- a/apps/cloudrun-assets/src/handlers/crons.ts
+++ b/apps/cloudrun-assets/src/handlers/crons.ts
@@ -16,12 +16,8 @@ export interface CronResult {
     [extra: string]: unknown;
 }
 
-export class InvalidArgsError extends Error {
-    constructor(message: string) {
-        super(message);
-        this.name = 'InvalidArgsError';
-    }
-}
+export { InvalidArgsError } from '@tokens/cloudrun-shutdown/http-errors';
+import { InvalidArgsError } from '@tokens/cloudrun-shutdown/http-errors';
 
 export interface VariantMarketUpsertFromBirdeye {
     mint: string;

--- a/apps/cloudrun-usage/src/handlers/errors.ts
+++ b/apps/cloudrun-usage/src/handlers/errors.ts
@@ -1,25 +1,5 @@
-/** Shared handler error types, mapped to HTTP statuses by the server dispatcher. */
-
-/** Malformed/invalid arguments → 400 `invalid_args`. */
-export class InvalidArgsError extends Error {
-    constructor(message: string) {
-        super(message);
-        this.name = 'InvalidArgsError';
-    }
-}
-
-/** Handler requires a caller identity (`x-tokens-identity`) and none was sent → 401 `identity_required`. */
-export class IdentityRequiredError extends Error {
-    constructor(message = 'caller identity required') {
-        super(message);
-        this.name = 'IdentityRequiredError';
-    }
-}
-
-/** Caller identity failed an authorization check (membership/role/allowlist) → 403 `unauthorized`. */
-export class UnauthorizedError extends Error {
-    constructor(message = 'Unauthorized') {
-        super(message);
-        this.name = 'UnauthorizedError';
-    }
-}
+/**
+ * Shared handler error types live in @tokens/cloudrun-shutdown/http-errors;
+ * re-exported here so existing imports keep working.
+ */
+export { IdentityRequiredError, InvalidArgsError, UnauthorizedError } from '@tokens/cloudrun-shutdown/http-errors';

--- a/apps/cloudrun-usage/src/server.ts
+++ b/apps/cloudrun-usage/src/server.ts
@@ -5,6 +5,7 @@ import type { IdentityRepo } from './handlers/clerkIdentity';
 import * as dashboard from './handlers/dashboard';
 import type { DashboardRepo } from './handlers/dashboard';
 import { IdentityRequiredError, InvalidArgsError, UnauthorizedError } from './handlers/errors';
+import { dispatchErrorResponse } from '@tokens/cloudrun-shutdown/http-errors';
 import { authenticateApiKey, logApiRequest, type PlatformAuthRepo } from './handlers/platformAuth';
 import * as usageDashboard from './handlers/usageDashboard';
 import type { UsageDashboardRepo } from './handlers/usageDashboard';
@@ -67,19 +68,6 @@ export function decodeIdentityHeader(raw: string | undefined): CallerIdentity | 
     }
 }
 
-function errorResponse(err: unknown, kind: string, name: string) {
-    if (err instanceof InvalidArgsError) {
-        return { body: { error: 'invalid_args', message: err.message }, status: 400 as const };
-    }
-    if (err instanceof IdentityRequiredError) {
-        return { body: { error: 'identity_required' }, status: 401 as const };
-    }
-    if (err instanceof UnauthorizedError) {
-        return { body: { error: 'unauthorized' }, status: 403 as const };
-    }
-    console.error(`[cloudrun-usage] ${kind} ${name} threw`, err);
-    return { body: { error: 'handler_error' }, status: 500 as const };
-}
 
 export function createApp(deps: ServerDeps) {
     const app = new Hono();
@@ -148,7 +136,7 @@ export function createApp(deps: ServerDeps) {
         try {
             return c.json(await handler(args, identity));
         } catch (err) {
-            const { body, status } = errorResponse(err, kind, name);
+            const { body, status } = dispatchErrorResponse('cloudrun-usage', err, kind, name);
             return c.json(body, status);
         }
     };

--- a/packages/cloudrun-shutdown/package.json
+++ b/packages/cloudrun-shutdown/package.json
@@ -9,7 +9,8 @@
   "type": "module",
   "sideEffects": false,
   "exports": {
-    ".": "./src/index.ts"
+    ".": "./src/index.ts",
+    "./http-errors": "./src/http-errors.ts"
   },
   "files": [
     "src"

--- a/packages/cloudrun-shutdown/src/http-errors.ts
+++ b/packages/cloudrun-shutdown/src/http-errors.ts
@@ -1,0 +1,54 @@
+/**
+ * Shared handler error types for the cloudrun services, mapped to HTTP
+ * statuses by each service's dispatcher. Previously triplicated across
+ * cloudrun-admin, cloudrun-usage, and cloudrun-assets (twice).
+ */
+
+/** Malformed/invalid arguments → 400 `invalid_args`. */
+export class InvalidArgsError extends Error {
+    constructor(message: string) {
+        super(message);
+        this.name = 'InvalidArgsError';
+    }
+}
+
+/** Handler requires a caller identity (`x-tokens-identity`) and none was sent → 401 `identity_required`. */
+export class IdentityRequiredError extends Error {
+    constructor(message = 'caller identity required') {
+        super(message);
+        this.name = 'IdentityRequiredError';
+    }
+}
+
+/** Caller identity failed an authorization check (membership/role/allowlist) → 403 `unauthorized`. */
+export class UnauthorizedError extends Error {
+    constructor(message = 'Unauthorized') {
+        super(message);
+        this.name = 'UnauthorizedError';
+    }
+}
+
+export interface DispatchErrorResponse {
+    body: { error: string; message?: string };
+    status: 400 | 401 | 403 | 500;
+}
+
+/** Shared query/mutation dispatcher error mapping (full error logged, stack preserved). */
+export function dispatchErrorResponse(
+    serviceName: string,
+    err: unknown,
+    kind: string,
+    name: string,
+): DispatchErrorResponse {
+    if (err instanceof InvalidArgsError) {
+        return { body: { error: 'invalid_args', message: err.message }, status: 400 };
+    }
+    if (err instanceof IdentityRequiredError) {
+        return { body: { error: 'identity_required' }, status: 401 };
+    }
+    if (err instanceof UnauthorizedError) {
+        return { body: { error: 'unauthorized' }, status: 403 };
+    }
+    console.error(`[${serviceName}] ${kind} ${name} threw`, err);
+    return { body: { error: 'handler_error' }, status: 500 };
+}

--- a/packages/effect/src/api-errors.ts
+++ b/packages/effect/src/api-errors.ts
@@ -80,6 +80,13 @@ export class JsonParseError extends Data.TaggedError('JsonParseError')<{
     body?: string;
 }> {}
 
+/** An upstream response parsed as JSON but failed schema validation. */
+export class UpstreamDataError extends Data.TaggedError('UpstreamDataError')<{
+    message: string;
+    service: string;
+    issue?: string;
+}> {}
+
 // -----------------------------------------------------------------------------
 // Conversions (unknown -> standardized error shape)
 // -----------------------------------------------------------------------------
@@ -177,6 +184,7 @@ export function httpStatusForError(error: unknown): number {
             return 404;
         case 'RateLimitedError':
             return 429;
+        case 'UpstreamDataError':
         case 'MissingEnvError':
         case 'UpstreamHttpError':
         case 'FetchFailedError':

--- a/packages/effect/src/fetch.ts
+++ b/packages/effect/src/fetch.ts
@@ -1,6 +1,8 @@
-import { Duration, Effect, Schedule } from 'effect';
+import { Duration, Effect, Schedule, type Schema } from 'effect';
 import { mergeSignals } from './abort';
-import { FetchFailedError, JsonParseError, RateLimitedError, UpstreamHttpError } from './api-errors';
+import { FetchFailedError, JsonParseError, RateLimitedError, UpstreamDataError, UpstreamHttpError } from './api-errors';
+import { CurrentRequestId, emitEvent } from './observability';
+import { decodeUpstreamOrFail, decodeUpstreamOrWarn } from './schema';
 
 type NextFetchInit = RequestInit & { next?: { revalidate?: number } };
 
@@ -9,7 +11,19 @@ export interface FetchJsonArgs {
     service: string;
     init?: NextFetchInit;
     signal?: AbortSignal;
+    /**
+     * Optional response schema. In 'warn' mode (the default, right for
+     * third-party APIs) mismatches log an `upstream_decode_failed` event and
+     * pass the raw payload through; in 'fail' mode they fail with a tagged
+     * `UpstreamDataError`.
+     */
+    schema?: Schema.ConstraintDecoder<unknown>;
+    decodeMode?: 'fail' | 'warn';
+    /** Per-attempt timeout. A timed-out attempt fails as FetchFailedError (retryable). */
+    timeout?: Duration.Input;
 }
+
+export type FetchJsonError = RateLimitedError | UpstreamHttpError | FetchFailedError | JsonParseError | UpstreamDataError;
 
 function parseRetryAfterMs(value: string | null): number | undefined {
     if (!value) return undefined;
@@ -45,10 +59,8 @@ function isRetryableFetchError(error: unknown): boolean {
     return false;
 }
 
-export function fetchJson<T = unknown>(
-    args: FetchJsonArgs,
-): Effect.Effect<T, RateLimitedError | UpstreamHttpError | FetchFailedError | JsonParseError> {
-    return Effect.tryPromise({
+export function fetchJson<T = unknown>(args: FetchJsonArgs): Effect.Effect<T, FetchJsonError> {
+    const attempt = Effect.tryPromise({
         try: (signal: AbortSignal) => {
             const merged = mergeSignals(signal, args.signal);
             return Promise.resolve()
@@ -63,7 +75,7 @@ export function fetchJson<T = unknown>(
             }),
     }).pipe(
         Effect.flatMap(res => {
-            type FetchJsonError = RateLimitedError | UpstreamHttpError | JsonParseError;
+            type BodyError = RateLimitedError | UpstreamHttpError | JsonParseError | UpstreamDataError;
 
             if (res.status === 429) {
                 return Effect.fail(
@@ -72,7 +84,7 @@ export function fetchJson<T = unknown>(
                         message: `${args.service} rate limited`,
                         retryAfterMs: parseRetryAfterMs(res.headers.get('retry-after')),
                     }),
-                ) as Effect.Effect<T, FetchJsonError, never>;
+                ) as Effect.Effect<T, BodyError, never>;
             }
 
             if (!res.ok) {
@@ -98,7 +110,7 @@ export function fetchJson<T = unknown>(
                             }),
                         ),
                     ),
-                ) as Effect.Effect<T, FetchJsonError, never>;
+                ) as Effect.Effect<T, BodyError, never>;
             }
 
             return Effect.tryPromise({
@@ -108,14 +120,37 @@ export function fetchJson<T = unknown>(
                         message: `Failed to parse JSON from ${args.service}`,
                         cause: error instanceof Error ? error.message : String(error),
                     }),
-            });
+            }).pipe(
+                Effect.flatMap(payload => {
+                    if (!args.schema) return Effect.succeed(payload);
+                    const decode =
+                        args.decodeMode === 'fail'
+                            ? decodeUpstreamOrFail(args.schema, args.service)
+                            : decodeUpstreamOrWarn(args.schema, args.service);
+                    return decode(payload) as Effect.Effect<T, UpstreamDataError, never>;
+                }),
+            );
         }),
+    );
+
+    if (args.timeout === undefined) return attempt;
+    return attempt.pipe(
+        Effect.timeout(args.timeout),
+        Effect.catchTag('TimeoutError', () =>
+            Effect.fail(
+                new FetchFailedError({
+                    service: args.service,
+                    message: `${args.service} request timed out`,
+                    cause: 'timeout',
+                }),
+            ),
+        ),
     );
 }
 
 export function fetchJsonWithRetry<T = unknown>(
     args: FetchJsonArgs & { maxRetries?: number; baseDelay?: Duration.Input },
-): Effect.Effect<T, RateLimitedError | UpstreamHttpError | FetchFailedError | JsonParseError> {
+): Effect.Effect<T, FetchJsonError> {
     const maxRetries = Math.max(0, args.maxRetries ?? 3);
     const baseDelay = args.baseDelay ?? '200 millis';
 
@@ -128,24 +163,35 @@ export function fetchJsonWithRetry<T = unknown>(
         schedule: Schedule.exponential(baseDelay),
     }).pipe(
         Effect.tap(() =>
-            Effect.sync(() => emitExternalCall({
-                provider: args.service,
-                endpoint,
-                status: null,
-                duration_ms: Date.now() - started,
-                ok: true,
-            })),
+            Effect.service(CurrentRequestId).pipe(
+                Effect.map(requestId =>
+                    emitExternalCall({
+                        provider: args.service,
+                        endpoint,
+                        status: null,
+                        duration_ms: Date.now() - started,
+                        ok: true,
+                        ...(requestId ? { request_id: requestId } : {}),
+                    }),
+                ),
+            ),
         ),
         Effect.tapError(err =>
-            Effect.sync(() => emitExternalCall({
-                provider: args.service,
-                endpoint,
-                status: extractStatus(err),
-                duration_ms: Date.now() - started,
-                ok: false,
-                error_tag: extractErrorTag(err),
-            })),
+            Effect.service(CurrentRequestId).pipe(
+                Effect.map(requestId =>
+                    emitExternalCall({
+                        provider: args.service,
+                        endpoint,
+                        status: extractStatus(err),
+                        duration_ms: Date.now() - started,
+                        ok: false,
+                        error_tag: extractErrorTag(err),
+                        ...(requestId ? { request_id: requestId } : {}),
+                    }),
+                ),
+            ),
         ),
+        Effect.withSpan(`external.${args.service}`),
     );
 }
 
@@ -176,8 +222,9 @@ interface ExternalCallEvent {
     duration_ms: number;
     ok: boolean;
     error_tag?: string;
+    request_id?: string;
 }
 
 function emitExternalCall(fields: ExternalCallEvent): void {
-    console.log(JSON.stringify({ event: 'external_call', ...fields }));
+    emitEvent({ event: 'external_call', ...fields });
 }

--- a/packages/effect/src/index.ts
+++ b/packages/effect/src/index.ts
@@ -4,5 +4,6 @@ export * from './abort';
 export * from './api-errors';
 export * from './fetch';
 export * from './limits';
+export * from './observability';
 export * from './schema';
 export * from './tap-error-and-default';

--- a/packages/effect/src/observability.ts
+++ b/packages/effect/src/observability.ts
@@ -1,0 +1,18 @@
+import { Context } from 'effect';
+
+/**
+ * Ambient request id (v4's Reference — the FiberRef replacement). Provided by
+ * the API's route() wrapper before each handler runs; readable anywhere in
+ * the fiber via `Effect.service(CurrentRequestId)` with zero R-channel cost
+ * (References have a default). Lets shared emitters like `external_call`
+ * correlate to the request that caused them without threading a parameter
+ * through every callsite.
+ */
+export const CurrentRequestId = Context.Reference<string | null>('tokens/CurrentRequestId', {
+    defaultValue: () => null,
+});
+
+/** The one JSON-to-stdout log sink (Cloud Run / Loki ingest this format). */
+export function emitEvent(entry: Record<string, unknown>): void {
+    console.log(JSON.stringify(entry));
+}

--- a/packages/effect/src/schema.ts
+++ b/packages/effect/src/schema.ts
@@ -1,5 +1,5 @@
 import { Effect, Schema } from 'effect';
-import { BadRequestError } from './api-errors';
+import { BadRequestError, UpstreamDataError } from './api-errors';
 
 // -----------------------------------------------------------------------------
 // Common schemas
@@ -59,4 +59,58 @@ export function decodeOptionalSearchParam<S extends Schema.ConstraintDecoder<unk
     const raw = params.get(key);
     if (raw == null) return Effect.succeed(null);
     return decodeUnknownOrBadRequest(schema, raw, `Invalid ${key}`);
+}
+
+// -----------------------------------------------------------------------------
+// Upstream (outbound) response decoding
+// -----------------------------------------------------------------------------
+
+/**
+ * Strictly decode an upstream response. Failure becomes a tagged
+ * `UpstreamDataError` (mapped to 500). Note that Schema decoding drops excess
+ * properties, so additive upstream changes never fail — only missing/wrong
+ * fields do. Use for first-party contracts (e.g. our Cloud Run services).
+ */
+export function decodeUpstreamOrFail<S extends Schema.ConstraintDecoder<unknown>>(
+    schema: S,
+    service: string,
+): (input: unknown) => Effect.Effect<S['Type'], UpstreamDataError, S['DecodingServices']> {
+    return input =>
+        Schema.decodeUnknownEffect(schema)(input).pipe(
+            Effect.mapError(
+                parseError =>
+                    new UpstreamDataError({
+                        message: `${service} response failed schema validation`,
+                        service,
+                        issue: parseErrorToMessage(parseError),
+                    }),
+            ),
+        );
+}
+
+/**
+ * Shadow-mode decode for third-party responses: on mismatch, log a structured
+ * `upstream_decode_failed` event and return the raw input (cast) so behavior
+ * is unchanged while schemas bed in. Flip callers to `decodeUpstreamOrFail`
+ * once the event is quiet in logs.
+ */
+export function decodeUpstreamOrWarn<S extends Schema.ConstraintDecoder<unknown>>(
+    schema: S,
+    service: string,
+): (input: unknown) => Effect.Effect<S['Type'], never, S['DecodingServices']> {
+    return input =>
+        Schema.decodeUnknownEffect(schema)(input).pipe(
+            Effect.catch(parseError =>
+                Effect.sync(() => {
+                    console.warn(
+                        JSON.stringify({
+                            event: 'upstream_decode_failed',
+                            service,
+                            issue: parseErrorToMessage(parseError).slice(0, 512),
+                        }),
+                    );
+                    return input as S['Type'];
+                }),
+            ),
+        );
 }

--- a/packages/effect/src/upstream-decode.test.ts
+++ b/packages/effect/src/upstream-decode.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'bun:test';
+import { Effect, Exit, Schema } from 'effect';
+
+import { decodeUpstreamOrFail, decodeUpstreamOrWarn } from './schema';
+
+const Payload = Schema.Struct({
+    id: Schema.String,
+    value: Schema.Number,
+});
+
+describe('decodeUpstreamOrFail', () => {
+    it('decodes valid payloads and drops excess keys', async () => {
+        const result = await Effect.runPromise(
+            decodeUpstreamOrFail(Payload, 'svc')({ id: 'a', value: 1, extra: 'dropped' }),
+        );
+        expect(result).toEqual({ id: 'a', value: 1 });
+    });
+
+    it('fails with UpstreamDataError carrying the issue', async () => {
+        const exit = await Effect.runPromiseExit(decodeUpstreamOrFail(Payload, 'svc')({ id: 'a' }));
+        expect(Exit.isFailure(exit)).toBe(true);
+        if (Exit.isFailure(exit)) {
+            const reason = exit.cause.reasons[0];
+            expect(reason?._tag).toBe('Fail');
+            if (reason?._tag === 'Fail') {
+                const error = reason.error as { _tag: string; service: string; issue?: string };
+                expect(error._tag).toBe('UpstreamDataError');
+                expect(error.service).toBe('svc');
+                expect(error.issue?.length).toBeGreaterThan(0);
+            }
+        }
+    });
+});
+
+describe('decodeUpstreamOrWarn', () => {
+    it('passes through raw input on mismatch, logging upstream_decode_failed', async () => {
+        const warnings: string[] = [];
+        const original = console.warn;
+        console.warn = (...args: unknown[]) => {
+            warnings.push(String(args[0]));
+        };
+        try {
+            const raw = { id: 'a', wrong: true };
+            const result = await Effect.runPromise(decodeUpstreamOrWarn(Payload, 'svc')(raw));
+            expect(result).toBe(raw as never);
+            const events = warnings.map(line => JSON.parse(line) as Record<string, unknown>);
+            expect(events.length).toBe(1);
+            expect(events[0]!.event).toBe('upstream_decode_failed');
+            expect(events[0]!.service).toBe('svc');
+        } finally {
+            console.warn = original;
+        }
+    });
+
+    it('is silent for valid payloads', async () => {
+        const warnings: string[] = [];
+        const original = console.warn;
+        console.warn = (...args: unknown[]) => {
+            warnings.push(String(args[0]));
+        };
+        try {
+            const result = await Effect.runPromise(decodeUpstreamOrWarn(Payload, 'svc')({ id: 'a', value: 2 }));
+            expect(result).toEqual({ id: 'a', value: 2 });
+            expect(warnings.length).toBe(0);
+        } finally {
+            console.warn = original;
+        }
+    });
+});


### PR DESCRIPTION
Fifteenth PR of the Effect-deepening sequence (stacked on #62). **Completes the cron worker-pool sweep: all 17 hand-rolled `nextIndex`/`worker()` pools now run on the shared `runJobPool`**, with structured concurrency, deadline budgets, SIGTERM draining, and total-failure `ok: false` semantics.

- `crons.misc.ts`: `refreshStaleTokens` + `refreshCuratedTokenMarkets` (its catch-path touch compensation becomes `onItemError`).
- `crons.seed.ts`: `backfillMissingAssetIdentity` — the per-asset error collection moves to `onItemError`; the `errors` result payload is preserved.
- `crons.prestocks.ts`: sequential single-shot job gains total-failure `ok: false`.
- `runRefresh`/`runBestEffort` in cacheWarm/adminActions now log full error objects (stacks preserved); their intentional fail-open semantics are unchanged.
- The last two per-module `sleep` copies are deleted — of the original 8 duplicates, only `crons.coingecko.ts`'s remains (one real user: prices chunk pacing).

All 442 tests green; tsc + eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)