### PR TITLE
feat(cloudrun): external-call hardening (C5)

### DIFF
--- a/apps/cloudrun-admin/src/handlers/errors.ts
+++ b/apps/cloudrun-admin/src/handlers/errors.ts
@@ -1,25 +1,5 @@
-/** Shared handler error types, mapped to HTTP statuses by the server dispatcher. */
-
-/** Malformed/invalid arguments (or Convex-parity handler errors) → 400 `invalid_args`. */
-export class InvalidArgsError extends Error {
-    constructor(message: string) {
-        super(message);
-        this.name = 'InvalidArgsError';
-    }
-}
-
-/** Handler requires a caller identity (`x-tokens-identity`) and none was sent → 401 `identity_required`. */
-export class IdentityRequiredError extends Error {
-    constructor(message = 'caller identity required') {
-        super(message);
-        this.name = 'IdentityRequiredError';
-    }
-}
-
-/** Caller identity failed an authorization check (admin allowlist) → 403 `unauthorized`. */
-export class UnauthorizedError extends Error {
-    constructor(message = 'Unauthorized') {
-        super(message);
-        this.name = 'UnauthorizedError';
-    }
-}
+/**
+ * Shared handler error types live in @tokens/cloudrun-shutdown/http-errors;
+ * re-exported here so existing imports keep working.
+ */
+export { IdentityRequiredError, InvalidArgsError, UnauthorizedError } from '@tokens/cloudrun-shutdown/http-errors';

--- a/apps/cloudrun-admin/src/server.ts
+++ b/apps/cloudrun-admin/src/server.ts
@@ -10,6 +10,7 @@ import type { AdminMutationsRepo } from './handlers/curatedTokensMutations';
 import * as reads from './handlers/curatedTokensReads';
 import type { AdminReadsRepo } from './handlers/curatedTokensReads';
 import { IdentityRequiredError, InvalidArgsError, UnauthorizedError } from './handlers/errors';
+import { dispatchErrorResponse } from '@tokens/cloudrun-shutdown/http-errors';
 import * as hardDeleteHandlers from './handlers/hardDelete';
 import type { HardDeleteRepo } from './handlers/hardDelete';
 import * as logoUploadsHandlers from './handlers/logoUploads';
@@ -57,19 +58,6 @@ export function decodeIdentityHeader(raw: string | undefined): CallerIdentity | 
     }
 }
 
