### PR TITLE
fix(curated): collapse DB-only variant mints into their canonical asset

### DIFF
--- a/apps/api/src/app/api/v1/assets/curated/_member-fallback-assets.test.ts
+++ b/apps/api/src/app/api/v1/assets/curated/_member-fallback-assets.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from 'bun:test';
+
+import type { CanonicalAsset } from '@tokens/asset-registry';
+
+import { addMemberFallbackAssets } from './_member-fallback-assets';
+
+const SILVER_MINT = 'SiLVFMgD3eD2rgK628NbTBq9MnuJF5FW2CRaVyTB35L';
+const ONDO_SILVER_MINT = 'iy11ytbSGcUnrjE6Lfv78TFqxKyUESfku1FugS9ondo';
+const WSOL_MINT = 'So11111111111111111111111111111111111111112';
+const JITOSOL_MINT = 'J1toso1uCk3RLmjorhTtrVwY9HJ7X8V9yYac6Y7kGCPn';
+const UNSEEDED_MINT = '9DRPPWYud8i6CaSsDsFESs1xyVr8dBCMtjPZji2xiZEa';
+
+function asset(assetId: string, mints: readonly string[]): CanonicalAsset {
+    return {
+        assetId,
+        category: 'commodity',
+        aliases: [],
+        variants: mints.map(mint => ({
+            variantId: `${assetId}:${mint.slice(0, 6)}`,
+            mint,
+            kind: 'wrapped',
+            trustTier: 'tier3',
+            tags: [],
+        })),
+    };
+}
+
+function run(args: {
+    assetIds: readonly string[];
+    canonicalAssetById: Map<string, CanonicalAsset>;
+    registry?: Record<string, CanonicalAsset>;
+}): Map<string, CanonicalAsset> {
+    const registry = args.registry ?? {};
+    addMemberFallbackAssets({
+        assetIds: args.assetIds,
+        canonicalAssetById: args.canonicalAssetById,
+        category: 'commodity',
+        kind: 'wrapped',
+        listId: 'metals',
+        resolveRegistryAsset: ref => registry[ref] ?? null,
+    });
+    return args.canonicalAssetById;
+}
+
+describe('addMemberFallbackAssets', () => {
+    it('does not duplicate a DB-attached mint the compiled registry does not know', () => {
+        // The admin attached SILVER_MINT to the `silver` canonical, so the caller's
+        // registry-only mint→asset pass surfaced it as `solana-<mint>`.
+        const canonicalAssetById = new Map([['silver', asset('silver', [ONDO_SILVER_MINT, SILVER_MINT])]]);
+
+        const result = run({
+            assetIds: ['silver', `solana-${SILVER_MINT}`],
+            canonicalAssetById,
+        });
+
+        expect([...result.keys()]).toEqual(['silver']);
+    });
+
+    it('collapses every DB variant mint of a member instead of one row per mint', () => {
+        // `solana` carries ~1.5k Sanctum LST variants in the DB; none of them may
+        // become a standalone row in a curated list.
+        const canonicalAssetById = new Map([['solana', asset('solana', [WSOL_MINT, JITOSOL_MINT])]]);
+
+        const result = run({
+            assetIds: ['solana', `solana-${JITOSOL_MINT}`, `solana-${WSOL_MINT}`],
+            canonicalAssetById,
+        });
+
+        expect([...result.keys()]).toEqual(['solana']);
+    });
+
+    it('still fabricates a singleton for a member no asset claims', () => {
+        const result = run({
+            assetIds: [`solana-${UNSEEDED_MINT}`],
+            canonicalAssetById: new Map(),
+        });
+
+        const fallback = result.get(`solana-${UNSEEDED_MINT}`);
+        expect(fallback?.assetId).toBe(`solana-${UNSEEDED_MINT}`);
+        expect(fallback?.variants.map(v => v.mint)).toEqual([UNSEEDED_MINT]);
+        expect(fallback?.variants[0]?.tags).toEqual(['curated:metals']);
+        expect(fallback?.category).toBe('commodity');
+    });
+
+    it('accepts a bare mint as the member id', () => {
+        const result = run({
+            assetIds: [UNSEEDED_MINT],
+            canonicalAssetById: new Map(),
+        });
+
+        expect(result.get(`solana-${UNSEEDED_MINT}`)?.variants[0]?.mint).toBe(UNSEEDED_MINT);
+    });
+
+    it('prefers a registry asset over a fabricated singleton, and claims its mints', () => {
+        const registryAsset = asset('gold', [UNSEEDED_MINT]);
+
+        const result = run({
+            assetIds: ['gold', `solana-${UNSEEDED_MINT}`],
+            canonicalAssetById: new Map(),
+            registry: { gold: registryAsset },
+        });
+
+        expect([...result.keys()]).toEqual(['gold']);
+    });
+
+    it('leaves assets already present untouched', () => {
+        const existing = asset('gold', [UNSEEDED_MINT]);
+        const canonicalAssetById = new Map([['gold', existing]]);
+
+        const result = run({ assetIds: ['gold'], canonicalAssetById });
+
+        expect(result.get('gold')).toBe(existing);
+    });
+});

