### PR TITLE
fix(ci): worker candidate tag exceeded Cloud Run's 46-char tag+name cap

### DIFF
--- a/.github/workflows/cloudrun-deploy.yml
+++ b/.github/workflows/cloudrun-deploy.yml
@@ -94,7 +94,9 @@ jobs:
           jobs_service=tokens-assets-jobs-${{ inputs.env }}-us
           if [ "${{ inputs.service }}" = "assets" ] && gcloud run services describe "$jobs_service" --region=${{ env.GCP_REGION }} --project=${{ env.GCP_PROJECT }} >/dev/null 2>&1; then
             worker_traffic=()
-            if [ "${{ inputs.env }}" = "prd" ]; then worker_traffic+=(--no-traffic --tag="$candidate_tag"); fi
+            # Tag + service name are capped at 46 chars; the jobs service name is
+            # 25, so the API's resilience-<sha12> tag (23) does not fit here.
+            if [ "${{ inputs.env }}" = "prd" ]; then worker_traffic+=(--no-traffic --tag="res-${GITHUB_SHA:0:12}"); fi
             gcloud run deploy "$jobs_service" --image="$IMAGE" --region=${{ env.GCP_REGION }} --project=${{ env.GCP_PROJECT }} --update-env-vars=SERVICE_ROLE=worker,PG_POOL_MAX=8,PG_CONNECT_TIMEOUT=3 "${worker_traffic[@]}" --quiet
           fi
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -717,7 +717,9 @@ jobs:
               --quiet
           fi
           if [ "${{ matrix.service }}" = "assets" ] && gcloud run services describe tokens-assets-jobs-prd-us --region=us-east4 --project=${{ vars.GCP_PROJECT }} >/dev/null 2>&1; then
-            gcloud run deploy tokens-assets-jobs-prd-us --image="$IMAGE" --region=us-east4 --project=${{ vars.GCP_PROJECT }} --update-env-vars=SERVICE_ROLE=worker,PG_POOL_MAX=8,PG_CONNECT_TIMEOUT=3 --no-traffic --tag="$candidate_tag" --quiet
+            # Tag + service name are capped at 46 chars; the jobs service name is
+            # 25, so the API's resilience-<sha12> tag (23) does not fit here.
+            gcloud run deploy tokens-assets-jobs-prd-us --image="$IMAGE" --region=us-east4 --project=${{ vars.GCP_PROJECT }} --update-env-vars=SERVICE_ROLE=worker,PG_POOL_MAX=8,PG_CONNECT_TIMEOUT=3 --no-traffic --tag="res-${GITHUB_SHA:0:12}" --quiet
           fi
 
       - uses: oven-sh/setup-bun@v2


### PR DESCRIPTION
The Moderna deploy (322310194316) failed on the worker leg:

```
ERROR: (gcloud.run.deploy) spec.traffic.tag: traffic tag 'resilience-322310194316' and service name 'tokens-assets-jobs-prd-us' together are too long. Combined traffic tag and service name cannot exceed 46 characters.
```

`resilience-<sha12>` (23) fits `tokens-assets-prd-us` (20 → 43) but not `tokens-assets-jobs-prd-us` (25 → 48). The worker now uses `res-<sha12>` (16 → 41). Same fix applied to `cloudrun-deploy.yml`, which reuses the tag identically. The fail-fast matrix also cancelled admin/usage/prices for that sha — merging this triggers a fresh full deploy that covers them.

The worker has been deployed manually with the 3223101943… image in the meantime so the registry seed isn't blocked on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)