### PR TITLE
infra(prd): enable isolated assets jobs worker (phase one)

### DIFF
--- a/terraform/envs/prd/main.tf
+++ b/terraform/envs/prd/main.tf
@@ -85,7 +85,7 @@ module "env" {
   # Phase-two activation. Keep these false while the application revision is
   # still a no-traffic candidate; otherwise Terraform can race the app deploy.
   enable_assets_db_startup_probe = false
-  enable_assets_worker           = false
+  enable_assets_worker           = true
   route_assets_jobs_to_worker    = false
 
   enable_crons         = true


### PR DESCRIPTION
## Why

All assets Cloud Scheduler jobs (OHLCV, prices, tickers, metadata, variant markets, clickhouse, prestocks) have returned 404 since the 2026-08-14 promotion of #76's assets revision: the service now runs `SERVICE_ROLE=api`, which rejects `/jobs/*`, but the isolated worker it hands jobs to was never provisioned (`enable_assets_worker = false`). Scheduler last-attempt status is code 5 (NOT_FOUND) on every job; OHLCV data has been missing since Aug 14.

## What

Phase one of the worker cutover per `docs/operations/assets-db-resilience.md`:
- `enable_assets_worker = true` in prd — provisions `tokens-assets-jobs-prd-us` with `SERVICE_ROLE=worker`.
- Scheduler routing unchanged (`route_assets_jobs_to_worker` stays false).

After apply: run `scripts/sync-assets-worker-env.sh` to mirror out-of-band provider credentials, smoke-test worker auth, then flip `route_assets_jobs_to_worker = true` in a follow-up PR.

OHLCV backfills itself once jobs run again (segment fetch from stored bounds, 90-day window).

🤖 Generated with [Claude Code](https://claude.com/claude-code)