### PR TITLE
feat(registry): add Moderna Backpack Securities variant

### DIFF
--- a/packages/asset-registry/src/data/curated-token-added-at.ts
+++ b/packages/asset-registry/src/data/curated-token-added-at.ts
@@ -622,4 +622,5 @@ export const CURATED_TOKEN_ADDED_AT: Record<string, number> = {
     'TTWofwAge91oFhZs7kpQdyrVRkmevgM88xijGvQFbKo': 1786001022385, // 2026-08-06
     'NBiSF3UaVUFtRzHwAfxyHsBCAZWGEKnMpewAE4oh7BG': 1786436068802, // 2026-08-11
     'PreC1KtJ1sBPPqaeeqL6Qb15GTLCYVvyYEwxhdfTwfx': 1786406400000, // 2026-08-11
+    'MRNAzXzhNcaEXJPibHEn8cd4vyekCDiivTyEwswLUCT': 1787166985000, // 2026-08-19
 };

--- a/packages/asset-registry/src/data/curated-token-lists.ts
+++ b/packages/asset-registry/src/data/curated-token-lists.ts
@@ -257,6 +257,7 @@ export const CURATED_TOKEN_LISTS = {
             'XspzcW1PRtgf6Wj92HCiZdjzKCyFekVD8P5Ueh3dRMX', // Microsoft
             'XsP7xzNPvEHS1m6qfanPUGjNmdnmsLKEoNAnHjdxxyZ', // MicroStrategy
             'MSTRdWXMeZxdE8osAQy3fA4rvTY5rgummDSMEx6U7Nz', // MicroStrategy (Backpack Securities)
+            'MRNAzXzhNcaEXJPibHEn8cd4vyekCDiivTyEwswLUCT', // Moderna (Backpack Securities)
             'XsyusqQvb8RDULsY9szwvUv2CxrDKa642w7kecZPdRM', // Monster
             'NBiSF3UaVUFtRzHwAfxyHsBCAZWGEKnMpewAE4oh7BG', // Nebius Group (Backpack Securities)
             'XsEH7wWfJJu2ZT3UCFeVfALnVA6CP5ur7Ee11KmzVpL', // Netflix

--- a/packages/asset-registry/src/data/equities.ts
+++ b/packages/asset-registry/src/data/equities.ts
@@ -16,6 +16,7 @@ const EQUITY_TICKER_BY_SLUG: Record<string, string> = {
     microsoft: 'MSFT',
     microstrategy: 'MSTR',
     micron: 'MU',
+    moderna: 'MRNA',
     nvidia: 'NVDA',
     robinhood: 'HOOD',
     'roundhill-memory-etf': 'DRAM',

--- a/packages/asset-registry/src/data/xstock-variant-groups.ts
+++ b/packages/asset-registry/src/data/xstock-variant-groups.ts
@@ -784,7 +784,10 @@ export const XSTOCK_VARIANT_GROUPS: TokenVariantGroup[] = [
     {
         id: 'xstock-moderna',
         label: 'Moderna variants',
-        addresses: [{ address: '14VP7DvCAdBCc5XGNZkPt6zhtPzJrWWS64Koxtxyondo', label: 'Ondo' }],
+        addresses: [
+            { address: '14VP7DvCAdBCc5XGNZkPt6zhtPzJrWWS64Koxtxyondo', label: 'Ondo' },
+            { address: 'MRNAzXzhNcaEXJPibHEn8cd4vyekCDiivTyEwswLUCT', label: 'Backpack Securities' },
+        ],
     },
     {
         id: 'xstock-monster',


### PR DESCRIPTION
## What

Adds `MRNAzXzhNcaEXJPibHEn8cd4vyekCDiivTyEwswLUCT` as a **Backpack Securities** variant of the existing `moderna` canonical asset (previously Ondo-only), following the MicroStrategy multi-variant pattern:

- `xstock-variant-groups.ts`: second address in `xstock-moderna` → variant `moderna:Backpack_Securities`, `share_redeemable`.
- `curated-token-lists.ts`: mint added alphabetically with the standard `(Backpack Securities)` comment.
- `curated-token-added-at.ts`: hand-appended (2026-08-19) — regen is lossy in this repo.
- `equities.ts`: `moderna: 'MRNA'` ticker so the canonical carries the symbol (MSTR/MU precedent).

## Verified

- On-chain (Token-2022): metadata name "Moderna - Backpack Securities", symbol MRNA, 6 decimals.
- Registry resolution: `getAsset('moderna')` → symbol MRNA, 2 variants (Ondo `cash_redeemable`, Backpack `share_redeemable`); both `MRNA` and the mint resolve as aliases to the canonical.
- `packages/asset-registry` tests: 36 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)