### PR TITLE
fix(web): variants badge reads from API so admin-added variants show without a redeploy

### DIFF
--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -1,5 +1,5 @@
 # Canonical site origin (used for metadataBase / share URLs)
-NEXT_PUBLIC_SITE_URL=https://token.solana.com
+NEXT_PUBLIC_SITE_URL=https://tokens.xyz
 
 # Public analytics
 NEXT_PUBLIC_POSTHOG_KEY=

--- a/apps/web/src/app/[name]/asset-page.tsx
+++ b/apps/web/src/app/[name]/asset-page.tsx
@@ -3,7 +3,7 @@ import Image from 'next/image';
 import Link from 'next/link';
 import { ArrowUpRight } from 'lucide-react';
 
-import type { AssetVariant, CanonicalAsset, LiquidityTier, TrustTier } from '@tokens/asset-registry';
+import type { AssetVariant, CanonicalAsset, LiquidityTier, TrustTier, VariantHub } from '@tokens/asset-registry';
 import { getVariantHubById, liquidityTierPriority } from '@tokens/asset-registry';
 import { Skeleton } from '@tokens/ui/skeleton';
 
@@ -246,19 +246,31 @@ function shouldShowSingletonVariantBadge(asset: CanonicalAsset): boolean {
     return asset.category === 'equity' && asset.variants.length === 1;
 }
 
