### PR TITLE
infra(prd): route scheduler jobs to worker; adopt out-of-band worker service

### DIFF
--- a/scripts/sync-assets-worker-env.sh
+++ b/scripts/sync-assets-worker-env.sh
@@ -59,10 +59,13 @@ secret_updates=$(
   ' "$source_config"
 )
 
+# --env-vars-file replaces the literal env-var set wholesale, which is exactly
+# the mirrored full set built above; the same invocation's --update-secrets
+# restores every secret ref. (--update-env-vars-file is not a gcloud flag.)
 gcloud run services update "$worker_service" \
   --project="$project" \
   --region="$region" \
-  --update-env-vars-file="$env_file" \
+  --env-vars-file="$env_file" \
   --update-secrets="$secret_updates" \
   --quiet >/dev/null
 

--- a/terraform/envs/prd/main.tf
+++ b/terraform/envs/prd/main.tf
@@ -40,6 +40,14 @@ import {
   id = "projects/${data.google_project.this.project_id}/locations/${var.region}/queues/tokens-rollups-prd"
 }
 
+# The isolated assets jobs worker was created out-of-band on 2026-08-19 to
+# restore Cloud Scheduler /jobs/* handling (404ing since the 2026-08-14 assets
+# deploy set SERVICE_ROLE=api); Terraform adopts it here.
+import {
+  to = module.env.module.cloud_run_assets_jobs[0].google_cloud_run_v2_service.this
+  id = "projects/${data.google_project.this.project_id}/locations/${var.region}/services/tokens-assets-jobs-prd-us"
+}
+
 module "env" {
   source = "../../modules/env"
 
@@ -82,11 +90,12 @@ module "env" {
     "usage",
   ]
 
-  # Phase-two activation. Keep these false while the application revision is
-  # still a no-traffic candidate; otherwise Terraform can race the app deploy.
+  # Phase-two activation (see docs/operations/assets-db-resilience.md). The
+  # startup probe stays false until its own staged rollout; the worker flags
+  # match the live out-of-band cutover adopted via the import block above.
   enable_assets_db_startup_probe = false
   enable_assets_worker           = true
-  route_assets_jobs_to_worker    = false
+  route_assets_jobs_to_worker    = true
 
   enable_crons         = true
   enable_load_balancer = true


### PR DESCRIPTION
## Why

Follow-up to #85 — that squash landed before this branch's second commit. **The in-progress terraform apply on main will fail creating `tokens-assets-jobs-prd-us`**: the service was already created out-of-band with gcloud at 18:35Z to restore prod crons immediately (mirrored from the live assets service: same image, `SERVICE_ROLE=worker`, `PG_POOL_MAX=8`, concurrency 2, scale 0–2, VPC + runtime SA identical). It is Ready and being credential-synced/smoke-tested per `docs/operations/assets-db-resilience.md`.

## What

- `import` block adopting the live worker service (same pattern as the existing subnet/router/queue imports in this file).
- `route_assets_jobs_to_worker = true` — repoints Cloud Scheduler jobs + OIDC audience to the worker and moves the scheduler invoker IAM binding.

Merging this and re-running the failed apply converges terraform to the live cutover and completes the rollout: API keeps serving `/query`+`/mutation` (404s `/jobs`), worker serves `/jobs` only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)