### PR TITLE
fix(assets): fall back to stock benchmark when on-chain market is dust

### DIFF
--- a/apps/api/src/app/api/v1/assets/[assetId]/route.ts
+++ b/apps/api/src/app/api/v1/assets/[assetId]/route.ts
@@ -556,12 +556,17 @@ export const GET = route(
             // underlying company's market cap (price × shares outstanding) when
             // shares data is available — the tokenized-supply aggregate remains the
             // fallback and stays available per-variant.
+            // EXCEPTION: when the on-chain markets are dust (a lone tiny trade
+            // on an empty pool can print an arbitrary price), the stock
+            // benchmark takes over percent change, and price too for public
+            // equities where one token equals one share.
             const effectiveStats = selectCanonicalAssetStats({
                 coingecko: shouldUseStockCanonicalMarket ? null : coinSnapshot,
                 stock: stockSnapshot ? { ...stockSnapshot, marketCapUsd: companyMarketCap } : null,
                 aggregate: stats,
                 preferAggregateVolume24h: !shouldUseStockCanonicalMarket,
                 preferStockMarket: shouldUseStockCanonicalMarket,
+                stockPriceMatchesTokenUnits: isCanonicalPublicEquityAsset(asset),
             });
 
             const primaryMint = primaryVariant?.mint ?? null;

--- a/apps/api/src/app/api/v1/assets/_asset-helpers.test.ts
+++ b/apps/api/src/app/api/v1/assets/_asset-helpers.test.ts
@@ -405,6 +405,98 @@ describe('canonical asset stat selection', () => {
         expect(selected?.liquidity).toBe(700);
     });
 
+    it('falls back to the stock benchmark when the on-chain market is dust', () => {
+        // Mirrors galaxy-digital: a single ~$10 trade on an empty pool printed
+        // ~3x the real GLXY price and a +360% 24h change.
+        const dustAggregate = {
+            price: 68.98,
+            liquidity: 0.52,
+            volume24hUSD: 8.38,
+            volume30dUSD: null,
+            marketCap: 6_608_913,
+            fdv: 40_008_995,
+            priceChange24hPercent: 359.9,
+            priceChange1hPercent: 359.9,
+            totalSupply: 580_000,
+            circulatingSupply: 95_807,
+        };
+
+        const selected = selectCanonicalAssetStats({
+            stock: {
+                priceUsd: 21.62,
+                volume24hUsd: 0,
+                priceChange24hPercent: 2.22,
+            },
+            aggregate: dustAggregate,
+            preferStockMarket: true,
+            stockPriceMatchesTokenUnits: true,
+        });
+
+        expect(selected?.price).toBe(21.62);
+        expect(selected?.priceChange24hPercent).toBe(2.22);
+        expect(selected?.priceChange1hPercent).toBeNull();
+        // On-chain activity figures stay truthful.
+        expect(selected?.volume24hUSD).toBe(8.38);
+        expect(selected?.liquidity).toBe(0.52);
+    });
+
+    it('only falls back percent change for dust markets when stock units differ from token units', () => {
+        const dustAggregate = {
+            price: 2600,
+            liquidity: 5,
+            volume24hUSD: 3,
+            volume30dUSD: null,
+            marketCap: 1_000_000,
+            fdv: 1_000_000,
+            priceChange24hPercent: 120,
+            priceChange1hPercent: 120,
+            totalSupply: 400,
+            circulatingSupply: 400,
+        };
+
+        const selected = selectCanonicalAssetStats({
+            stock: {
+                priceUsd: 240, // e.g. GLD share price — different units than the per-oz token
+                volume24hUsd: 0,
+                priceChange24hPercent: 0.8,
+            },
+            aggregate: dustAggregate,
+            preferStockMarket: true,
+        });
+
+        expect(selected?.price).toBe(2600);
+        expect(selected?.priceChange24hPercent).toBe(0.8);
+        expect(selected?.priceChange1hPercent).toBeNull();
+    });
+
+    it('keeps on-chain stats for stock-canonical assets with real activity', () => {
+        const selected = selectCanonicalAssetStats({
+            stock: {
+                priceUsd: 21.62,
+                volume24hUsd: 0,
+                priceChange24hPercent: 2.22,
+            },
+            aggregate: {
+                price: 21.8,
+                liquidity: 250_000,
+                volume24hUSD: 90_000,
+                volume30dUSD: null,
+                marketCap: 6_608_913,
+                fdv: 40_008_995,
+                priceChange24hPercent: 3.1,
+                priceChange1hPercent: 0.4,
+                totalSupply: 580_000,
+                circulatingSupply: 95_807,
+            },
+            preferStockMarket: true,
+            stockPriceMatchesTokenUnits: true,
+        });
+
+        expect(selected?.price).toBe(21.8);
+        expect(selected?.priceChange24hPercent).toBe(3.1);
+        expect(selected?.priceChange1hPercent).toBe(0.4);
+    });
+
     it('prefers the underlying company market cap for stock-canonical assets', () => {
         const selected = selectCanonicalAssetStats({
             stock: {

--- a/apps/api/src/app/api/v1/assets/_asset-helpers.ts
+++ b/apps/api/src/app/api/v1/assets/_asset-helpers.ts
@@ -551,6 +551,13 @@ function weightedAverageByVariantActivity(
     return weightSum > 0 ? weightedSum / weightSum : null;
 }
 
+// On-chain markets below both floors are treated as inactive ("dust") for
+// stock-priced assets: a single tiny trade on an empty pool can print an
+// arbitrary price (and a wild 24h change computed from it), so the stock
+// benchmark is more trustworthy than anything derived from these markets.
+const DUST_ONCHAIN_MARKET_MAX_LIQUIDITY_USD = 100;
+const DUST_ONCHAIN_MARKET_MAX_VOLUME24H_USD = 100;
+
 export function selectCanonicalAssetStats(args: {
     coingecko?: {
         priceUsd?: number | null;
@@ -569,6 +576,13 @@ export function selectCanonicalAssetStats(args: {
     primaryVariant?: AssetStats | null;
     preferAggregateVolume24h?: boolean;
     preferStockMarket?: boolean;
+    /**
+     * One token represents one share of the underlying stock, so
+     * `stock.priceUsd` is a valid substitute for the on-chain token price.
+     * Leave unset for commodities and other assets where the benchmark's
+     * units differ from the token's (e.g. gold: GLD share vs per-oz spot).
+     */
+    stockPriceMatchesTokenUnits?: boolean;
 }): AssetStats | null {
     const coingecko = args.coingecko ?? null;
     const stock = args.stock ?? null;
@@ -584,8 +598,18 @@ export function selectCanonicalAssetStats(args: {
         return null;
     };
 
+    const onChainLiquidity = pick(aggregate?.liquidity, primaryVariant?.liquidity) ?? 0;
+    const onChainVolume24hUSD = pick(aggregate?.volume24hUSD, primaryVariant?.volume24hUSD) ?? 0;
+    const useStockForDustOnChain =
+        preferStockMarket &&
+        stock !== null &&
+        onChainLiquidity < DUST_ONCHAIN_MARKET_MAX_LIQUIDITY_USD &&
+        onChainVolume24hUSD < DUST_ONCHAIN_MARKET_MAX_VOLUME24H_USD;
+
     const price = preferStockMarket
-        ? pick(aggregate?.price, primaryVariant?.price, coingecko?.priceUsd)
+        ? useStockForDustOnChain && args.stockPriceMatchesTokenUnits === true
+            ? pick(stock?.priceUsd, aggregate?.price, primaryVariant?.price, coingecko?.priceUsd)
+            : pick(aggregate?.price, primaryVariant?.price, coingecko?.priceUsd)
         : pick(coingecko?.priceUsd, stock?.priceUsd, aggregate?.price, primaryVariant?.price);
     const volume24hUSD = preferStockMarket
         ? pick(aggregate?.volume24hUSD, primaryVariant?.volume24hUSD, coingecko?.volume24hUsd)
@@ -598,11 +622,18 @@ export function selectCanonicalAssetStats(args: {
           pick(stock?.marketCapUsd, aggregate?.marketCap, primaryVariant?.marketCap, coingecko?.marketCapUsd)
         : pick(coingecko?.marketCapUsd, aggregate?.marketCap, primaryVariant?.marketCap);
     const priceChange24hPercent = preferStockMarket
-        ? pick(
-              aggregate?.priceChange24hPercent,
-              primaryVariant?.priceChange24hPercent,
-              coingecko?.priceChange24hPercent,
-          )
+        ? useStockForDustOnChain
+            ? pick(
+                  stock?.priceChange24hPercent,
+                  aggregate?.priceChange24hPercent,
+                  primaryVariant?.priceChange24hPercent,
+                  coingecko?.priceChange24hPercent,
+              )
+            : pick(
+                  aggregate?.priceChange24hPercent,
+                  primaryVariant?.priceChange24hPercent,
+                  coingecko?.priceChange24hPercent,
+              )
         : pick(
               coingecko?.priceChange24hPercent,
               stock?.priceChange24hPercent,
@@ -618,7 +649,9 @@ export function selectCanonicalAssetStats(args: {
         marketCap,
         fdv: pick(aggregate?.fdv, primaryVariant?.fdv),
         priceChange24hPercent,
-        priceChange1hPercent: pick(aggregate?.priceChange1hPercent, primaryVariant?.priceChange1hPercent),
+        priceChange1hPercent: useStockForDustOnChain
+            ? null
+            : pick(aggregate?.priceChange1hPercent, primaryVariant?.priceChange1hPercent),
         totalSupply: pick(aggregate?.totalSupply, primaryVariant?.totalSupply),
         circulatingSupply: pick(aggregate?.circulatingSupply, primaryVariant?.circulatingSupply),
     };

--- a/apps/api/src/app/api/v1/assets/curated/route.ts
+++ b/apps/api/src/app/api/v1/assets/curated/route.ts
@@ -841,6 +841,7 @@ export const GET = route(
                     aggregate: stats,
                     preferAggregateVolume24h: !shouldUseStockCanonicalMarket,
                     preferStockMarket: shouldUseStockCanonicalMarket,
+                    stockPriceMatchesTokenUnits: isCanonicalPublicEquityAsset(asset),
                 });
             }
 

--- a/apps/api/src/app/api/v1/assets/search/route.ts
+++ b/apps/api/src/app/api/v1/assets/search/route.ts
@@ -862,6 +862,7 @@ export const GET = route(
                     aggregate: stats,
                     preferAggregateVolume24h: !shouldUseStockCanonicalMarket,
                     preferStockMarket: shouldUseStockCanonicalMarket,
+                    stockPriceMatchesTokenUnits: isCanonicalPublicEquityAsset(asset),
                 });
             }
 


### PR DESCRIPTION
## Problem

The home page "Biggest Gainer" card showed galaxy-digital at **+350%**, and the asset page flashed **$68.98** before the chart corrected it to the real ~$21.62.

Root cause: a single ~$10 trade on the near-empty GLXYx pool ($0.003 liquidity) printed ~3.2× the real GLXY price, and Birdeye computed a +359.9% 24h change from it. That number propagated unguarded:

1. galaxy-digital has a **single variant**, so the liquidity-weighted aggregate in `aggregateTokenStats` degenerates to the mint's raw provider number.
2. `selectCanonicalAssetStats` with `preferStockMarket: true` never consulted the stock benchmark for `price`/`priceChange24hPercent` — only for market cap — so the poisoned value became the asset's `stats`.
3. The gainer card ranks on `stats.priceChange24hPercent` with no liquidity floor.

## Fix

In `selectCanonicalAssetStats`, when a stock-priced asset's on-chain market is **dust** (liquidity *and* 24h volume both under $100), the stock benchmark takes over the fields it can safely provide:

- **`priceChange24hPercent` always** — percent change is unit-free, safe for any stock-priced asset.
- **`price` only for public equities** (new `stockPriceMatchesTokenUnits` option, set from `isCanonicalPublicEquityAsset`) where 1 token = 1 share. Commodities keep the on-chain price — the existing contract comment's concern (GLD share price vs per-oz gold token) still holds and is now documented alongside the dust exception.
- The bogus on-chain **1h change is dropped** (null) rather than reported — the benchmark has no 1h substitute.

Liquidity/volume stay the truthful on-chain figures, and assets with real activity are unaffected. For galaxy-digital, `stats` now carries $21.62 / +2.22% — fixing the gainer card, the detail page header, and search rows in one place. The `?solana=<mint>` variant view intentionally still shows that mint's raw market.

## Testing

- 3 new tests: the exact GLXY dust scenario (equity), commodity units case (percent-only fallback), healthy-liquidity xStock unaffected.
- Full `apps/api` suite: 209 pass. `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)