-function errorResponse(err: unknown, kind: string, name: string) {
-    if (err instanceof InvalidArgsError) {
-        return { body: { error: 'invalid_args', message: err.message }, status: 400 as const };
-    }
-    if (err instanceof IdentityRequiredError) {
-        return { body: { error: 'identity_required' }, status: 401 as const };
-    }
-    if (err instanceof UnauthorizedError) {
-        return { body: { error: 'unauthorized' }, status: 403 as const };
-    }
-    console.error(`[cloudrun-admin] ${kind} ${name} threw`, err);
-    return { body: { error: 'handler_error' }, status: 500 as const };
-}
 
 export function createApp(deps: ServerDeps) {
     const app = new Hono();
@@ -151,7 +139,7 @@ export function createApp(deps: ServerDeps) {
         try {
             return c.json(await handler(args, identity));
         } catch (err) {
-            const { body: errBody, status } = errorResponse(err, kind, name);
+            const { body: errBody, status } = dispatchErrorResponse('cloudrun-admin', err, kind, name);
             return c.json(errBody, status);
         }
     };

--- a/apps/cloudrun-assets/src/clients.ts
+++ b/apps/cloudrun-assets/src/clients.ts
@@ -1,3 +1,6 @@
+import { Effect, Schema } from 'effect';
+import { fetchJsonWithRetry } from '@tokens/effect';
+import { decodeUpstreamOrWarn } from '@tokens/effect/schema';
 import { withExternalTiming } from './externalTiming';
 import type {
     BirdeyeClient,
@@ -29,6 +32,19 @@ import type {
 import type { BirdeyeMarketsClient, TokenMarketEntry } from './handlers/crons.misc';
 import type { PreStocksApiSnapshot, PreStocksClient } from './handlers/crons.prestocks';
 
+// Shadow-mode envelope schemas (warn on mismatch, pass through) — the two
+// highest-traffic blind casts. Row shapes stay unknown/T on purpose.
+const BirdeyeEnvelopeSchema = Schema.Struct({
+    success: Schema.optionalKey(Schema.Unknown),
+    data: Schema.optionalKey(Schema.NullishOr(Schema.Record(Schema.String, Schema.Unknown))),
+});
+
+const EXTERNAL_FETCH_TIMEOUT_MS = 30_000;
+
+const GatewayEnvelopeSchema = Schema.Struct({
+    data: Schema.optionalKey(Schema.NullishOr(Schema.Array(Schema.Unknown))),
+});
+
 interface MakeBirdeyeOptions {
     apiKey: string;
     origin?: string;
@@ -49,11 +65,21 @@ export function makeBirdeyeClient(opts: MakeBirdeyeOptions): BirdeyeClient {
     return {
         async fetchTokenOverview(mint: string): Promise<BirdeyeOverview | null> {
             const url = `${baseUrl}/defi/token_overview?address=${encodeURIComponent(mint)}`;
-            const res = await withExternalTiming('birdeye', url, () => fetch(url, { headers }));
-            const json = (await res.json().catch(() => null)) as
-                | { success?: unknown; data?: BirdeyeOverview }
-                | null;
-            if (!res.ok || !json || json.success !== true || !json.data) return null;
+            const json = await Effect.runPromise(
+                fetchJsonWithRetry<{ success?: unknown; data?: BirdeyeOverview } | null>({
+                    url,
+                    service: 'birdeye',
+                    init: { headers },
+                    maxRetries: 2,
+                    timeout: '15 seconds',
+                    schema: BirdeyeEnvelopeSchema,
+                }).pipe(
+                    // Non-2xx keeps the historical null-degrade contract; network
+                    // failures / timeouts still throw (tagged) after retries.
+                    Effect.catchTag('UpstreamHttpError', () => Effect.succeed(null)),
+                ),
+            );
+            if (!json || json.success !== true || !json.data) return null;
             return json.data;
         },
     };
@@ -116,11 +142,16 @@ export function makeBirdeyeOhlcvClient(opts: MakeBirdeyeOhlcvOptions): BirdeyeOh
                 time_to: String(args.to),
             });
             const url = `${baseUrl}/defi/v3/ohlcv?${params.toString()}`;
-            const res = await withExternalTiming('birdeye', url, () => fetch(url, { headers }));
-            const json = (await res.json().catch(() => null)) as
-                | { success?: unknown; data?: { items?: unknown[] } }
-                | null;
-            if (!res.ok || !json || json.success !== true || !json.data || !Array.isArray(json.data.items)) {
+            const json = await Effect.runPromise(
+                fetchJsonWithRetry<{ success?: unknown; data?: { items?: unknown[] } } | null>({
+                    url,
+                    service: 'birdeye',
+                    init: { headers },
+                    maxRetries: 2,
+                    timeout: '30 seconds',
+                }).pipe(Effect.catchTag('UpstreamHttpError', () => Effect.succeed(null))),
+            );
+            if (!json || json.success !== true || !json.data || !Array.isArray(json.data.items)) {
                 return [];
             }
             const out: OhlcvCandle[] = [];
@@ -151,11 +182,14 @@ export function makeSanctumClient(opts: MakeSanctumOptions): SanctumClient {
             };
             let res: Response;
             try {
-                res = await withExternalTiming('sanctum', url.toString(), () => fetch(url, { headers: primaryHeaders }));
+                res = await withExternalTiming('sanctum', url.toString(), () =>
+                    fetch(url, { headers: primaryHeaders, signal: AbortSignal.timeout(EXTERNAL_FETCH_TIMEOUT_MS) }),
+                );
                 if (!res.ok && (res.status === 400 || res.status === 401 || res.status === 403)) {
                     res = await withExternalTiming('sanctum', url.toString(), () =>
                         fetch(url, {
                             headers: { Accept: 'application/json', Authorization: `Bearer ${apiKey}` },
+                            signal: AbortSignal.timeout(EXTERNAL_FETCH_TIMEOUT_MS),
                         }),
                     );
                 }
@@ -163,7 +197,10 @@ export function makeSanctumClient(opts: MakeSanctumOptions): SanctumClient {
                     const fallback = new URL(url.toString());
                     fallback.searchParams.set('apiKey', apiKey);
                     res = await withExternalTiming('sanctum', fallback.toString(), () =>
-                        fetch(fallback, { headers: { Accept: 'application/json' } }),
+                        fetch(fallback, {
+                            headers: { Accept: 'application/json' },
+                            signal: AbortSignal.timeout(EXTERNAL_FETCH_TIMEOUT_MS),
+                        }),
                     );
                 }
             } catch (err) {
@@ -197,7 +234,10 @@ export function makeWebacyClient(opts: MakeWebacyOptions): WebacyClient {
         if (!apiKey) return { ok: false, status: 0, message: 'WEBACY_API_KEY not configured' };
         try {
             const res = await withExternalTiming('webacy', url, () =>
-                fetch(url, { headers: { 'x-api-key': apiKey, Accept: 'application/json' } }),
+                fetch(url, {
+                    headers: { 'x-api-key': apiKey, Accept: 'application/json' },
+                    signal: AbortSignal.timeout(EXTERNAL_FETCH_TIMEOUT_MS),
+                }),
             );
             const json = await res.json().catch(() => null);
             if (!res.ok || !json) {
@@ -301,13 +341,18 @@ export function makeCoingeckoClient(opts: MakeCoingeckoOptions): CoingeckoClient
     if (apiKey) headers['x-cg-pro-api-key'] = apiKey;
 
     async function fetchJson(url: URL | string): Promise<unknown> {
-        const res = await withExternalTiming('coingecko', url.toString(), () => fetch(url, { headers }));
-        const json: unknown = await res.json().catch(() => null);
-        if (!res.ok) {
-            const body = json ? JSON.stringify(json) : '(no json body)';
-            throw new Error(`CoinGecko ${url.toString()} failed: HTTP ${res.status} ${res.statusText} ${body}`.trim());
-        }
-        return json;
+        // Tagged failures (UpstreamHttpError / RateLimitedError / FetchFailedError)
+        // propagate to per-item catches; adds 429/5xx retry + a timeout, which
+        // these calls previously lacked entirely.
+        return Effect.runPromise(
+            fetchJsonWithRetry<unknown>({
+                url: url.toString(),
+                service: 'coingecko',
+                init: { headers },
+                maxRetries: 2,
+                timeout: '30 seconds',
+            }),
+        );
     }
 
     return {
@@ -524,8 +569,11 @@ export function makeClickhouseClient(opts: MakeClickhouseOptions): ClickhouseCli
             const text = await res.text().catch(() => '');
             throw new ClickhouseApiError(`clickhouse-api HTTP ${res.status}: ${text.slice(0, 500)}`, res.status);
         }
-        const payload = (await res.json()) as { data?: T[] };
-        return payload.data ?? [];
+        const payload: unknown = await res.json();
+        const decoded = await Effect.runPromise(
+            decodeUpstreamOrWarn(GatewayEnvelopeSchema, 'clickhouse-api')(payload),
+        );
+        return ((decoded as { data?: T[] }).data ?? []) as T[];
     }
 
     return {
@@ -961,13 +1009,15 @@ export function makeRwaXyzClient(opts: MakeRwaXyzOptions): RwaXyzClient {
 
     async function fetchJson(path: string): Promise<unknown> {
         const url = `${baseUrl}/${apiVersion}${path}`;
-        const res = await withExternalTiming('rwaxyz', url, () => fetch(url, { headers }));
-        const json = await res.json().catch(() => null);
-        if (!res.ok || !json) {
-            const body = json ? JSON.stringify(json) : '(no json body)';
-            throw new Error(`RWA.xyz request failed: HTTP ${res.status} ${res.statusText} ${body}`);
-        }
-        return json;
+        return Effect.runPromise(
+            fetchJsonWithRetry<unknown>({
+                url,
+                service: 'rwaxyz',
+                init: { headers },
+                maxRetries: 2,
+                timeout: '30 seconds',
+            }),
+        );
     }
 
     async function fetchTokenByMint(mint: string): Promise<RwaXyzTokenRaw | null> {

--- a/apps/cloudrun-assets/src/handlers/assets.ts
+++ b/apps/cloudrun-assets/src/handlers/assets.ts
@@ -132,12 +132,8 @@ export function rowToResult(row: AssetRow): AssetResult {
     return result;
 }
 
-export class InvalidArgsError extends Error {
-    constructor(message: string) {
-        super(message);
-        this.name = 'InvalidArgsError';
-    }
-}
+export { InvalidArgsError } from '@tokens/cloudrun-shutdown/http-errors';
+import { InvalidArgsError } from '@tokens/cloudrun-shutdown/http-errors';
 
 function isAssetCategory(value: unknown): value is AssetCategory {
     return typeof value === 'string' && (ASSET_CATEGORIES as readonly string[]).includes(value);

--- a/apps/cloudrun-assets/src/handlers/crons.ts
+++ b/apps/cloudrun-assets/src/handlers/crons.ts
@@ -16,12 +16,8 @@ export interface CronResult {
     [extra: string]: unknown;
 }
 
-export class InvalidArgsError extends Error {
-    constructor(message: string) {
-        super(message);
-        this.name = 'InvalidArgsError';
-    }
-}
+export { InvalidArgsError } from '@tokens/cloudrun-shutdown/http-errors';
+import { InvalidArgsError } from '@tokens/cloudrun-shutdown/http-errors';
 
 export interface VariantMarketUpsertFromBirdeye {
     mint: string;

--- a/apps/cloudrun-usage/src/handlers/errors.ts
+++ b/apps/cloudrun-usage/src/handlers/errors.ts
@@ -1,25 +1,5 @@
-/** Shared handler error types, mapped to HTTP statuses by the server dispatcher. */
-
-/** Malformed/invalid arguments → 400 `invalid_args`. */
-export class InvalidArgsError extends Error {
-    constructor(message: string) {
-        super(message);
-        this.name = 'InvalidArgsError';
-    }
-}
-
-/** Handler requires a caller identity (`x-tokens-identity`) and none was sent → 401 `identity_required`. */
-export class IdentityRequiredError extends Error {
-    constructor(message = 'caller identity required') {
-        super(message);
-        this.name = 'IdentityRequiredError';
-    }
-}
-
-/** Caller identity failed an authorization check (membership/role/allowlist) → 403 `unauthorized`. */
-export class UnauthorizedError extends Error {
-    constructor(message = 'Unauthorized') {
-        super(message);
-        this.name = 'UnauthorizedError';
-    }
-}
+/**
+ * Shared handler error types live in @tokens/cloudrun-shutdown/http-errors;
+ * re-exported here so existing imports keep working.
+ */
+export { IdentityRequiredError, InvalidArgsError, UnauthorizedError } from '@tokens/cloudrun-shutdown/http-errors';

--- a/apps/cloudrun-usage/src/server.ts
+++ b/apps/cloudrun-usage/src/server.ts
@@ -5,6 +5,7 @@ import type { IdentityRepo } from './handlers/clerkIdentity';
 import * as dashboard from './handlers/dashboard';
 import type { DashboardRepo } from './handlers/dashboard';
 import { IdentityRequiredError, InvalidArgsError, UnauthorizedError } from './handlers/errors';
+import { dispatchErrorResponse } from '@tokens/cloudrun-shutdown/http-errors';
 import { authenticateApiKey, logApiRequest, type PlatformAuthRepo } from './handlers/platformAuth';
 import * as usageDashboard from './handlers/usageDashboard';
 import type { UsageDashboardRepo } from './handlers/usageDashboard';
@@ -67,19 +68,6 @@ export function decodeIdentityHeader(raw: string | undefined): CallerIdentity | 
     }
 }
 
-function errorResponse(err: unknown, kind: string, name: string) {
-    if (err instanceof InvalidArgsError) {
-        return { body: { error: 'invalid_args', message: err.message }, status: 400 as const };
-    }
-    if (err instanceof IdentityRequiredError) {
-        return { body: { error: 'identity_required' }, status: 401 as const };
-    }
-    if (err instanceof UnauthorizedError) {
-        return { body: { error: 'unauthorized' }, status: 403 as const };
-    }
-    console.error(`[cloudrun-usage] ${kind} ${name} threw`, err);
-    return { body: { error: 'handler_error' }, status: 500 as const };
-}
 
 export function createApp(deps: ServerDeps) {
     const app = new Hono();
@@ -148,7 +136,7 @@ export function createApp(deps: ServerDeps) {
         try {
             return c.json(await handler(args, identity));
         } catch (err) {
-            const { body, status } = errorResponse(err, kind, name);
+            const { body, status } = dispatchErrorResponse('cloudrun-usage', err, kind, name);
             return c.json(body, status);
         }
     };

--- a/packages/cloudrun-shutdown/package.json
+++ b/packages/cloudrun-shutdown/package.json
@@ -9,7 +9,8 @@
   "type": "module",
   "sideEffects": false,
   "exports": {
-    ".": "./src/index.ts"
+    ".": "./src/index.ts",
+    "./http-errors": "./src/http-errors.ts"
   },
   "files": [
     "src"

--- a/packages/cloudrun-shutdown/src/http-errors.ts
+++ b/packages/cloudrun-shutdown/src/http-errors.ts
@@ -1,0 +1,54 @@
+/**
+ * Shared handler error types for the cloudrun services, mapped to HTTP
+ * statuses by each service's dispatcher. Previously triplicated across
+ * cloudrun-admin, cloudrun-usage, and cloudrun-assets (twice).
+ */
+
+/** Malformed/invalid arguments → 400 `invalid_args`. */
+export class InvalidArgsError extends Error {
+    constructor(message: string) {
+        super(message);
+        this.name = 'InvalidArgsError';
+    }
+}
+
+/** Handler requires a caller identity (`x-tokens-identity`) and none was sent → 401 `identity_required`. */
+export class IdentityRequiredError extends Error {
+    constructor(message = 'caller identity required') {
+        super(message);
+        this.name = 'IdentityRequiredError';
+    }
+}
+
+/** Caller identity failed an authorization check (membership/role/allowlist) → 403 `unauthorized`. */
+export class UnauthorizedError extends Error {
+    constructor(message = 'Unauthorized') {
+        super(message);
+        this.name = 'UnauthorizedError';
+    }
+}
+
+export interface DispatchErrorResponse {
+    body: { error: string; message?: string };
+    status: 400 | 401 | 403 | 500;
+}
+
+/** Shared query/mutation dispatcher error mapping (full error logged, stack preserved). */
+export function dispatchErrorResponse(
+    serviceName: string,
+    err: unknown,
+    kind: string,
+    name: string,
+): DispatchErrorResponse {
+    if (err instanceof InvalidArgsError) {
+        return { body: { error: 'invalid_args', message: err.message }, status: 400 };
+    }
+    if (err instanceof IdentityRequiredError) {
+        return { body: { error: 'identity_required' }, status: 401 };
+    }
+    if (err instanceof UnauthorizedError) {
+        return { body: { error: 'unauthorized' }, status: 403 };
+    }
+    console.error(`[${serviceName}] ${kind} ${name} threw`, err);
+    return { body: { error: 'handler_error' }, status: 500 };
+}

--- a/packages/effect/src/fetch.ts
+++ b/packages/effect/src/fetch.ts
@@ -19,6 +19,8 @@ export interface FetchJsonArgs {
      */
     schema?: Schema.ConstraintDecoder<unknown>;
     decodeMode?: 'fail' | 'warn';
+    /** Per-attempt timeout. A timed-out attempt fails as FetchFailedError (retryable). */
+    timeout?: Duration.Input;
 }
 
 export type FetchJsonError = RateLimitedError | UpstreamHttpError | FetchFailedError | JsonParseError | UpstreamDataError;
@@ -58,7 +60,7 @@ function isRetryableFetchError(error: unknown): boolean {
 }
 
 export function fetchJson<T = unknown>(args: FetchJsonArgs): Effect.Effect<T, FetchJsonError> {
-    return Effect.tryPromise({
+    const attempt = Effect.tryPromise({
         try: (signal: AbortSignal) => {
             const merged = mergeSignals(signal, args.signal);
             return Promise.resolve()
@@ -129,6 +131,20 @@ export function fetchJson<T = unknown>(args: FetchJsonArgs): Effect.Effect<T, Fe
                 }),
             );
         }),
+    );
+
+    if (args.timeout === undefined) return attempt;
+    return attempt.pipe(
+        Effect.timeout(args.timeout),
+        Effect.catchTag('TimeoutError', () =>
+            Effect.fail(
+                new FetchFailedError({
+                    service: args.service,
+                    message: `${args.service} request timed out`,
+                    cause: 'timeout',
+                }),
+            ),
+        ),
     );
 }
 


### PR DESCRIPTION
Twenty-first PR of the Effect-deepening sequence (stacked on #68). The plan flagged this as the highest-risk app PR — scope was kept deliberately conservative, one client per commit-sized change, preserving each client's exact degrade contract.

## What changed
- **`fetchJson` gains a `timeout` option** (`@tokens/effect`): per-attempt, failing as a retryable `FetchFailedError`.
- **Birdeye (overview + OHLCV), CoinGecko, rwa.xyz** → `fetchJsonWithRetry` with `maxRetries: 2` + 15–30s timeouts. These calls previously had **no timeout and no retry at all**; 429s were never retried. Degrade contracts preserved exactly — birdeye's non-2xx → `null` via `catchTag(UpstreamHttpError)`; coingecko/rwaxyz keep throw-on-error (now tagged errors that per-item cron catches already handle).
- **Sanctum + Webacy deliberately NOT converted** (multi-auth fallback dance; status-preserving triple-call results — converting would disturb carefully-designed contracts for little gain). Their raw fetches gain the missing `AbortSignal.timeout(30s)` instead.
- **Shadow-mode envelope decodes** for the two highest-traffic blind casts: ClickHouse gateway (`as {data?: T[]}`) and the Birdeye overview envelope — `upstream_decode_failed` warn events only, rows stay `unknown`/`T`.
- `externalTiming.ts` stays (sanctum/webacy/clickhouse/prestocks still use it); the converted clients now emit `external_call` through the shared emitter with identical fields.

## Watch on stg
Retries multiply upstream calls — per the plan, watch provider rate-limit dashboards after deploy. `maxRetries: 2` and 429s respect the retry classification (`RateLimitedError` is retryable with backoff).

All 442 tests green; tsc + eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)