### PR TITLE
fix(cloudrun): copy workspace packages from deps stage (unbreaks staging deploy)

### DIFF
--- a/apps/cloudrun-admin/Dockerfile
+++ b/apps/cloudrun-admin/Dockerfile
@@ -12,7 +12,11 @@ ENV NODE_ENV=production
 ENV PORT=8080
 COPY --from=deps /app/node_modules ./node_modules
 COPY --from=deps /app/apps/cloudrun-admin/node_modules ./apps/cloudrun-admin/node_modules
-COPY packages ./packages
+# Take packages from the deps stage, not the build context: workspace
+# packages are consumed as TS source, so their own node_modules (where
+# bun's isolated install puts their runtime deps, e.g. `effect`) must
+# come along or imports inside packages/*/src fail to resolve at boot.
+COPY --from=deps /app/packages ./packages
 COPY apps/cloudrun-admin/package.json apps/cloudrun-admin/package.json
 COPY apps/cloudrun-admin/src ./apps/cloudrun-admin/src
 WORKDIR /app/apps/cloudrun-admin

--- a/apps/cloudrun-assets/Dockerfile
+++ b/apps/cloudrun-assets/Dockerfile
@@ -17,7 +17,11 @@ ENV NODE_ENV=production
 ENV PORT=8080
 COPY --from=deps /app/node_modules ./node_modules
 COPY --from=deps /app/apps/cloudrun-assets/node_modules ./apps/cloudrun-assets/node_modules
-COPY packages ./packages
+# Take packages from the deps stage, not the build context: workspace
+# packages are consumed as TS source, so their own node_modules (where
+# bun's isolated install puts their runtime deps, e.g. `effect`) must
+# come along or imports inside packages/*/src fail to resolve at boot.
+COPY --from=deps /app/packages ./packages
 COPY apps/cloudrun-assets/package.json apps/cloudrun-assets/package.json
 COPY apps/cloudrun-assets/src ./apps/cloudrun-assets/src
 WORKDIR /app/apps/cloudrun-assets

--- a/apps/cloudrun-prices/Dockerfile
+++ b/apps/cloudrun-prices/Dockerfile
@@ -12,7 +12,11 @@ ENV NODE_ENV=production
 ENV PORT=8080
 COPY --from=deps /app/node_modules ./node_modules
 COPY --from=deps /app/apps/cloudrun-prices/node_modules ./apps/cloudrun-prices/node_modules
-COPY packages ./packages
+# Take packages from the deps stage, not the build context: workspace
+# packages are consumed as TS source, so their own node_modules (where
+# bun's isolated install puts their runtime deps, e.g. `effect`) must
+# come along or imports inside packages/*/src fail to resolve at boot.
+COPY --from=deps /app/packages ./packages
 COPY apps/cloudrun-prices/package.json apps/cloudrun-prices/package.json
 COPY apps/cloudrun-prices/src ./apps/cloudrun-prices/src
 WORKDIR /app/apps/cloudrun-prices

--- a/apps/cloudrun-usage/Dockerfile
+++ b/apps/cloudrun-usage/Dockerfile
@@ -12,7 +12,11 @@ ENV NODE_ENV=production
 ENV PORT=8080
 COPY --from=deps /app/node_modules ./node_modules
 COPY --from=deps /app/apps/cloudrun-usage/node_modules ./apps/cloudrun-usage/node_modules
-COPY packages ./packages
+# Take packages from the deps stage, not the build context: workspace
+# packages are consumed as TS source, so their own node_modules (where
+# bun's isolated install puts their runtime deps, e.g. `effect`) must
+# come along or imports inside packages/*/src fail to resolve at boot.
+COPY --from=deps /app/packages ./packages
 COPY apps/cloudrun-usage/package.json apps/cloudrun-usage/package.json
 COPY apps/cloudrun-usage/src ./apps/cloudrun-usage/src
 WORKDIR /app/apps/cloudrun-usage


### PR DESCRIPTION
## The failure

Staging deploy of `cloudrun-assets` after #48 failed with the generic Cloud Run message:

> The user-provided container failed to start and listen on the port defined provided by the PORT=8080 environment variable

The actual cause, reproduced locally:

```
Cannot find package 'effect' from '/app/packages/effect/src/schema.ts'
```

## Root cause

`@tokens/effect` is consumed as **TypeScript source** (its exports point at `src/*.ts`), so `import { Effect } from 'effect'` inside `packages/effect/src/schema.ts` resolves upward from `/app/packages/effect/`. Bun's isolated install puts that dependency at `packages/effect/node_modules/effect` — but the runner stage did:

```dockerfile
COPY packages ./packages          # from the BUILD CONTEXT
```

which in CI is a fresh checkout with **no `node_modules`**. The deps stage's `packages/*/node_modules` were never copied, so the import had nowhere to resolve and the process died before opening the port.

This was **latent, not new** — it only surfaced because C1 made `cloudrun-assets` import `@tokens/effect/job-runner`, whose barrel pulls in `schema.ts` → `effect`. Nothing in the pipeline caught it: the container isn't built or booted in PR CI (build/deploy are post-merge only), and every test run resolves `effect` from the repo-root hoisted `node_modules`, which the container layout doesn't reproduce.

## The fix

```dockerfile
COPY --from=deps /app/packages ./packages
```

Applied to **all four** cloudrun Dockerfiles — admin/prices/usage carry the identical latent bug and would break the first time they use a workspace package with a runtime dep.

## Verification

Replicated the container filesystem exactly (deps-stage `bun install --production --frozen-lockfile --ignore-scripts` + the symlink step, then only the files each `COPY` brings over):

- **Old layout**: reproduces `BOOT FAIL: Cannot find package 'effect' …` ✗
- **New layout**: all four services boot — `cloudrun-assets`, `-admin`, `-prices`, `-usage` all report `BOOT OK port 8080`, and `cloudrun-assets` serves **HTTP 200 on `:8080`** (the exact probe Cloud Run runs) and drains cleanly on SIGTERM ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)