### PR TITLE
refactor(cloudrun): shared handler errors + dispatcher mapper (C6)

### DIFF
--- a/apps/cloudrun-admin/src/handlers/errors.ts
+++ b/apps/cloudrun-admin/src/handlers/errors.ts
@@ -1,25 +1,5 @@
-/** Shared handler error types, mapped to HTTP statuses by the server dispatcher. */
-
-/** Malformed/invalid arguments (or Convex-parity handler errors) → 400 `invalid_args`. */
-export class InvalidArgsError extends Error {
-    constructor(message: string) {
-        super(message);
-        this.name = 'InvalidArgsError';
-    }
-}
-
-/** Handler requires a caller identity (`x-tokens-identity`) and none was sent → 401 `identity_required`. */
-export class IdentityRequiredError extends Error {
-    constructor(message = 'caller identity required') {
-        super(message);
-        this.name = 'IdentityRequiredError';
-    }
-}
-
-/** Caller identity failed an authorization check (admin allowlist) → 403 `unauthorized`. */
-export class UnauthorizedError extends Error {
-    constructor(message = 'Unauthorized') {
-        super(message);
-        this.name = 'UnauthorizedError';
-    }
-}
+/**
+ * Shared handler error types live in @tokens/cloudrun-shutdown/http-errors;
+ * re-exported here so existing imports keep working.
+ */
+export { IdentityRequiredError, InvalidArgsError, UnauthorizedError } from '@tokens/cloudrun-shutdown/http-errors';

--- a/apps/cloudrun-admin/src/server.ts
+++ b/apps/cloudrun-admin/src/server.ts
@@ -10,6 +10,7 @@ import type { AdminMutationsRepo } from './handlers/curatedTokensMutations';
 import * as reads from './handlers/curatedTokensReads';
 import type { AdminReadsRepo } from './handlers/curatedTokensReads';
 import { IdentityRequiredError, InvalidArgsError, UnauthorizedError } from './handlers/errors';
+import { dispatchErrorResponse } from '@tokens/cloudrun-shutdown/http-errors';
 import * as hardDeleteHandlers from './handlers/hardDelete';
 import type { HardDeleteRepo } from './handlers/hardDelete';
 import * as logoUploadsHandlers from './handlers/logoUploads';
@@ -57,19 +58,6 @@ export function decodeIdentityHeader(raw: string | undefined): CallerIdentity | 
     }
 }
 
