### PR TITLE
Fix Grafana push dependency setup

### DIFF
--- a/.github/workflows/grafana-push.yml
+++ b/.github/workflows/grafana-push.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [main]
     paths:
+      - '.github/workflows/grafana-push.yml'
       - 'dashboards/**'
       - 'alert-rules/**'
       - 'notification-policies/**'

--- a/.github/workflows/grafana-push.yml
+++ b/.github/workflows/grafana-push.yml
@@ -28,8 +28,15 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.6
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
       - name: Validate Grafana configuration
-        run: node scripts/validate-grafana-config.mjs
+        run: bun run validate:grafana-config
 
       - name: Install Doppler CLI
         uses: dopplerhq/cli-action@014df23b1329b615816a38eb5f473bb9000700b1 # v3


### PR DESCRIPTION
## Summary

- install the repository's frozen Bun dependencies before running the Grafana configuration validator
- invoke the validator through its package script, matching the main CI workflow
- include the Grafana workflow file in its own `main` path filter so merging this hotfix automatically reruns the failed sync

## Root cause

The post-merge Grafana push for #80 failed before contacting Grafana because `scripts/validate-grafana-config.mjs` imports `@grafana/lezer-logql`, but `.github/workflows/grafana-push.yml` did not install dependencies first.

Failed run: https://github.com/solana-foundation/tokens/actions/runs/31918254232

## Validation

- `bun install --frozen-lockfile` (no lockfile changes)
- `bun run validate:grafana-config` (25 files, 18 alert UIDs, 68 LogQL expressions)
- `bun run check:repo-hygiene`
- `git diff --check`

## After merge

The workflow-file path now triggers `Grafana push (dashboards + alert rules)` on `main`. Confirm that run validates successfully and syncs the alert/dashboard changes from #80.