--- a/apps/api/src/app/api/v1/assets/curated/_member-fallback-assets.ts
+++ b/apps/api/src/app/api/v1/assets/curated/_member-fallback-assets.ts
@@ -1,0 +1,81 @@
+import {
+    resolveAlias as resolveRegistryAlias,
+    type AssetCategory,
+    type CanonicalAsset,
+    type VariantKind,
+} from '@tokens/asset-registry';
+
+import { looksLikeSolanaMintAddress, mintToSingletonAssetId, singletonAssetIdToMint } from '../_singleton-asset-id';
+
+export interface MemberFallbackArgs {
+    /** Collection members + registry-derived member ids, already tombstone-filtered. */
+    assetIds: readonly string[];
+    /** Assets built from the DB (and registry) so far; mutated in place. */
+    canonicalAssetById: Map<string, CanonicalAsset>;
+    /** Category/kind to stamp on a fabricated singleton, derived from the list id. */
+    category: AssetCategory;
+    kind: VariantKind;
+    /** Tag suffix for a fabricated singleton (`curated:<listId>`). */
+    listId: string;
+    resolveRegistryAsset?: (ref: string) => CanonicalAsset | null;
+}
+
+/**
+ * Ensures every collection member is represented, even before the registry seed
+ * knows about it: a member that produced no DB asset becomes a registry asset when
+ * one resolves, otherwise a single-mint singleton shell.
+ *
+ * A member id is only mint-shaped (`<mint>` / `solana-<mint>`) because the caller
+ * resolves mint → asset through the *compiled* registry, which lags the DB. When
+ * the DB has already attached that mint to a canonical asset in this payload —
+ * an admin-added variant, or one of the ~1.5k Sanctum LSTs hanging off `solana` —
+ * fabricating a singleton would duplicate the token as a second, nameless row. So
+ * mints already claimed by an asset in the payload are skipped.
+ */
+export function addMemberFallbackAssets(args: MemberFallbackArgs): void {
+    const { assetIds, canonicalAssetById, category, kind, listId } = args;
+    const resolveRegistryAsset = args.resolveRegistryAsset ?? resolveRegistryAlias;
+
+    const claimedMints = new Set<string>();
+    for (const asset of canonicalAssetById.values()) {
+        for (const variant of asset.variants) claimedMints.add(variant.mint);
+    }
+
+    for (const memberAssetId of assetIds) {
+        const normalizedAssetId = looksLikeSolanaMintAddress(memberAssetId)
+            ? mintToSingletonAssetId(memberAssetId)
+            : memberAssetId;
+        if (canonicalAssetById.has(normalizedAssetId)) continue;
+
+        const singletonMint = singletonAssetIdToMint(memberAssetId);
+        const mint = singletonMint ?? (looksLikeSolanaMintAddress(memberAssetId) ? memberAssetId.trim() : null);
+
+        // Prefer registry fallbacks when possible.
+        const registryAsset = resolveRegistryAsset(memberAssetId);
+        if (registryAsset) {
+            canonicalAssetById.set(registryAsset.assetId, registryAsset);
+            for (const variant of registryAsset.variants) claimedMints.add(variant.mint);
+            continue;
+        }
+
+        if (!mint) continue;
+        if (claimedMints.has(mint)) continue;
+
+        const singletonAssetId = mintToSingletonAssetId(mint);
+        canonicalAssetById.set(singletonAssetId, {
+            assetId: singletonAssetId,
+            category,
+            aliases: [singletonAssetId, mint],
+            variants: [
+                {
+                    variantId: `${singletonAssetId}:mint`,
+                    mint,
+                    kind,
+                    trustTier: 'tier3',
+                    tags: [`curated:${listId}`],
+                },
+            ],
+        });
+        claimedMints.add(mint);
+    }
+}

