### PR TITLE
infra(stg): complete assets jobs-worker cutover, mirroring prd

### DIFF
--- a/terraform/envs/stg/main.tf
+++ b/terraform/envs/stg/main.tf
@@ -1,5 +1,13 @@
 data "google_project" "this" {}
 
+# The isolated assets jobs worker was created out-of-band on 2026-08-19 to
+# restore Cloud Scheduler /jobs/* handling (404ing since the 2026-08-14 assets
+# deploy set SERVICE_ROLE=api); Terraform adopts it here, mirroring prd.
+import {
+  to = module.env.module.cloud_run_assets_jobs[0].google_cloud_run_v2_service.this
+  id = "projects/${data.google_project.this.project_id}/locations/${var.region}/services/tokens-assets-jobs-stg-us"
+}
+
 module "env" {
   source = "../../modules/env"
 
@@ -26,11 +34,12 @@ module "env" {
     "usage",
   ]
 
-  # Enable the DB-aware startup probe and isolated worker in a follow-up
-  # apply only after the application revision containing /startup is live.
+  # Worker cutover mirrors prd (see docs/operations/assets-db-resilience.md):
+  # the worker was created out-of-band on 2026-08-19 and is adopted via the
+  # import block above. The startup probe stays false pending its own rollout.
   enable_assets_db_startup_probe = false
-  enable_assets_worker           = false
-  route_assets_jobs_to_worker    = false
+  enable_assets_worker           = true
+  route_assets_jobs_to_worker    = true
 
   enable_load_balancer = false
   enable_crons         = true


### PR DESCRIPTION
## Why

Staging has the same defect prd had until today: `tokens-assets-stg-us` runs `SERVICE_ROLE=api` (404s all `/jobs/*`) with no worker provisioned, so every stg cron has failed with scheduler status code 5 since 2026-08-14.

## What

Mirrors the prd cutover (#85/#86):
- `tokens-assets-jobs-stg-us` already created out-of-band in `tokens-stage` (cloned from the live stg assets service: same image, `SERVICE_ROLE=worker`, scale 0–2) and credential-synced with the now-fixed `scripts/sync-assets-worker-env.sh`.
- `import` block adopts it; `enable_assets_worker` + `route_assets_jobs_to_worker` flipped to true — the apply repoints stg Scheduler jobs + OIDC audience and moves the invoker binding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)