### PR TITLE
Fix Grafana alert UID limit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,7 @@ jobs:
 
       - run: bun install --frozen-lockfile
       - run: bun run check:repo-hygiene
+      - run: bun run validate:grafana-config
       - run: bun run verify:api-health-routes
       - run: bun run lint
       - run: bun run typecheck

--- a/.github/workflows/grafana-push.yml
+++ b/.github/workflows/grafana-push.yml
@@ -28,6 +28,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Validate Grafana configuration
+        run: node scripts/validate-grafana-config.mjs
+
       - name: Install Doppler CLI
         uses: dopplerhq/cli-action@014df23b1329b615816a38eb5f473bb9000700b1 # v3
 

--- a/alert-rules/assets-db-connect-timeout-critical.json
+++ b/alert-rules/assets-db-connect-timeout-critical.json
@@ -1,5 +1,5 @@
 {
-    "uid": "tokens-assets-db-connect-timeout-critical",
+    "uid": "tokens-assets-db-timeout-critical",
     "title": "tokens-assets: Postgres connect timeouts > 300/10m",
     "ruleGroup": "tokens-assets-availability",
     "folderUID": "tokens-xyz",

--- a/alert-rules/assets-db-connect-timeout-warning.json
+++ b/alert-rules/assets-db-connect-timeout-warning.json
@@ -1,5 +1,5 @@
 {
-    "uid": "tokens-assets-db-connect-timeout-warning",
+    "uid": "tokens-assets-db-timeout-warning",
     "title": "tokens-assets: Postgres connect timeouts > 100/10m",
     "ruleGroup": "tokens-assets-availability",
     "folderUID": "tokens-xyz",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
         "typecheck": "turbo run typecheck",
         "test": "turbo run test",
         "check:repo-hygiene": "node scripts/check-repo-hygiene.mjs",
+        "validate:grafana-config": "node scripts/validate-grafana-config.mjs",
         "verify:api-health-routes": "bun scripts/verify-api-health-routes.ts",
         "audit:deps": "bun audit",
         "verify:assets-api-v1": "bun scripts/verify-assets-api-v1-contract.ts",

--- a/scripts/validate-grafana-config.mjs
+++ b/scripts/validate-grafana-config.mjs
@@ -1,0 +1,57 @@
+import { readFile, readdir } from 'node:fs/promises';
+import { join, relative } from 'node:path';
+
+const root = process.cwd();
+const jsonRoots = ['alert-rules', 'dashboards', 'notification-policies'];
+const errors = [];
+const alertUids = new Map();
+let checked = 0;
+
+async function jsonFiles(directory) {
+    const entries = await readdir(directory, { withFileTypes: true }).catch(error => {
+        if (error?.code === 'ENOENT') return [];
+        throw error;
+    });
+    const files = [];
+    for (const entry of entries) {
+        const path = join(directory, entry.name);
+        if (entry.isDirectory()) files.push(...(await jsonFiles(path)));
+        else if (entry.isFile() && entry.name.endsWith('.json')) files.push(path);
+    }
+    return files;
+}
+
+for (const directory of jsonRoots) {
+    for (const path of await jsonFiles(join(root, directory))) {
+        const displayPath = relative(root, path);
+        let document;
+        try {
+            document = JSON.parse(await readFile(path, 'utf8'));
+            checked += 1;
+        } catch (error) {
+            errors.push(`${displayPath}: invalid JSON (${error.message})`);
+            continue;
+        }
+
+        if (directory !== 'alert-rules') continue;
+        const uid = document?.uid;
+        if (typeof uid !== 'string' || uid.length === 0) {
+            errors.push(`${displayPath}: missing non-empty top-level uid`);
+            continue;
+        }
+        if (uid.length > 40) errors.push(`${displayPath}: alert uid is ${uid.length} characters; Grafana allows 40`);
+        if (!/^[A-Za-z0-9_-]+$/.test(uid)) {
+            errors.push(`${displayPath}: alert uid contains unsupported characters`);
+        }
+        const previous = alertUids.get(uid);
+        if (previous) errors.push(`${displayPath}: alert uid duplicates ${previous}`);
+        else alertUids.set(uid, displayPath);
+    }
+}
+
+if (errors.length > 0) {
+    for (const error of errors) console.error(`ERROR: ${error}`);
+    process.exit(1);
+}
+
+console.log(`Validated ${checked} Grafana JSON files (${alertUids.size} alert UIDs).`);


### PR DESCRIPTION
## Summary

- shorten the two assets DB timeout alert UIDs to stay within Grafana’s 40-character limit
- validate all Grafana JSON and alert UID constraints in normal PR CI
- run the same validation before the production Grafana push fetches credentials or mutates resources

## Validation

- `bun run validate:grafana-config`
- Prettier check for changed JSON, YAML, and JavaScript
- all 18 alert UIDs are unique and at most 40 characters

This repairs the failed post-merge Grafana workflow from #76. The preceding rule updates were idempotent; the failed critical and not-yet-reached warning rules will be created when this hotfix reaches `main`.