### PR TITLE
Fix assets and CoinGecko provider alert noise

### DIFF
--- a/alert-rules/assets-5xx-ratio-high.json
+++ b/alert-rules/assets-5xx-ratio-high.json
@@ -4,7 +4,7 @@
     "ruleGroup": "tokens-assets-availability",
     "folderUID": "tokens-xyz",
     "noDataState": "OK",
-    "execErrState": "Error",
+    "execErrState": "OK",
     "for": "2m",
     "data": [
         {
@@ -13,7 +13,7 @@
             "queryType": "range",
             "relativeTimeRange": { "from": 300, "to": 0 },
             "model": {
-                "expr": "sum(count_over_time({service=\"tokens-assets-prd-us\"} | json | httpRequest_status >= 500 [5m])) / clamp_min(sum(count_over_time({service=\"tokens-assets-prd-us\"} | json | httpRequest_requestMethod != \"\" [5m])), 1)",
+                "expr": "((sum(count_over_time({service=\"tokens-assets-prd-us\"} | json | httpRequest_status >= 500 [5m])) or on() vector(0)) / (sum(count_over_time({service=\"tokens-assets-prd-us\"} | json | httpRequest_requestMethod != \"\" [5m])) > 0)) or on() vector(0)",
                 "queryType": "range",
                 "refId": "A"
             }

--- a/apps/api/src/app/api/coingecko/news/route.ts
+++ b/apps/api/src/app/api/coingecko/news/route.ts
@@ -2,6 +2,7 @@ import { Effect } from 'effect';
 
 import { fetchJsonWithRetry } from '@tokens/effect';
 import { route } from '@/effect/next-route';
+import { createCoinGeckoNewsNotFoundRecovery, validateCoinGeckoNewsCoinId } from '@/lib/coingecko-news';
 import { getRedisClient, type RedisClient } from '@/lib/redis';
 import { tapErrorAndDefault } from '@tokens/effect';
 
@@ -90,6 +91,9 @@ export const GET = route(
             const coinId = (url.searchParams.get('coin_id') ?? '').trim();
             const perPage = parseNewsPerPage(url.searchParams.get('per_page'));
 
+            const validation = yield* validateCoinGeckoNewsCoinId(coinId);
+            if (!validation.shouldFetch) return [];
+
             const apiKey = process.env.COINGECKO_API_KEY?.trim();
             if (!apiKey) {
                 const shouldLog = yield* Effect.tryPromise(() =>
@@ -120,6 +124,7 @@ export const GET = route(
                     next: { revalidate: 60 },
                 },
                 maxRetries: 2,
+                recoverHttpError: createCoinGeckoNewsNotFoundRecovery<CoinGeckoNewsResponse>([]),
             }).pipe(
                 Effect.catch(error =>
                     Effect.gen(function* () {

--- a/apps/api/src/app/api/v1/news/feed/_feed-helpers.test.ts
+++ b/apps/api/src/app/api/v1/news/feed/_feed-helpers.test.ts
@@ -130,6 +130,19 @@ describe('selectFeedArticles', () => {
         expect(selected.slice(3).every(item => item.feed_source === 'coingecko')).toBe(true);
     });
 
+    it('retains X results when CoinGecko has no candidates', () => {
+        const selected = selectFeedArticles({
+            newsArticles: [],
+            xArticles,
+            limit: 10,
+            source: 'all',
+            tweetReserve: 3,
+        });
+
+        expect(selected.length).toBe(3);
+        expect(selected.every(item => item.feed_source === 'x')).toBe(true);
+    });
+
     it('removes unsafe URLs and never exceeds the limit', () => {
         const selected = selectFeedArticles({
             newsArticles: [

--- a/apps/api/src/app/api/v1/news/feed/route.ts
+++ b/apps/api/src/app/api/v1/news/feed/route.ts
@@ -2,6 +2,7 @@ import { Effect } from 'effect';
 
 import { fetchJsonWithRetry, tapErrorAndDefault } from '@tokens/effect';
 import { route } from '@/effect/next-route';
+import { createCoinGeckoNewsNotFoundRecovery, validateCoinGeckoNewsCoinId } from '@/lib/coingecko-news';
 import { resolveXBearerToken, runXRequest } from '@/lib/x-auth';
 import { buildMediaByKey, getPostImage, type XMedia, type XPostMediaAttachment } from '@/lib/x-media';
 import {
@@ -128,9 +129,15 @@ function mapCoinGeckoNewsArticle(article: CoinGeckoNewsArticle): FeedArticle {
 }
 
 async function fetchCoinGeckoNews(coinId: string, requestedCount: number): Promise<FeedArticle[]> {
+    if (requestedCount <= 0) return [];
+
+    const validation = await Effect.runPromise(validateCoinGeckoNewsCoinId(coinId));
+    if (!validation.shouldFetch) return [];
+
     const apiKey = process.env.COINGECKO_API_KEY?.trim();
     if (!apiKey) return [];
-    if (requestedCount <= 0) return [];
+
+    const recoverCoinNotFound = createCoinGeckoNewsNotFoundRecovery<CoinGeckoNewsResponse>([]);
 
     const pageCount = getCoinGeckoNewsPageCount({
         requestedCount,
@@ -148,18 +155,21 @@ async function fetchCoinGeckoNews(coinId: string, requestedCount: number): Promi
             upstreamUrl.searchParams.set('type', 'news');
             if (coinId) upstreamUrl.searchParams.set('coin_id', coinId);
 
-            return Effect.runPromise(fetchJsonWithRetry<CoinGeckoNewsResponse>({
-                url: upstreamUrl.toString(),
-                service: 'coingecko',
-                init: {
-                    headers: {
-                        Accept: 'application/json',
-                        'x-cg-pro-api-key': apiKey,
+            return Effect.runPromise(
+                fetchJsonWithRetry<CoinGeckoNewsResponse>({
+                    url: upstreamUrl.toString(),
+                    service: 'coingecko',
+                    init: {
+                        headers: {
+                            Accept: 'application/json',
+                            'x-cg-pro-api-key': apiKey,
+                        },
+                        next: { revalidate: 60 },
                     },
-                    next: { revalidate: 60 },
-                },
-                maxRetries: 2,
-            }));
+                    maxRetries: 2,
+                    recoverHttpError: recoverCoinNotFound,
+                }),
+            );
         },
         mapPageItems: articles => articles.filter(item => item && item.type === 'news').map(mapCoinGeckoNewsArticle),
         onPageError: (error, context) => {

--- a/apps/api/src/app/api/v1/news/feed/routes.test.ts
+++ b/apps/api/src/app/api/v1/news/feed/routes.test.ts
@@ -1,0 +1,196 @@
+import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test';
+
+mock.module('server-only', () => ({}));
+
+const { __resetCloudRunClientForTesting } = await import('@/lib/cloudrun/client');
+const { resetEnvForTests } = await import('@/lib/env');
+const { signPlaygroundProxyAuthPayload } = await import('@/effect/playground-proxy-auth');
+const { GET: legacyNewsGet } = await import('../../../coingecko/news/route');
+const { GET: feedGet } = await import('./route');
+
+const ORIGINAL_FETCH = globalThis.fetch;
+const ORIGINAL_LOG = console.log;
+const ORIGINAL_WARN = console.warn;
+const ORIGINAL_ERROR = console.error;
+
+const ENV_KEYS = [
+    'COINGECKO_API_KEY',
+    'TOKENS_CLOUDRUN_AUTH_TOKEN',
+    'TOKENS_CLOUDRUN_ASSETS_URL',
+    'TOKENS_CLOUDRUN_PRICES_URL',
+    'TOKENS_CLOUDRUN_USAGE_URL',
+    'TOKENS_PLAYGROUND_PROXY_SECRET',
+    'TOKENS_USAGE_LOG_MODE',
+    'TOKENS_REDIS_TARGET',
+    'UPSTASH_REDIS_REST_URL',
+    'UPSTASH_REDIS_REST_TOKEN',
+] as const;
+
+const savedEnv: Partial<Record<(typeof ENV_KEYS)[number], string>> = {};
+
+beforeEach(() => {
+    for (const key of ENV_KEYS) {
+        const value = process.env[key];
+        if (value !== undefined) savedEnv[key] = value;
+        else delete savedEnv[key];
+        delete process.env[key];
+    }
+
+    process.env.COINGECKO_API_KEY = 'enterprise-key';
+    process.env.TOKENS_CLOUDRUN_AUTH_TOKEN = 'cloudrun-token';
+    process.env.TOKENS_CLOUDRUN_ASSETS_URL = 'https://assets.example.run.app';
+    process.env.TOKENS_CLOUDRUN_PRICES_URL = 'https://prices.example.run.app';
+    process.env.TOKENS_CLOUDRUN_USAGE_URL = 'https://usage.example.run.app';
+    process.env.TOKENS_PLAYGROUND_PROXY_SECRET = 'test-playground-secret';
+    process.env.TOKENS_USAGE_LOG_MODE = 'off';
+    resetEnvForTests();
+    __resetCloudRunClientForTesting();
+
+    console.log = () => undefined;
+    console.warn = () => undefined;
+    console.error = () => undefined;
+});
+
+afterEach(() => {
+    globalThis.fetch = ORIGINAL_FETCH;
+    console.log = ORIGINAL_LOG;
+    console.warn = ORIGINAL_WARN;
+    console.error = ORIGINAL_ERROR;
+
+    for (const key of ENV_KEYS) {
+        const value = savedEnv[key];
+        if (value === undefined) delete process.env[key];
+        else process.env[key] = value;
+    }
+    resetEnvForTests();
+    __resetCloudRunClientForTesting();
+});
+
+async function authHeader(): Promise<string> {
+    const now = Date.now();
+    return signPlaygroundProxyAuthPayload({
+        apiKeyId: 'test-key',
+        keyPrefix: 'tk_test',
+        projectId: 'test-project',
+        ownerClerkUserId: 'test-user',
+        scopes: ['assets:read'],
+        iat: now,
+        exp: now + 60_000,
+    });
+}
+
+function newsArticle() {
+    return {
+        title: 'Bitcoin update',
+        url: 'https://example.com/bitcoin',
+        image: '',
+        author: 'Reporter',
+        posted_at: '2026-08-15T12:00:00.000Z',
+        type: 'news',
+        source_name: 'Example',
+        related_coin_ids: ['bitcoin'],
+    };
+}
+
+async function request(
+    handler: (request: Request, context: never) => Promise<Response>,
+    path: string,
+): Promise<Response> {
+    return handler(
+        new Request(`https://api.example.test${path}`, {
+            headers: { 'x-tokens-playground-auth': await authHeader() },
+        }),
+        {} as never,
+    );
+}
+
+describe('CoinGecko news route catalog boundary', () => {
+    it('lets active ids reach CoinGecko in both news routes', async () => {
+        let upstreamCalls = 0;
+        globalThis.fetch = (async (input: string | URL | Request) => {
+            const url = String(input);
+            if (url.includes('/query/coingeckoReadsGetCoinById')) {
+                return new Response(JSON.stringify({ lastSyncedAt: Date.now() }), { status: 200 });
+            }
+            if (url.startsWith('https://pro-api.coingecko.com/api/v3/news')) {
+                upstreamCalls += 1;
+                return new Response(JSON.stringify([newsArticle()]), { status: 200 });
+            }
+            throw new Error(`Unexpected fetch: ${url}`);
+        }) as typeof fetch;
+
+        const feedResponse = await request(feedGet, '/api/v1/news/feed?source=news&coin_id=bitcoin');
+        const legacyResponse = await request(legacyNewsGet, '/api/coingecko/news?coin_id=bitcoin');
+
+        expect(feedResponse.status).toBe(200);
+        expect(legacyResponse.status).toBe(200);
+        expect(upstreamCalls).toBe(2);
+    });
+
+    it('skips a missing internal id in both news routes without an upstream call', async () => {
+        let upstreamCalls = 0;
+        globalThis.fetch = (async (input: string | URL | Request) => {
+            const url = String(input);
+            if (url.includes('/query/coingeckoReadsGetCoinById')) {
+                return new Response('null', { status: 200 });
+            }
+            if (url.startsWith('https://pro-api.coingecko.com/api/v3/news')) {
+                upstreamCalls += 1;
+                return new Response(JSON.stringify([newsArticle()]), { status: 200 });
+            }
+            throw new Error(`Unexpected fetch: ${url}`);
+        }) as typeof fetch;
+
+        const feedResponse = await request(feedGet, '/api/v1/news/feed?source=news&coin_id=stock-tzuc3szn');
+        const legacyResponse = await request(legacyNewsGet, '/api/coingecko/news?coin_id=stock-tzuc3szn');
+        const feedBody = (await feedResponse.json()) as { items: unknown[] };
+        const legacyBody = (await legacyResponse.json()) as unknown[];
+
+        expect(feedResponse.status).toBe(200);
+        expect(legacyResponse.status).toBe(200);
+        expect(feedBody.items).toEqual([]);
+        expect(legacyBody).toEqual([]);
+        expect(upstreamCalls).toBe(0);
+    });
+
+    it('returns HTTP 200 with an empty feed when catalog validation fails', async () => {
+        globalThis.fetch = (async (input: string | URL | Request) => {
+            const url = String(input);
+            if (url.includes('/query/coingeckoReadsGetCoinById')) {
+                return new Response('catalog unavailable', { status: 500 });
+            }
+            throw new Error(`Unexpected fetch: ${url}`);
+        }) as typeof fetch;
+
+        const response = await request(feedGet, '/api/v1/news/feed?source=news&coin_id=bitcoin');
+        const body = (await response.json()) as { items: unknown[] };
+
+        expect(response.status).toBe(200);
+        expect(body.items).toEqual([]);
+    });
+
+    it('continues to fetch global news without a catalog lookup', async () => {
+        let catalogCalls = 0;
+        let upstreamCalls = 0;
+        globalThis.fetch = (async (input: string | URL | Request) => {
+            const url = String(input);
+            if (url.includes('/query/coingeckoReadsGetCoinById')) {
+                catalogCalls += 1;
+                return new Response('null', { status: 200 });
+            }
+            if (url.startsWith('https://pro-api.coingecko.com/api/v3/news')) {
+                upstreamCalls += 1;
+                return new Response(JSON.stringify([newsArticle()]), { status: 200 });
+            }
+            throw new Error(`Unexpected fetch: ${url}`);
+        }) as typeof fetch;
+
+        const response = await request(feedGet, '/api/v1/news/feed?source=news');
+        const body = (await response.json()) as { items: unknown[] };
+
+        expect(response.status).toBe(200);
+        expect(body.items.length).toBe(1);
+        expect(catalogCalls).toBe(0);
+        expect(upstreamCalls).toBe(1);
+    });
+});

--- a/apps/api/src/lib/coingecko-news.test.ts
+++ b/apps/api/src/lib/coingecko-news.test.ts
@@ -1,0 +1,155 @@
+import { afterEach, describe, expect, it } from 'bun:test';
+import { Effect } from 'effect';
+
+import { fetchJsonWithRetry, UpstreamHttpError } from '@tokens/effect';
+import {
+    COINGECKO_NEWS_CATALOG_FRESHNESS_MS,
+    createCoinGeckoNewsNotFoundRecovery,
+    validateCoinGeckoNewsCoinId,
+} from './coingecko-news';
+
+const NOW = Date.UTC(2026, 7, 15, 12);
+const ORIGINAL_FETCH = globalThis.fetch;
+const ORIGINAL_LOG = console.log;
+
+afterEach(() => {
+    globalThis.fetch = ORIGINAL_FETCH;
+    console.log = ORIGINAL_LOG;
+});
+
+describe('validateCoinGeckoNewsCoinId', () => {
+    it('allows an active catalog id', async () => {
+        const result = await Effect.runPromise(
+            validateCoinGeckoNewsCoinId('bitcoin', {
+                lookup: () => Effect.succeed({ lastSyncedAt: NOW - COINGECKO_NEWS_CATALOG_FRESHNESS_MS + 1 }),
+                now: () => NOW,
+            }),
+        );
+
+        expect(result).toEqual({ shouldFetch: true });
+    });
+
+    it('skips a missing internal-looking id and emits the reason', async () => {
+        const events: Record<string, unknown>[] = [];
+        const result = await Effect.runPromise(
+            validateCoinGeckoNewsCoinId('stock-tzuc3szn', {
+                lookup: () => Effect.succeed(null),
+                now: () => NOW,
+                emit: event => events.push(event),
+            }),
+        );
+
+        expect(result).toEqual({ shouldFetch: false, reason: 'missing' });
+        expect(events).toEqual([
+            {
+                event: 'coingecko_news_skipped',
+                coin_id: 'stock-tzuc3szn',
+                reason: 'missing',
+            },
+        ]);
+    });
+
+    it('skips a stale catalog row', async () => {
+        const result = await Effect.runPromise(
+            validateCoinGeckoNewsCoinId('old-coin', {
+                lookup: () => Effect.succeed({ lastSyncedAt: NOW - COINGECKO_NEWS_CATALOG_FRESHNESS_MS - 1 }),
+                now: () => NOW,
+                emit: () => undefined,
+            }),
+        );
+
+        expect(result).toEqual({ shouldFetch: false, reason: 'stale' });
+    });
+
+    it('fails closed when catalog validation is unavailable', async () => {
+        const events: Record<string, unknown>[] = [];
+        const result = await Effect.runPromise(
+            validateCoinGeckoNewsCoinId('bitcoin', {
+                lookup: () => Effect.fail(new Error('catalog unavailable')),
+                emit: event => events.push(event),
+            }),
+        );
+
+        expect(result).toEqual({ shouldFetch: false, reason: 'validation_unavailable' });
+        expect(events[0]).toEqual({
+            event: 'coingecko_news_skipped',
+            coin_id: 'bitcoin',
+            reason: 'validation_unavailable',
+        });
+    });
+
+    it('leaves global news unchanged without consulting the catalog', async () => {
+        let lookupCount = 0;
+        const result = await Effect.runPromise(
+            validateCoinGeckoNewsCoinId('   ', {
+                lookup: () => {
+                    lookupCount += 1;
+                    return Effect.succeed(null);
+                },
+            }),
+        );
+
+        expect(result).toEqual({ shouldFetch: true });
+        expect(lookupCount).toBe(0);
+    });
+});
+
+describe('createCoinGeckoNewsNotFoundRecovery', () => {
+    const recover = createCoinGeckoNewsNotFoundRecovery<string[]>([]);
+
+    function error(body: string, status = 404) {
+        return new UpstreamHttpError({
+            message: 'CoinGecko request failed',
+            service: 'coingecko',
+            status,
+            statusText: 'Not Found',
+            body,
+        });
+    }
+
+    it('recovers the exact CoinGecko lookup miss as an empty result', () => {
+        expect(recover(error(JSON.stringify({ error_code: 404, error_message: 'Coin not found.' })))).toEqual({
+            value: [],
+            outcome: 'coin_not_found',
+        });
+    });
+
+    it('emits recovered success telemetry for the exact lookup miss', async () => {
+        const logs: string[] = [];
+        console.log = (...args: unknown[]) => logs.push(String(args[0]));
+        globalThis.fetch = (async () =>
+            new Response(JSON.stringify({ error_code: 404, error_message: 'Coin not found.' }), {
+                status: 404,
+                statusText: 'Not Found',
+            })) as typeof fetch;
+
+        const result = await Effect.runPromise(
+            fetchJsonWithRetry<string[]>({
+                url: 'https://pro-api.coingecko.com/api/v3/news?coin_id=catalog-race',
+                service: 'coingecko',
+                maxRetries: 0,
+                recoverHttpError: recover,
+            }),
+        );
+        const event = logs
+            .map(line => JSON.parse(line) as Record<string, unknown>)
+            .find(line => line.event === 'external_call');
+
+        expect(result).toEqual([]);
+        expect(event?.provider).toBe('coingecko');
+        expect(event?.endpoint).toBe('/api/v3/news');
+        expect(event?.status).toBe(404);
+        expect(event?.ok).toBe(true);
+        expect(event?.recovered).toBe(true);
+        expect(event?.outcome).toBe('coin_not_found');
+    });
+
+    it('does not recover a different 404 body', () => {
+        expect(recover(error(JSON.stringify({ error_code: 404, error_message: 'Endpoint not found.' })))).toBeNull();
+        expect(recover(error('<html>Not found</html>'))).toBeNull();
+    });
+
+    it('does not recover the same body for another status', () => {
+        expect(recover(error(JSON.stringify({ error_code: 404, error_message: 'Coin not found.' }), 500))).toBeNull();
+    });
+});

--- a/apps/api/src/lib/coingecko-news.ts
+++ b/apps/api/src/lib/coingecko-news.ts
@@ -1,0 +1,93 @@
+import { Effect } from 'effect';
+
+import { emitEvent, type FetchHttpRecovery, type UpstreamHttpError } from '@tokens/effect';
+import { coingeckoGetCoinById } from '@/lib/cloudrun';
+
+export const COINGECKO_NEWS_CATALOG_FRESHNESS_MS = 15 * 24 * 60 * 60 * 1000;
+
+export type CoinGeckoNewsSkipReason = 'missing' | 'stale' | 'validation_unavailable';
+
+export type CoinGeckoNewsValidation = { shouldFetch: true } | { shouldFetch: false; reason: CoinGeckoNewsSkipReason };
+
+interface CoinGeckoCatalogEntry {
+    lastSyncedAt: number;
+}
+
+interface CoinGeckoNewsValidationOptions {
+    lookup?: (coinId: string) => Effect.Effect<CoinGeckoCatalogEntry | null, unknown>;
+    now?: () => number;
+    emit?: (entry: Record<string, unknown>) => void;
+}
+
+export function classifyCoinGeckoNewsCoinId(
+    entry: CoinGeckoCatalogEntry | null,
+    nowMs: number,
+): CoinGeckoNewsValidation {
+    if (!entry) return { shouldFetch: false, reason: 'missing' };
+    if (!Number.isFinite(entry.lastSyncedAt) || entry.lastSyncedAt < nowMs - COINGECKO_NEWS_CATALOG_FRESHNESS_MS) {
+        return { shouldFetch: false, reason: 'stale' };
+    }
+    return { shouldFetch: true };
+}
+
+/**
+ * Gate coin-specific news against the synchronized CoinGecko catalog. Global
+ * news has no coin id and deliberately bypasses catalog validation.
+ */
+export function validateCoinGeckoNewsCoinId(
+    rawCoinId: string,
+    options: CoinGeckoNewsValidationOptions = {},
+): Effect.Effect<CoinGeckoNewsValidation, never> {
+    const coinId = rawCoinId.trim();
+    if (!coinId) return Effect.succeed({ shouldFetch: true });
+
+    const lookup = options.lookup ?? (id => coingeckoGetCoinById({ id }));
+    const now = options.now ?? Date.now;
+    const emit = options.emit ?? emitEvent;
+
+    return lookup(coinId).pipe(
+        Effect.map(entry => classifyCoinGeckoNewsCoinId(entry, now())),
+        Effect.catch(() =>
+            Effect.succeed({
+                shouldFetch: false as const,
+                reason: 'validation_unavailable' as const,
+            }),
+        ),
+        Effect.tap(result =>
+            result.shouldFetch
+                ? Effect.void
+                : Effect.sync(() =>
+                      emit({
+                          event: 'coingecko_news_skipped',
+                          coin_id: coinId,
+                          reason: result.reason,
+                      }),
+                  ),
+        ),
+    );
+}
+
+function isExactCoinNotFoundBody(body: string | undefined): boolean {
+    if (!body) return false;
+
+    try {
+        const parsed = JSON.parse(body) as unknown;
+        if (!parsed || typeof parsed !== 'object') return false;
+        const value = parsed as Record<string, unknown>;
+        return value.error_code === 404 && value.error_message === 'Coin not found.';
+    } catch {
+        return false;
+    }
+}
+
+/** Recover only CoinGecko's exact coin lookup miss, not an absent endpoint. */
+export function createCoinGeckoNewsNotFoundRecovery<T>(
+    emptyValue: T,
+): (error: UpstreamHttpError) => FetchHttpRecovery<T> | null {
+    return error => {
+        if (error._tag !== 'UpstreamHttpError' || error.status !== 404 || !isExactCoinNotFoundBody(error.body)) {
+            return null;
+        }
+        return { value: emptyValue, outcome: 'coin_not_found' };
+    };
+}

--- a/apps/docs/content/docs/v1/endpoints/news-feed.mdx
+++ b/apps/docs/content/docs/v1/endpoints/news-feed.mdx
@@ -22,7 +22,7 @@ Return the filterable activity feed used by the floating market feed.
 - `limit` (optional): integer `1–50`, default `10`
 - `source` (optional): `all`, `news`, or `tweets`, default `all`
 - `tweet_reserve` (optional): integer `0–limit`, default `3`. Reserves visible slots for matching `@tokens` posts when `source=all`.
-- `coin_id` (optional): CoinGecko coin id, such as `bitcoin` or `solana`
+- `coin_id` (optional): active CoinGecko coin id, such as `bitcoin` or `solana`
 - `symbol` (optional): token symbol used to match related `@tokens` posts, such as `BTC`
 - `name` (optional): token/display name used to match related `@tokens` posts, such as `Bitcoin`
 - `asset_id` (optional): canonical asset id used as an additional matching term
@@ -88,6 +88,7 @@ curl -sS "$API_BASE_URL/v1/news/feed?terms=solana,SOL&source=tweets&limit=50" \
 - `feed_source="coingecko"` items come from CoinGecko news.
 - `feed_source="x"` items come from `@tokens` on X.
 - In token mode, `@tokens` posts are included only when their text/source metadata matches the supplied token terms.
+- Unknown or stale `coin_id` values produce no CoinGecko items. With `source=all`, matching X items may still be returned.
 - `limit` supports up to `50`; larger values are clamped to `50`.
 - `tweet_reserve` is ignored for single-source feeds (`source=news` or `source=tweets`).
-- Upstream provider failures are best-effort: the endpoint can return a partial feed when either CoinGecko or X is unavailable.
+- Provider content is best-effort: unknown or stale CoinGecko ids and upstream provider failures return an empty or partial feed with HTTP `200`, rather than failing the request.

--- a/bun.lock
+++ b/bun.lock
@@ -9,6 +9,8 @@
         "hono": "^4.13.0",
       },
       "devDependencies": {
+        "@grafana/lezer-logql": "0.3.0",
+        "@lezer/lr": "1.4.10",
         "@solana/prettier-config-solana": "^0.0.5",
         "@tokens/asset-registry": "workspace:*",
         "@tokens/token-risk-helpers": "workspace:*",
@@ -557,6 +559,8 @@
 
     "@google-cloud/storage": ["@google-cloud/storage@7.21.0", "", { "dependencies": { "@google-cloud/paginator": "^5.0.0", "@google-cloud/projectify": "^4.0.0", "@google-cloud/promisify": "<4.1.0", "abort-controller": "^3.0.0", "async-retry": "^1.3.3", "duplexify": "^4.1.3", "fast-xml-parser": "^5.3.4", "gaxios": "^6.0.2", "google-auth-library": "^9.6.3", "html-entities": "^2.5.2", "mime": "^3.0.0", "p-limit": "^3.0.1", "retry-request": "^7.0.0", "teeny-request": "^9.0.0" } }, "sha512-l+IFTkd+6Y5LoAuXyYCKNAKtw/Ci+rAMqgdTB1jv4iZiLhw0rtq+0qjIRbBizXkNzEFmXiXUW0H7sZQQvk1ffA=="],
 
+    "@grafana/lezer-logql": ["@grafana/lezer-logql@0.3.0", "", { "peerDependencies": { "@lezer/lr": "^1.0.0" } }, "sha512-375VvHfjm/JgBg+VP/V2M/PElaUzvmIcv+K6nJ1q+aWBSFqilELRobKGrBzS4T6jDHRFuXTYADOstDU3GcedRQ=="],
+
     "@heroicons/react": ["@heroicons/react@2.2.0", "", { "peerDependencies": { "react": ">= 16 || ^19.0.0-rc" } }, "sha512-LMcepvRaS9LYHJGsF0zzmgKCUim/X3N/DQKc4jepAXJ7l8QxJ1PmxJzqplF2Z3FE4PqBAIGyJAQ/w4B5dsqbtQ=="],
 
     "@humanfs/core": ["@humanfs/core@0.19.1", "", {}, "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA=="],
@@ -636,6 +640,10 @@
     "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
 
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
+
+    "@lezer/common": ["@lezer/common@1.5.2", "", {}, "sha512-sxQE460fPZyU3sdc8lafxiPwJHBzZRy/udNFynGQky1SePYBdhkBl1kOagA9uT3pxR8K09bOrmTUqA9wb/PjSQ=="],
+
+    "@lezer/lr": ["@lezer/lr@1.4.10", "", { "dependencies": { "@lezer/common": "^1.0.0" } }, "sha512-rnCpTIBafOx4mRp43xOxDJbFipJm/c0cia/V5TiGlhmMa+wsSdoGmUN3w5Bqrks/09Q/D4tNAmWaT8p6NRi77A=="],
 
     "@mdx-js/mdx": ["@mdx-js/mdx@3.1.1", "", { "dependencies": { "@types/estree": "^1.0.0", "@types/estree-jsx": "^1.0.0", "@types/hast": "^3.0.0", "@types/mdx": "^2.0.0", "acorn": "^8.0.0", "collapse-white-space": "^2.0.0", "devlop": "^1.0.0", "estree-util-is-identifier-name": "^3.0.0", "estree-util-scope": "^1.0.0", "estree-walker": "^3.0.0", "hast-util-to-jsx-runtime": "^2.0.0", "markdown-extensions": "^2.0.0", "recma-build-jsx": "^1.0.0", "recma-jsx": "^1.0.0", "recma-stringify": "^1.0.0", "rehype-recma": "^1.0.0", "remark-mdx": "^3.0.0", "remark-parse": "^11.0.0", "remark-rehype": "^11.0.0", "source-map": "^0.7.0", "unified": "^11.0.0", "unist-util-position-from-estree": "^2.0.0", "unist-util-stringify-position": "^4.0.0", "unist-util-visit": "^5.0.0", "vfile": "^6.0.0" } }, "sha512-f6ZO2ifpwAQIpzGWaBQT2TXxPv6z3RBzQKpVftEWN78Vl/YweF1uwussDx8ECAXVtr3Rs89fKyG9YlzUs9DyGQ=="],
 

--- a/dashboards/assets-db-resilience.json
+++ b/dashboards/assets-db-resilience.json
@@ -122,7 +122,7 @@
                 },
                 {
                     "refId": "B",
-                    "expr": "100 * sum(count_over_time({service=\"tokens-assets-prd-us\"} | json | httpRequest_status >= 500 [$__interval])) / clamp_min(sum(count_over_time({service=\"tokens-assets-prd-us\"} | json | httpRequest_requestMethod != \"\" [$__interval])), 1)",
+                    "expr": "100 * (((sum(count_over_time({service=\"tokens-assets-prd-us\"} | json | httpRequest_status >= 500 [$__interval])) or on() vector(0)) / (sum(count_over_time({service=\"tokens-assets-prd-us\"} | json | httpRequest_requestMethod != \"\" [$__interval])) > 0)) or on() vector(0))",
                     "legendFormat": "5xx percent"
                 }
             ],

--- a/package.json
+++ b/package.json
@@ -33,6 +33,8 @@
         "hono": "^4.13.0"
     },
     "devDependencies": {
+        "@grafana/lezer-logql": "0.3.0",
+        "@lezer/lr": "1.4.10",
         "@solana/prettier-config-solana": "^0.0.5",
         "@tokens/asset-registry": "workspace:*",
         "@tokens/token-risk-helpers": "workspace:*",

--- a/packages/effect/src/fetch.test.ts
+++ b/packages/effect/src/fetch.test.ts
@@ -1,0 +1,109 @@
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import { Effect } from 'effect';
+import { fetchJsonWithRetry } from './fetch';
+
+const ORIGINAL_FETCH = globalThis.fetch;
+const ORIGINAL_LOG = console.log;
+
+let logs: string[] = [];
+
+beforeEach(() => {
+    logs = [];
+    console.log = (...args: unknown[]) => {
+        logs.push(String(args[0]));
+    };
+});
+
+afterEach(() => {
+    globalThis.fetch = ORIGINAL_FETCH;
+    console.log = ORIGINAL_LOG;
+});
+
+function respond(status: number, body: string, statusText = 'Error'): void {
+    globalThis.fetch = (async () => new Response(body, { status, statusText })) as typeof fetch;
+}
+
+function recoverCoinNotFound(error: { status: number; body?: string }) {
+    if (error.status !== 404 || !error.body) return null;
+
+    try {
+        const body = JSON.parse(error.body) as { error_code?: unknown; error_message?: unknown };
+        return body.error_code === 404 && body.error_message === 'Coin not found.'
+            ? { value: [] as string[], outcome: 'coin_not_found' }
+            : null;
+    } catch {
+        return null;
+    }
+}
+
+describe('fetchJsonWithRetry HTTP recovery', () => {
+    it('recovers a matching HTTP error before emitting success telemetry', async () => {
+        respond(404, JSON.stringify({ error_code: 404, error_message: 'Coin not found.' }), 'Not Found');
+
+        const result = await Effect.runPromise(
+            fetchJsonWithRetry<string[]>({
+                url: 'https://pro-api.coingecko.com/api/v3/news?coin_id=missing',
+                service: 'coingecko',
+                maxRetries: 0,
+                recoverHttpError: recoverCoinNotFound,
+            }),
+        );
+
+        expect(result).toEqual([]);
+        const event = logs
+            .map(line => JSON.parse(line) as Record<string, unknown>)
+            .find(line => line.event === 'external_call');
+        expect(event).toMatchObject({
+            event: 'external_call',
+            provider: 'coingecko',
+            endpoint: '/api/v3/news',
+            status: 404,
+            ok: true,
+            recovered: true,
+            outcome: 'coin_not_found',
+        });
+        expect(event?.error_tag).toBeUndefined();
+    });
+
+    it('keeps a different 404 body as an UpstreamHttpError', async () => {
+        respond(404, JSON.stringify({ error_code: 404, error_message: 'Endpoint not found.' }), 'Not Found');
+
+        const error = await Effect.runPromise(
+            Effect.flip(
+                fetchJsonWithRetry<string[]>({
+                    url: 'https://pro-api.coingecko.com/api/v3/news',
+                    service: 'coingecko',
+                    maxRetries: 0,
+                    recoverHttpError: recoverCoinNotFound,
+                }),
+            ),
+        );
+
+        expect(error).toMatchObject({ _tag: 'UpstreamHttpError', status: 404 });
+        const event = logs
+            .map(line => JSON.parse(line) as Record<string, unknown>)
+            .find(line => line.event === 'external_call');
+        expect(event).toMatchObject({ ok: false, status: 404, error_tag: 'UpstreamHttpError' });
+    });
+
+    it.each([
+        [401, 'UpstreamHttpError'],
+        [429, 'RateLimitedError'],
+        [500, 'UpstreamHttpError'],
+    ] as const)('does not recover HTTP %s', async (status, tag) => {
+        respond(status, JSON.stringify({ error_code: status, error_message: 'Different failure.' }));
+
+        const error = await Effect.runPromise(
+            Effect.flip(
+                fetchJsonWithRetry<string[]>({
+                    url: 'https://pro-api.coingecko.com/api/v3/news',
+                    service: 'coingecko',
+                    maxRetries: 0,
+                    recoverHttpError: recoverCoinNotFound,
+                }),
+            ),
+        );
+
+        expect(error._tag).toBe(tag);
+    });
+});

--- a/packages/effect/src/fetch.ts
+++ b/packages/effect/src/fetch.ts
@@ -25,6 +25,11 @@ export interface FetchJsonArgs {
 
 export type FetchJsonError = RateLimitedError | UpstreamHttpError | FetchFailedError | JsonParseError | UpstreamDataError;
 
+export interface FetchHttpRecovery<T> {
+    value: T;
+    outcome: string;
+}
+
 function parseRetryAfterMs(value: string | null): number | undefined {
     if (!value) return undefined;
     const trimmed = value.trim();
@@ -149,7 +154,11 @@ export function fetchJson<T = unknown>(args: FetchJsonArgs): Effect.Effect<T, Fe
 }
 
 export function fetchJsonWithRetry<T = unknown>(
-    args: FetchJsonArgs & { maxRetries?: number; baseDelay?: Duration.Input },
+    args: FetchJsonArgs & {
+        maxRetries?: number;
+        baseDelay?: Duration.Input;
+        recoverHttpError?: (error: UpstreamHttpError) => FetchHttpRecovery<T> | null;
+    },
 ): Effect.Effect<T, FetchJsonError> {
     const maxRetries = Math.max(0, args.maxRetries ?? 3);
     const baseDelay = args.baseDelay ?? '200 millis';
@@ -157,20 +166,36 @@ export function fetchJsonWithRetry<T = unknown>(
     const started = Date.now();
     const endpoint = extractEndpoint(args.url);
 
-    return Effect.retry(fetchJson<T>(args), {
+    const request = Effect.retry(fetchJson<T>(args), {
         while: isRetryableFetchError,
         times: maxRetries,
         schedule: Schedule.exponential(baseDelay),
     }).pipe(
-        Effect.tap(() =>
+        Effect.map(value => ({ value, recovered: false as const })),
+        Effect.catchTag('UpstreamHttpError', error => {
+            const recovery = args.recoverHttpError?.(error) ?? null;
+            if (!recovery) return Effect.fail(error);
+
+            return Effect.succeed({
+                value: recovery.value,
+                recovered: true as const,
+                status: error.status,
+                outcome: recovery.outcome,
+            });
+        }),
+    );
+
+    return request.pipe(
+        Effect.tap(result =>
             Effect.service(CurrentRequestId).pipe(
                 Effect.map(requestId =>
                     emitExternalCall({
                         provider: args.service,
                         endpoint,
-                        status: null,
+                        status: result.recovered ? result.status : null,
                         duration_ms: Date.now() - started,
                         ok: true,
+                        ...(result.recovered ? { recovered: true, outcome: result.outcome } : {}),
                         ...(requestId ? { request_id: requestId } : {}),
                     }),
                 ),
@@ -191,6 +216,7 @@ export function fetchJsonWithRetry<T = unknown>(
                 ),
             ),
         ),
+        Effect.map(result => result.value),
         Effect.withSpan(`external.${args.service}`),
     );
 }
@@ -222,6 +248,8 @@ interface ExternalCallEvent {
     duration_ms: number;
     ok: boolean;
     error_tag?: string;
+    recovered?: boolean;
+    outcome?: string;
     request_id?: string;
 }
 

--- a/scripts/validate-grafana-config.mjs
+++ b/scripts/validate-grafana-config.mjs
@@ -1,3 +1,4 @@
+import { parser as logqlParser } from '@grafana/lezer-logql';
 import { readFile, readdir } from 'node:fs/promises';
 import { join, relative } from 'node:path';
 
@@ -6,6 +7,7 @@ const jsonRoots = ['alert-rules', 'dashboards', 'notification-policies'];
 const errors = [];
 const alertUids = new Map();
 let checked = 0;
+let logqlExpressions = 0;
 
 async function jsonFiles(directory) {
     const entries = await readdir(directory, { withFileTypes: true }).catch(error => {
@@ -21,6 +23,48 @@ async function jsonFiles(directory) {
     return files;
 }
 
+function collectExpressions(value, path = '$', expressions = []) {
+    if (Array.isArray(value)) {
+        value.forEach((item, index) => collectExpressions(item, `${path}[${index}]`, expressions));
+        return expressions;
+    }
+    if (!value || typeof value !== 'object') return expressions;
+
+    for (const [key, item] of Object.entries(value)) {
+        const itemPath = `${path}.${key}`;
+        if (key === 'expr' && typeof item === 'string') expressions.push({ path: itemPath, query: item });
+        collectExpressions(item, itemPath, expressions);
+    }
+    return expressions;
+}
+
+function normalizeGrafanaMacros(query) {
+    return query.replaceAll('$__rate_interval', '5m').replaceAll('$__interval', '5m');
+}
+
+function queryFragment(query, from, to) {
+    const context = 30;
+    const start = Math.max(0, from - context);
+    const end = Math.min(query.length, Math.max(to, from + 1) + context);
+    return query.slice(start, end);
+}
+
+function validateLogql(displayPath, document) {
+    for (const expression of collectExpressions(document)) {
+        logqlExpressions += 1;
+        const query = normalizeGrafanaMacros(expression.query);
+        logqlParser.parse(query).iterate({
+            enter(node) {
+                if (!node.type.isError) return;
+                const fragment = queryFragment(query, node.from, node.to);
+                errors.push(
+                    `${displayPath} ${expression.path}: invalid LogQL at ${node.from}-${node.to} near ${JSON.stringify(fragment)}`,
+                );
+            },
+        });
+    }
+}
+
 for (const directory of jsonRoots) {
     for (const path of await jsonFiles(join(root, directory))) {
         const displayPath = relative(root, path);
@@ -31,6 +75,10 @@ for (const directory of jsonRoots) {
         } catch (error) {
             errors.push(`${displayPath}: invalid JSON (${error.message})`);
             continue;
+        }
+
+        if (directory === 'alert-rules' || directory === 'dashboards') {
+            validateLogql(displayPath, document);
         }
 
         if (directory !== 'alert-rules') continue;
@@ -54,4 +102,6 @@ if (errors.length > 0) {
     process.exit(1);
 }
 
-console.log(`Validated ${checked} Grafana JSON files (${alertUids.size} alert UIDs).`);
+console.log(
+    `Validated ${checked} Grafana JSON files (${alertUids.size} alert UIDs, ${logqlExpressions} LogQL expressions).`,
+);


### PR DESCRIPTION
## Summary

- replace unsupported `clamp_min()` usage with Loki's zero-safe ratio pattern in the assets 5xx alert and DB resilience dashboard
- set the assets rule evaluation error state to `OK` so query failures do not page as user-facing outages
- parse all checked-in alert and dashboard LogQL in CI, with actionable file, JSON path, position, and query-fragment errors
- validate coin-specific CoinGecko news requests against the synchronized catalog and its 15-day freshness window
- skip missing, stale, or unverifiable `coin_id` values before making a paid CoinGecko request
- recover only CoinGecko's exact `404 Coin not found` lookup response as an empty result with `ok=true` telemetry

## Root causes

### Assets DatasourceError

Grafana was firing its `DatasourceError` meta-alert because `clamp_min()` is a PromQL-only function and the Loki query failed to parse on every evaluation. The same invalid expression also broke the dashboard's 5xx percentage panel.

### CoinGecko provider alert

The Enterprise API and `/api/v3/news` endpoint are healthy. Internal asset IDs and unsupported stock, ETF, and RWA slugs were being passed as CoinGecko `coin_id` values. CoinGecko returned `404 {"error_code":404,"error_message":"Coin not found."}`, which was logged as `external_call ok=false` and tripped the low-volume provider error-rate alert.

## CoinGecko behavior after this change

- active catalog IDs continue to fetch CoinGecko news
- missing or stale IDs return an empty CoinGecko result without an upstream request
- catalog validation failures fail closed because news is best-effort
- global news requests without `coin_id` remain unchanged
- mixed feeds can still return matching X items when CoinGecko is skipped
- exact `404 Coin not found` catalog races emit `ok=true`, `recovered=true`, and `outcome=coin_not_found`
- different 404 responses, 401s, 429s, transport failures, and 5xx responses remain provider errors
- no Grafana threshold, traffic-floor, or provider-wide 404 exclusion changes are included

## Validation

- `bun test packages/effect/src/fetch.test.ts`
- `bun test apps/api/src/lib/coingecko-news.test.ts`
- `bun test apps/api/src/app/api/v1/news/feed`
- route-level coverage for active, missing, validation-unavailable, and global requests across both news routes
- `bun run validate:grafana-config` (25 files, 18 alert UIDs, 68 LogQL expressions)
- validator under Node 20
- negative `clamp_min()` fixture exits nonzero with file/path/error context
- `bun run check:repo-hygiene`
- `bun run lint`
- `bun run typecheck`
- `bun run test`
- `bun run build`
- `git diff --check`

## Post-merge verification

After the Grafana push and API deployment complete:

- confirm the assets rule evaluates normally, the existing `DatasourceError` resolves, and the dashboard percentage panel renders
- confirm `coingecko_news_skipped` contains the previously failing internal, stock, ETF, and RWA identifiers
- confirm skipped IDs no longer produce CoinGecko upstream calls
- confirm `/api/v3/news` `ok=false status=404` drops to zero or near zero
- check `recovered=true outcome=coin_not_found` for catalog-race cases
- verify global, Bitcoin, and Solana feeds still return news
- monitor the unchanged critical provider alert for 24 hours

Production Grafana verification was not available locally because the checkout credentials require reauthentication.