-function errorResponse(err: unknown, kind: string, name: string) {
-    if (err instanceof InvalidArgsError) {
-        return { body: { error: 'invalid_args', message: err.message }, status: 400 as const };
-    }
-    if (err instanceof IdentityRequiredError) {
-        return { body: { error: 'identity_required' }, status: 401 as const };
-    }
-    if (err instanceof UnauthorizedError) {
-        return { body: { error: 'unauthorized' }, status: 403 as const };
-    }
-    console.error(`[cloudrun-admin] ${kind} ${name} threw`, err);
-    return { body: { error: 'handler_error' }, status: 500 as const };
-}
 
 export function createApp(deps: ServerDeps) {
     const app = new Hono();
@@ -151,7 +139,7 @@ export function createApp(deps: ServerDeps) {
         try {
             return c.json(await handler(args, identity));
         } catch (err) {
-            const { body: errBody, status } = errorResponse(err, kind, name);
+            const { body: errBody, status } = dispatchErrorResponse('cloudrun-admin', err, kind, name);
             return c.json(errBody, status);
         }
     };

--- a/apps/cloudrun-assets/src/handlers/assets.ts
+++ b/apps/cloudrun-assets/src/handlers/assets.ts
@@ -132,12 +132,8 @@ export function rowToResult(row: AssetRow): AssetResult {
     return result;
 }
 
-export class InvalidArgsError extends Error {
-    constructor(message: string) {
-        super(message);
-        this.name = 'InvalidArgsError';
-    }
-}
+export { InvalidArgsError } from '@tokens/cloudrun-shutdown/http-errors';
+import { InvalidArgsError } from '@tokens/cloudrun-shutdown/http-errors';
 
 function isAssetCategory(value: unknown): value is AssetCategory {
     return typeof value === 'string' && (ASSET_CATEGORIES as readonly string[]).includes(value);

--- a/apps/cloudrun-assets/src/handlers/crons.ts
+++ b/apps/cloudrun-assets/src/handlers/crons.ts
@@ -16,12 +16,8 @@ export interface CronResult {
     [extra: string]: unknown;
 }
 
-export class InvalidArgsError extends Error {
-    constructor(message: string) {
-        super(message);
-        this.name = 'InvalidArgsError';
-    }
-}
+export { InvalidArgsError } from '@tokens/cloudrun-shutdown/http-errors';
+import { InvalidArgsError } from '@tokens/cloudrun-shutdown/http-errors';
 
 export interface VariantMarketUpsertFromBirdeye {
     mint: string;

--- a/apps/cloudrun-usage/src/handlers/errors.ts
+++ b/apps/cloudrun-usage/src/handlers/errors.ts
@@ -1,25 +1,5 @@
-/** Shared handler error types, mapped to HTTP statuses by the server dispatcher. */
-
-/** Malformed/invalid arguments → 400 `invalid_args`. */
-export class InvalidArgsError extends Error {
-    constructor(message: string) {
-        super(message);
-        this.name = 'InvalidArgsError';
-    }
-}
-
-/** Handler requires a caller identity (`x-tokens-identity`) and none was sent → 401 `identity_required`. */
-export class IdentityRequiredError extends Error {
-    constructor(message = 'caller identity required') {
-        super(message);
-        this.name = 'IdentityRequiredError';
-    }
-}
-
-/** Caller identity failed an authorization check (membership/role/allowlist) → 403 `unauthorized`. */
-export class UnauthorizedError extends Error {
-    constructor(message = 'Unauthorized') {
-        super(message);
-        this.name = 'UnauthorizedError';
-    }
-}
+/**
+ * Shared handler error types live in @tokens/cloudrun-shutdown/http-errors;
+ * re-exported here so existing imports keep working.
+ */
+export { IdentityRequiredError, InvalidArgsError, UnauthorizedError } from '@tokens/cloudrun-shutdown/http-errors';

--- a/apps/cloudrun-usage/src/server.ts
+++ b/apps/cloudrun-usage/src/server.ts
@@ -5,6 +5,7 @@ import type { IdentityRepo } from './handlers/clerkIdentity';
 import * as dashboard from './handlers/dashboard';
 import type { DashboardRepo } from './handlers/dashboard';
 import { IdentityRequiredError, InvalidArgsError, UnauthorizedError } from './handlers/errors';
+import { dispatchErrorResponse } from '@tokens/cloudrun-shutdown/http-errors';
 import { authenticateApiKey, logApiRequest, type PlatformAuthRepo } from './handlers/platformAuth';
 import * as usageDashboard from './handlers/usageDashboard';
 import type { UsageDashboardRepo } from './handlers/usageDashboard';
@@ -67,19 +68,6 @@ export function decodeIdentityHeader(raw: string | undefined): CallerIdentity | 
     }
 }
 
-function errorResponse(err: unknown, kind: string, name: string) {
-    if (err instanceof InvalidArgsError) {
-        return { body: { error: 'invalid_args', message: err.message }, status: 400 as const };
-    }
-    if (err instanceof IdentityRequiredError) {
-        return { body: { error: 'identity_required' }, status: 401 as const };
-    }
-    if (err instanceof UnauthorizedError) {
-        return { body: { error: 'unauthorized' }, status: 403 as const };
-    }
-    console.error(`[cloudrun-usage] ${kind} ${name} threw`, err);
-    return { body: { error: 'handler_error' }, status: 500 as const };
-}
 
 export function createApp(deps: ServerDeps) {
     const app = new Hono();
@@ -148,7 +136,7 @@ export function createApp(deps: ServerDeps) {
         try {
             return c.json(await handler(args, identity));
         } catch (err) {
-            const { body, status } = errorResponse(err, kind, name);
+            const { body, status } = dispatchErrorResponse('cloudrun-usage', err, kind, name);
             return c.json(body, status);
         }
     };

--- a/packages/cloudrun-shutdown/package.json
+++ b/packages/cloudrun-shutdown/package.json
@@ -9,7 +9,8 @@
   "type": "module",
   "sideEffects": false,
   "exports": {
-    ".": "./src/index.ts"
+    ".": "./src/index.ts",
+    "./http-errors": "./src/http-errors.ts"
   },
   "files": [
     "src"

--- a/packages/cloudrun-shutdown/src/http-errors.ts
+++ b/packages/cloudrun-shutdown/src/http-errors.ts
@@ -1,0 +1,54 @@
+/**
+ * Shared handler error types for the cloudrun services, mapped to HTTP
+ * statuses by each service's dispatcher. Previously triplicated across
+ * cloudrun-admin, cloudrun-usage, and cloudrun-assets (twice).
+ */
+
+/** Malformed/invalid arguments → 400 `invalid_args`. */
+export class InvalidArgsError extends Error {
+    constructor(message: string) {
+        super(message);
+        this.name = 'InvalidArgsError';
+    }
+}
+
+/** Handler requires a caller identity (`x-tokens-identity`) and none was sent → 401 `identity_required`. */
+export class IdentityRequiredError extends Error {
+    constructor(message = 'caller identity required') {
+        super(message);
+        this.name = 'IdentityRequiredError';
+    }
+}
+
+/** Caller identity failed an authorization check (membership/role/allowlist) → 403 `unauthorized`. */
+export class UnauthorizedError extends Error {
+    constructor(message = 'Unauthorized') {
+        super(message);
+        this.name = 'UnauthorizedError';
+    }
+}
+
+export interface DispatchErrorResponse {
+    body: { error: string; message?: string };
+    status: 400 | 401 | 403 | 500;
+}
+
+/** Shared query/mutation dispatcher error mapping (full error logged, stack preserved). */
+export function dispatchErrorResponse(
+    serviceName: string,
+    err: unknown,
+    kind: string,
+    name: string,
+): DispatchErrorResponse {
+    if (err instanceof InvalidArgsError) {
+        return { body: { error: 'invalid_args', message: err.message }, status: 400 };
+    }
+    if (err instanceof IdentityRequiredError) {
+        return { body: { error: 'identity_required' }, status: 401 };
+    }
+    if (err instanceof UnauthorizedError) {
+        return { body: { error: 'unauthorized' }, status: 403 };
+    }
+    console.error(`[${serviceName}] ${kind} ${name} threw`, err);
+    return { body: { error: 'handler_error' }, status: 500 };
+}


### PR DESCRIPTION
Twenty-second PR of the Effect-deepening sequence (stacked on #69). No Effect dependency needed here — pure dedup.

- **`@tokens/cloudrun-shutdown/http-errors`** (new subpath): `InvalidArgsError`/`IdentityRequiredError`/`UnauthorizedError` were defined identically in cloudrun-admin, cloudrun-usage, and **twice** in cloudrun-assets. Each app's `handlers/errors.ts` becomes a re-export, so all ~20 importers are untouched.
- **`dispatchErrorResponse(serviceName, err, kind, name)`**: the byte-identical (minus log prefix) query/mutation error mapping in admin/usage collapses to one function.
- cloudrun-assets' two `InvalidArgsError` definitions now resolve to the same class — the `InvalidArgsError as CronInvalidArgsError` import disambiguation in its server.ts keeps working, with `instanceof` now true across both aliases (strictly more correct).

Verification: 650 tests green across the three services (101 + 107 + 442); tsc clean in all three.

🤖 Generated with [Claude Code](https://claude.com/claude-code)