-function buildVariantGroup(assetId: string, displayName: string, variants: VariantWithMarket[]) {
+function buildVariantGroup(
+    assetId: string,
+    displayName: string,
+    variants: VariantWithMarket[],
+    registryHub?: VariantHub | null,
+) {
     if (variants.length === 0) return null;
+
+    // API variants (registry ∪ DB) decide membership so admin-added variants
+    // appear without a redeploy; the static registry hub only supplies labels.
+    const registryLabelByMint = new Map(
+        (registryHub?.addresses ?? []).map(item => [item.address, item.label] as const),
+    );
 
     return {
         id: assetId,
         label: `${displayName} variants`,
         addresses: (() => {
-            const unique: Array<{ address: string }> = [];
+            const unique: Array<{ address: string; label?: string }> = [];
             const seen = new Set<string>();
             for (const variant of variants) {
                 if (seen.has(variant.mint)) continue;
                 seen.add(variant.mint);
-                unique.push({ address: variant.mint });
+                const label = registryLabelByMint.get(variant.mint) ?? variant.label?.trim() ?? undefined;
+                unique.push({ address: variant.mint, ...(label ? { label } : {}) });
             }
             return unique;
         })(),
@@ -742,10 +754,9 @@ function AssetPageShellFallback({ asset, requestedName, requestedMint }: AssetPa
     const variantHubFromRegistry = getVariantHubById(canonicalAssetId);
     const showSingletonVariantBadge = shouldShowSingletonVariantBadge(asset);
     const variantGroup =
-        variantHubFromRegistry ??
         (variants.length > 1 || showSingletonVariantBadge
-            ? buildVariantGroup(canonicalAssetId, displayName, variants)
-            : null);
+            ? buildVariantGroup(canonicalAssetId, displayName, variants, variantHubFromRegistry)
+            : null) ?? variantHubFromRegistry;
 
     return (
         <TokenPageScaffold
@@ -1020,10 +1031,9 @@ async function loadAssetPageModel({ asset, requestedName, requestedMint }: Asset
     const variantHubFromRegistry = getVariantHubById(canonicalAssetId);
     const showSingletonVariantBadge = shouldShowSingletonVariantBadge(effectiveAsset);
     const variantGroup =
-        variantHubFromRegistry ??
         (variants.length > 1 || showSingletonVariantBadge
-            ? buildVariantGroup(canonicalAssetId, displayName, variants)
-            : null);
+            ? buildVariantGroup(canonicalAssetId, displayName, variants, variantHubFromRegistry)
+            : null) ?? variantHubFromRegistry;
 
     return {
         assetRef,

--- a/apps/web/src/app/[name]/page.tsx
+++ b/apps/web/src/app/[name]/page.tsx
@@ -87,9 +87,9 @@ function firstString(value: string | string[] | undefined): string | null {
 // Static so generateMetadata never touches request headers (keeps the route cacheable/ISR).
 function getMetadataBase(): URL {
     try {
-        return new URL(process.env.NEXT_PUBLIC_SITE_URL ?? 'https://token.solana.com');
+        return new URL(process.env.NEXT_PUBLIC_SITE_URL ?? 'https://tokens.xyz');
     } catch {
-        return new URL('https://token.solana.com');
+        return new URL('https://tokens.xyz');
     }
 }
 

--- a/apps/web/src/app/token/[address]/components/token-variants-badge.tsx
+++ b/apps/web/src/app/token/[address]/components/token-variants-badge.tsx
@@ -93,6 +93,7 @@ interface VariantListItem {
     address: string;
     symbol: string;
     name: string;
+    label?: string;
     decimals: number;
     logoURI?: string;
     liquidity: number;
@@ -186,7 +187,10 @@ function VariantTokenRow({
 }: VariantTokenRowProps) {
     const isLight = appearance === 'light';
     const isCurrent = token.address === currentAddress;
-    const label = group.id === 'solana' ? undefined : normalizeVariantBadgeLabel(getAddressLabel(group, token.address));
+    const label =
+        group.id === 'solana'
+            ? undefined
+            : normalizeVariantBadgeLabel(getAddressLabel(group, token.address) ?? token.label);
     const shouldShowLabelBadge =
         Boolean(label) && normalizeBadgeToken(label ?? '') !== normalizeBadgeToken(token.symbol);
     const href = `/${encodeURIComponent(routeName)}?solana=${encodeURIComponent(token.address)}`;
@@ -508,12 +512,13 @@ export function TokenVariantsBadge({
     });
 
     const variantCount = React.useMemo(() => {
-        if (group.id === 'solana') {
-            const apiCount = new Set((data?.variants ?? []).map(v => v.mint)).size;
-            if (apiCount > 0) return apiCount;
-        }
+        // API variants (registry ∪ DB) are the source of truth so admin-added
+        // variants show without a redeploy; fall back to the static registry
+        // hub until the query has loaded.
+        const apiCount = new Set((data?.variants ?? []).map(v => v.mint)).size;
+        if (apiCount > 0) return apiCount;
         return new Set(group.addresses.map(item => item.address)).size;
-    }, [data?.variants, group.addresses, group.id]);
+    }, [data?.variants, group.addresses]);
     const variantCountLabel = variantCount > 1 ? `${variantCount}+` : `${variantCount}`;
 
     const tokens: VariantListItem[] = React.useMemo(() => {
@@ -521,7 +526,7 @@ export function TokenVariantsBadge({
         const byMint = new Map(variants.map(v => [v.mint, v]));
 
         const items: VariantListItem[] = [];
-        const addresses = group.id === 'solana' ? variants.map(v => ({ address: v.mint })) : group.addresses;
+        const addresses = variants.length > 0 ? variants.map(v => ({ address: v.mint })) : group.addresses;
         for (const item of addresses) {
             const v = byMint.get(item.address);
             const market = v?.market ?? null;
@@ -549,10 +554,12 @@ export function TokenVariantsBadge({
             });
             const logoURI = normalizeOptionalText(market?.logoURI) || getMintLogoOverride(item.address);
 
+            const rowLabel = itemLabel || apiLabel;
             items.push({
                 address: item.address,
                 symbol,
                 name,
+                ...(rowLabel ? { label: rowLabel } : {}),
                 decimals,
                 ...(logoURI ? { logoURI } : {}),
                 liquidity,
@@ -562,7 +569,7 @@ export function TokenVariantsBadge({
         }
 
         return items.sort((a, b) => (b.liquidity ?? 0) - (a.liquidity ?? 0));
-    }, [data?.variants, group.addresses, group.id]);
+    }, [data?.variants, group.addresses]);
 
     return (
         <>

--- a/apps/web/src/lib/token-social-image.ts
+++ b/apps/web/src/lib/token-social-image.ts
@@ -93,7 +93,7 @@ function getCoinDocImageUrl(coinDoc: CoinDoc | null): string | undefined {
 }
 
 function getRequestHost(headers: Headers): string {
-    const raw = headers.get('x-forwarded-host') ?? headers.get('host') ?? 'token.solana.com';
+    const raw = headers.get('x-forwarded-host') ?? headers.get('host') ?? 'tokens.xyz';
     const first = raw.split(',')[0]?.trim();
     return first && first.length > 0 ? first : raw.trim();
 }


### PR DESCRIPTION
## Problem

The VARIANTS hover badge (and its mobile drawer) on token/asset pages rendered its rows and count from the static `@tokens/asset-registry` `VariantHub` baked into the web build — only the `solana` hub used the API response. Variants added through the admin app land in `asset_variants` and are already served by `GET /api/v1/assets/{assetId}/variants` (which merges registry ∪ DB and resolves aliases), but the badge never reflected them.

Concrete case: the Eli Lilly Backpack Securities variant (`LLYuwZ33…TvD`, added via the admin app) shows in the asset page's variants tab and resolves via the API, but the hover badge stayed at 2 (xStock + Ondo from `xstock-variant-groups.ts`). Until now this only worked by also landing a registry PR (e.g. #87 for Moderna) and redeploying.

## Change

- **`token-variants-badge.tsx`** — once the variants query loads, the API list is the row source and count for every hub (previously `solana` only). The static hub remains the pre-fetch/loading fallback, and static labels still take precedence for known mints; API labels carry through for mints the static hub doesn't know.
- **`asset-page.tsx`** — `buildVariantGroup` (built from the API asset-detail variants, fetched server-side) now takes precedence over `getVariantHubById`, so the badge count is correct at render time without waiting for the hover fetch. The registry hub is demoted to label enrichment plus fallback when the API list is empty.

No API changes — the variants route already returned the right data.

## Notes / follow-ups

- On `/token/[address]` pages the pre-hover count still comes from the static hub (the query stays `enabled: isOpen` to avoid a new API call on every token page view); it corrects on open. Asset pages (`/[name]`) are correct server-side.
- Known remaining gap (unchanged by this PR): a canonical with exactly 1 registry variant renders no hub on `/token/[address]` (`getVariantHubByMint` returns null for singletons), so a 2nd admin-added variant won't surface a badge there until a registry entry exists.

## Testing

- `turbo typecheck lint test --filter=@tokens/web` — all green (45 tests).
- Verified prod API: `GET /api/v1/assets/eli-lilly` and `/api/v1/assets/resolve?mint=LLYuwZ33…` both return all 3 variants including the Backpack mint, so the badge picks it up on deploy with no registry edit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Also included: OG share-card fix

Share cards (Twitter/OG unfurls) were broken because `og:image`/`twitter:image` meta tags fell back to `token.solana.com`, which no longer resolves in DNS. The image routes themselves are healthy on tokens.xyz; crawlers just could not fetch them. Commit e729102 defaults `metadataBase` and the OG route host fallback to `https://tokens.xyz`.

Note for deploy: if `NEXT_PUBLIC_SITE_URL` is explicitly set to the old domain in the Vercel project env, it overrides this fallback and must be updated there too.