--- a/apps/api/src/app/api/v1/assets/curated/route.ts
+++ b/apps/api/src/app/api/v1/assets/curated/route.ts
@@ -66,8 +66,9 @@ import {
     type TokenMarketSnapshot,
     type VariantExecutionQualitySnapshot,
 } from '../_asset-helpers';
-import { looksLikeSolanaMintAddress, mintToSingletonAssetId, singletonAssetIdToMint } from '../_singleton-asset-id';
+import { looksLikeSolanaMintAddress, mintToSingletonAssetId } from '../_singleton-asset-id';
 import { normalizeCoinGeckoCoinIdForAsset } from '../_coingecko-id';
+import { addMemberFallbackAssets } from './_member-fallback-assets';
 
 type CuratedTokenCategoryId = 'all' | CuratedTokenListId;
 
@@ -406,42 +407,13 @@ export const GET = route(
             }
 
             // …then ensure *every* DB collection member is represented, even before seeding.
-            for (const memberAssetId of assetIds) {
-                const normalizedAssetId = looksLikeSolanaMintAddress(memberAssetId)
-                    ? mintToSingletonAssetId(memberAssetId)
-                    : memberAssetId;
-                if (canonicalAssetById.has(normalizedAssetId)) continue;
-
-                const singletonMint = singletonAssetIdToMint(memberAssetId);
-                const mint = singletonMint ?? (looksLikeSolanaMintAddress(memberAssetId) ? memberAssetId.trim() : null);
-
-                // Prefer registry fallbacks when possible.
-                const registryAsset = resolveRegistryAlias(memberAssetId);
-                if (registryAsset) {
-                    canonicalAssetById.set(registryAsset.assetId, registryAsset);
-                    continue;
-                }
-
-                if (!mint) continue;
-
-                const singletonAssetId = mintToSingletonAssetId(mint);
-                const fallback: CanonicalAsset = {
-                    assetId: singletonAssetId,
-                    category: categoryForCuratedListId(listId),
-                    aliases: [singletonAssetId, mint],
-                    variants: [
-                        {
-                            variantId: `${singletonAssetId}:mint`,
-                            mint,
-                            kind: kindForCuratedListId(listId),
-                            trustTier: 'tier3',
-                            tags: [`curated:${listId}`],
-                        },
-                    ],
-                };
-
-                canonicalAssetById.set(singletonAssetId, fallback);
-            }
+            addMemberFallbackAssets({
+                assetIds,
+                canonicalAssetById,
+                category: categoryForCuratedListId(listId),
+                kind: kindForCuratedListId(listId),
+                listId,
+            });
 
             function mergeRegistryVariantMetadata(asset: CanonicalAsset): CanonicalAsset {
                 const registryAsset =

--- a/apps/cloudrun-assets/src/db.ts
+++ b/apps/cloudrun-assets/src/db.ts
@@ -3182,20 +3182,41 @@ export function makePostgresAssetCollectionsReadsRepo(sql: Sql): AssetCollection
         },
         async getSummariesBySlugs(slugs) {
             if (slugs.length === 0) return [];
+            // "Last added" counts a new variant on an existing member too: attaching
+            // a mint to a canonical that is already in the list (the admin add-variant
+            // flow) never writes asset_collection_members, so membership added_at
+            // alone can never see it. Auto-synced yield/LST variants are excluded so
+            // Sanctum churn cannot hold the highlight hostage.
             const rows = await sql<
                 { collection_slug: string; member_count: number; last_added_asset_id: string | null; last_added_at: number | null }[]
             >`
-                SELECT acm.collection_slug,
+                WITH members AS (
+                    SELECT acm.collection_slug,
+                           acm.asset_id,
+                           acm.rank,
+                           GREATEST(
+                               acm.added_at,
+                               COALESCE((
+                                   SELECT MAX((EXTRACT(EPOCH FROM av.created_at) * 1000)::bigint)
+                                   FROM asset_variants av
+                                   WHERE av.asset_id = acm.asset_id
+                                     AND av.is_active = true
+                                     AND av.kind NOT IN ('yield', 'lst')
+                               ), acm.added_at)
+                           ) AS added_at
+                    FROM asset_collection_members acm
+                    JOIN assets a ON a.asset_id = acm.asset_id AND a.is_active = true
+                    WHERE acm.collection_slug IN ${sql([...slugs])}
+                      AND NOT EXISTS (
+                          SELECT 1 FROM asset_deletion_tombstones t WHERE t.asset_id = acm.asset_id
+                      )
+                )
+                SELECT collection_slug,
                        COUNT(*)::int AS member_count,
-                       (ARRAY_AGG(acm.asset_id ORDER BY acm.added_at DESC, acm.rank ASC))[1] AS last_added_asset_id,
-                       MAX(acm.added_at) AS last_added_at
-                FROM asset_collection_members acm
-                JOIN assets a ON a.asset_id = acm.asset_id AND a.is_active = true
-                WHERE acm.collection_slug IN ${sql([...slugs])}
-                  AND NOT EXISTS (
-                      SELECT 1 FROM asset_deletion_tombstones t WHERE t.asset_id = acm.asset_id
-                  )
-                GROUP BY acm.collection_slug
+                       (ARRAY_AGG(asset_id ORDER BY added_at DESC, rank ASC))[1] AS last_added_asset_id,
+                       MAX(added_at) AS last_added_at
+                FROM members
+                GROUP BY collection_slug
             `;
             return rows.map(r => ({
                 collection_slug: r.collection_slug,

--- a/apps/cloudrun-assets/src/handlers/assetCollectionsReads.ts
+++ b/apps/cloudrun-assets/src/handlers/assetCollectionsReads.ts
@@ -19,9 +19,18 @@ export interface AssetCollectionSummaryRow {
 
 export interface AssetCollectionsReadsRepo {
     listMembersBySlug(slug: string, limit: number): Promise<AssetCollectionMemberRow[]>;
-    /** Active-variant mints for a collection's members, rank order. */
+    /**
+     * Active-variant mints for a collection's members, rank order. Deliberately
+     * includes the ~1.5k Sanctum yield variants hanging off `solana`: they keep the
+     * prefetch's market coverage complete for `groupBy=mint` callers. Consumers must
+     * not assume one mint per member (see `addMemberFallbackAssets` in the API).
+     */
     listMemberMintsBySlug(slug: string, limit: number): Promise<AssetCollectionMemberMintRow[]>;
-    /** Per-slug count + latest-added member, active-assets only, tombstone-filtered. */
+    /**
+     * Per-slug count + latest-added member, active-assets only, tombstone-filtered.
+     * Latest-added also reflects a new variant on an existing member (the admin
+     * add-variant flow leaves membership untouched).
+     */
     getSummariesBySlugs(slugs: readonly string[]): Promise<AssetCollectionSummaryRow[]>;
 }
 


### PR DESCRIPTION
## What broke

Adding a token via the admin portal (`SiLVFMgD3eD2rgK628NbTBq9MnuJF5FW2CRaVyTB35L`) surfaced two bugs in the no-PR pipeline (#32). The add itself was fine — the mint is correctly attached to the `silver` canonical.

Measured against prod before this change:

| Symptom | Reality |
|---|---|
| Crypto tab shows every Solana variant | `list=majors` returned **1481** rows: 31 real + **1450 nameless phantoms** |
| Metals shows the added variant | `SiLVFMgD…` rendered **twice** — as `silver` (correct) and as a nameless `solana-SiLVFMgD…` row |
| "Latest Added" ignores the new token | Every slug's `lastAddedAt` was the same seed timestamp (2026-08-13T03:00:20Z), so the card resolved to `abbott` |

## Why

**Phantom rows.** `getEffectiveCuratedAddresses` unions in `assetCollectionsGetMemberMints(slug)`, which expands every collection member into *all* of its active variant mints. `solana` carries **1,464** variants in prod (1,463 Sanctum LSTs), so majors' 30 members produced 1481 mints. The route then maps mint → asset via the *compiled* registry only (`getVariantByMint`), so every DB-only mint fell through to the `solana-<mint>` singleton fallback and became its own row. The admin-added silver mint hit the same path: the DB knows it belongs to `silver`, the compiled registry doesn't.

Before #32 this couldn't happen — `majors` was 33 hand-picked mints, one per asset. The DB union added asset-level membership expanded per-variant.

**Latest Added.** The signal came from `asset_collection_members.added_at` alone. Attaching a mint to a canonical that is already a member — the admin add-variant flow — never writes that table, so no timestamp moves. On top of that, the first merge-based seed stamped nearly every member with the same `nowMs` (the added-at map misses those mints), leaving `MAX(added_at)` arbitrary.

## Changes

- **`_member-fallback-assets.ts`** (new, 6 unit tests) — extracts the "ensure every member is represented" loop out of the route and skips any mint already claimed by a canonical asset in the payload. Those mints now collapse into the asset row that owns them. Majors: 1481 → 31 rows. Metals: Silver once.
- **`getSummariesBySlugs`** — per-slug last-added becomes `GREATEST(member added_at, newest non-yield variant created_at)`, so a new variant on an existing member registers. Yield/LST variants are excluded from *this signal only*, so Sanctum churn can't permanently park SOL in the card.

The mint union is deliberately left as-is (and now documents why). Filtering yield variants out of it changed zero rows — the variant payload comes from `assetVariantsListByAssetIds`, not the mint list — but it dropped ~1.4k mints out of the batched prefetch and into the route's `missingMints` gapfill: ~12 extra sequential Cloud Run round-trips on the very tab being fixed.

## Verification

- 649 tests pass (190 api, 459 cloudrun-assets); typecheck and lint clean.
- Both SQL variants validated against a scratch Postgres reproducing the prod shape: member counts unchanged, metals → `silver` @ 14:12 today (beats stocks' 03:00:21 seed stamp, so the card shows Silver), and the newest-of-all Sanctum variants correctly ignored.
- No migration and no data repair required.

## Deploy

Both `apps/api` (Vercel) and `apps/cloudrun-assets` (Cloud Run). The metals duplicate needs only api; Latest Added needs both.

## Follow-ups (not in scope)

- `listMemberMintsBySlug` has `LIMIT 2000` and `solana` is rank 0 in majors with 1,464 variants — once the Sanctum set passes ~2,000 it starves the other members' mints. Invisible after this fix (rows come from the member asset-id list, markets from the gapfill), but the ceiling is closer than it looks.
- `list=majors&groupBy=mint` still emits a row per LST mint for `solana` (`shouldIncludeMintRow` only caps yield rows for `all`/`lsts`). Unchanged here and not user-visible — the web never requests that combination.
- Nothing in this repo writes the 1,463 `yield` variants on `solana` (the registry seed knows 14; the only other writers are the two admin flows), so they most likely arrived with the Convex-era migration. Worth confirming that's intentional.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
