### PR TITLE
feat(api): variants=all returns every canonical's full variant list in one call

### DIFF
--- a/apps/api/src/app/api/v1/assets/curated/route.ts
+++ b/apps/api/src/app/api/v1/assets/curated/route.ts
@@ -198,17 +198,21 @@ function curatedStaleCacheKey(request: Request): string | null {
         const rawListId = (searchParams.get('list') ?? 'all').trim();
         const listId = rawListId === 'all' ? 'all' : (normalizeCuratedTokenListId(rawListId) ?? 'all');
         const groupBy = parseGroupBy(searchParams.get('groupBy'));
+        const includeVariants = groupBy === 'asset' && (searchParams.get('variants') ?? '').trim() === 'all';
         const variantsMode = (searchParams.get('variantsMode') ?? '').trim();
         const strategy = (searchParams.get('primaryVariantStrategy') ?? '').trim();
         const shouldPaginate = searchParams.has('limit') || searchParams.has('offset');
         const offset = shouldPaginate ? (searchParams.get('offset') ?? '').trim() : '';
         const limit = shouldPaginate ? (searchParams.get('limit') ?? '').trim() : '';
+        // `variants` is spread conditionally so pre-existing key hashes (incl.
+        // the warmer's) stay stable.
         const canonical = JSON.stringify({
             listId,
             groupBy,
             variantsMode,
             strategy,
             pagination: shouldPaginate ? { offset, limit } : null,
+            ...(includeVariants ? { variants: 'all' } : {}),
         });
         const shapeHash = createHash('sha256').update(canonical).digest('hex').slice(0, 32);
         return `stale-response:v2:assets-curated:${shapeHash}`;
@@ -229,6 +233,7 @@ export const GET = route(
                 return normalizeCuratedTokenListId(trimmed) ?? 'all';
             })();
             const groupBy = parseGroupBy(searchParams.get('groupBy'));
+            const includeVariants = groupBy === 'asset' && (searchParams.get('variants') ?? '').trim() === 'all';
             const shouldPaginate = searchParams.has('limit') || searchParams.has('offset');
             const offset = shouldPaginate ? yield* decodeOffset(searchParams.get('offset')) : 0;
             const limit = shouldPaginate
@@ -502,9 +507,12 @@ export const GET = route(
 
             const canonicalAssets = Array.from(canonicalAssetById.values()).map(mergeRegistryVariantMetadata);
 
-            const shouldLoadSanctumLsts = groupBy === 'mint' && (listId === 'lsts' || listId === 'all');
+            // variants=all needs sanctum ranks too: shouldIncludeMintRow gates
+            // nested solana LST variants on sanctum membership.
+            const shouldLoadSanctumLsts =
+                (groupBy === 'mint' || includeVariants) && (listId === 'lsts' || listId === 'all');
             // Prefetch already loaded sanctum when the caller asked for it (listId=all|lsts);
-            // groupBy=asset short-circuits below because shouldLoadSanctumLsts is false anyway.
+            // plain groupBy=asset short-circuits below because shouldLoadSanctumLsts is false anyway.
             const sanctumLsts = shouldLoadSanctumLsts
                 ? prefetch && prefetch.sanctumLsts.length > 0
                     ? prefetch.sanctumLsts
@@ -951,6 +959,65 @@ export const GET = route(
                 return primaryVariantStrategy;
             }
 
+            function makeVariantWithMarketBuilder(ctx: {
+                responseSymbol: string | undefined;
+                imageUrl: string | null;
+            }) {
+                return function buildVariantWithMarket(variant: CanonicalAsset['variants'][number]) {
+                    const token = tokenByMint.get(variant.mint);
+                    const marketMeta = marketMetaByMint.get(variant.mint);
+                    const variantSymbol = resolveVariantSymbol({
+                        variantSymbol: variant.symbol,
+                        marketSymbol: token?.symbol,
+                        label: variant.label,
+                        canonicalSymbol: ctx.responseSymbol,
+                    });
+                    const variantName =
+                        optionalText(variant.name) ??
+                        optionalText(token?.name) ??
+                        optionalText(variant.label) ??
+                        variantSymbol;
+                    const market = token
+                        ? {
+                              ...(token.source ? { source: token.source } : {}),
+                              ...(token.metricsSource ? { metricsSource: token.metricsSource } : {}),
+                              price: token.price,
+                              liquidity: token.liquidity,
+                              volume1hUSD: token.volume1hUSD ?? null,
+                              volume24hUSD: token.volume24hUSD,
+                              trade1h: token.trade1h ?? null,
+                              trade24h: token.trade24h ?? null,
+                              uniqueWallet1h: token.uniqueWallet1h ?? null,
+                              uniqueWallet24h: token.uniqueWallet24h ?? null,
+                              marketCap: token.marketCap,
+                              fdv: token.fdv,
+                              holder: token.holder,
+                              totalSupply: token.totalSupply,
+                              circulatingSupply: token.circulatingSupply,
+                              priceChange24hPercent: token.priceChange24hPercent,
+                              priceChange1hPercent: token.priceChange1hPercent,
+                              decimals: token.decimals,
+                              logoURI: token.logoURI ?? ctx.imageUrl ?? null,
+                              lastTradeAt: token.lastTradeAt ?? null,
+                              asOf: token.asOf ?? null,
+                              lastFetchedAt: marketMeta ? marketMeta.lastFetchedAt : null,
+                          }
+                        : null;
+                    const executionQuality = fillQualityByMint.get(variant.mint) ?? null;
+
+                    return withDerivedVariantTier(
+                        {
+                            ...variant,
+                            ...(variantSymbol ? { symbol: variantSymbol } : {}),
+                            ...(variantName ? { name: variantName } : {}),
+                            market,
+                            executionQuality,
+                        },
+                        market?.liquidity,
+                    );
+                };
+            }
+
             const results =
                 groupBy === 'mint'
                     ? (() => {
@@ -981,52 +1048,16 @@ export const GET = route(
                                   imageUrl: assetImageById.get(asset.assetId) ?? null,
                               });
 
+                              const buildVariantWithMarket = makeVariantWithMarketBuilder({
+                                  responseSymbol,
+                                  imageUrl,
+                              });
+
                               return asset.variants
                                   .filter(variant =>
                                       shouldIncludeMintRow(asset, variant, tokenByMint.get(variant.mint)),
                                   )
                                   .map(variant => {
-                                      const token = tokenByMint.get(variant.mint);
-                                      const marketMeta = marketMetaByMint.get(variant.mint);
-                                      const variantSymbol = resolveVariantSymbol({
-                                          variantSymbol: variant.symbol,
-                                          marketSymbol: token?.symbol,
-                                          label: variant.label,
-                                          canonicalSymbol: responseSymbol,
-                                      });
-                                      const variantName =
-                                          optionalText(variant.name) ??
-                                          optionalText(token?.name) ??
-                                          optionalText(variant.label) ??
-                                          variantSymbol;
-                                      const market = token
-                                          ? {
-                                                ...(token.source ? { source: token.source } : {}),
-                                                ...(token.metricsSource ? { metricsSource: token.metricsSource } : {}),
-                                                price: token.price,
-                                                liquidity: token.liquidity,
-                                                volume1hUSD: token.volume1hUSD ?? null,
-                                                volume24hUSD: token.volume24hUSD,
-                                                trade1h: token.trade1h ?? null,
-                                                trade24h: token.trade24h ?? null,
-                                                uniqueWallet1h: token.uniqueWallet1h ?? null,
-                                                uniqueWallet24h: token.uniqueWallet24h ?? null,
-                                                marketCap: token.marketCap,
-                                                fdv: token.fdv,
-                                                holder: token.holder,
-                                                totalSupply: token.totalSupply,
-                                                circulatingSupply: token.circulatingSupply,
-                                                priceChange24hPercent: token.priceChange24hPercent,
-                                                priceChange1hPercent: token.priceChange1hPercent,
-                                                decimals: token.decimals,
-                                                logoURI: token.logoURI ?? imageUrl ?? null,
-                                                lastTradeAt: token.lastTradeAt ?? null,
-                                                asOf: token.asOf ?? null,
-                                                lastFetchedAt: marketMeta ? marketMeta.lastFetchedAt : null,
-                                            }
-                                          : null;
-                                      const executionQuality = fillQualityByMint.get(variant.mint) ?? null;
-
                                       const out = {
                                           assetId: asset.assetId,
                                           name: asset.name,
@@ -1035,16 +1066,7 @@ export const GET = route(
                                           imageUrl,
                                           stats: effectiveStats,
                                           ...(canonicalMarket ? { canonicalMarket } : {}),
-                                          primaryVariant: withDerivedVariantTier(
-                                              {
-                                                  ...variant,
-                                                  ...(variantSymbol ? { symbol: variantSymbol } : {}),
-                                                  ...(variantName ? { name: variantName } : {}),
-                                                  market,
-                                                  executionQuality,
-                                              },
-                                              market?.liquidity,
-                                          ),
+                                          primaryVariant: buildVariantWithMarket(variant),
                                       };
 
                                       const rank = shouldSortBySanctumRank
@@ -1075,7 +1097,6 @@ export const GET = route(
                                   },
                               );
                               const token = primaryVariant ? tokenByMint.get(primaryVariant.mint) : undefined;
-                              const marketMeta = primaryVariant ? marketMetaByMint.get(primaryVariant.mint) : undefined;
                               const aggregates = aggregatesByAssetId.get(asset.assetId) ?? null;
 
                               const stats = mergeAssetStatsWithAggregates(
@@ -1091,45 +1112,21 @@ export const GET = route(
                                   symbol: responseSymbol ?? null,
                                   imageUrl: assetImageById.get(asset.assetId) ?? null,
                               });
-                              const variantSymbol = resolveVariantSymbol({
-                                  variantSymbol: primaryVariant?.symbol,
-                                  marketSymbol: token?.symbol,
-                                  label: primaryVariant?.label,
-                                  canonicalSymbol: responseSymbol,
+                              const buildVariantWithMarket = makeVariantWithMarketBuilder({
+                                  responseSymbol,
+                                  imageUrl,
                               });
-                              const variantName =
-                                  optionalText(primaryVariant?.name) ??
-                                  optionalText(token?.name) ??
-                                  optionalText(primaryVariant?.label) ??
-                                  variantSymbol;
-                              const market = token
-                                  ? {
-                                        ...(token.source ? { source: token.source } : {}),
-                                        ...(token.metricsSource ? { metricsSource: token.metricsSource } : {}),
-                                        price: token.price,
-                                        liquidity: token.liquidity,
-                                        volume1hUSD: token.volume1hUSD ?? null,
-                                        volume24hUSD: token.volume24hUSD,
-                                        trade1h: token.trade1h ?? null,
-                                        trade24h: token.trade24h ?? null,
-                                        uniqueWallet1h: token.uniqueWallet1h ?? null,
-                                        uniqueWallet24h: token.uniqueWallet24h ?? null,
-                                        marketCap: token.marketCap,
-                                        fdv: token.fdv,
-                                        holder: token.holder,
-                                        totalSupply: token.totalSupply,
-                                        circulatingSupply: token.circulatingSupply,
-                                        priceChange24hPercent: token.priceChange24hPercent,
-                                        priceChange1hPercent: token.priceChange1hPercent,
-                                        decimals: token.decimals,
-                                        logoURI: token.logoURI ?? imageUrl ?? null,
-                                        lastTradeAt: token.lastTradeAt ?? null,
-                                        asOf: token.asOf ?? null,
-                                        lastFetchedAt: marketMeta ? marketMeta.lastFetchedAt : null,
-                                    }
-                                  : null;
-                              const executionQuality = primaryVariant
-                                  ? (fillQualityByMint.get(primaryVariant.mint) ?? null)
+                              // Same eligibility gate as groupBy=mint rows, so nested
+                              // counts agree with mint-grouping for the same params.
+                              const variants = includeVariants
+                                  ? asset.variants
+                                        .filter(variant =>
+                                            shouldIncludeMintRow(asset, variant, tokenByMint.get(variant.mint)),
+                                        )
+                                        .map(buildVariantWithMarket)
+                                        .sort(
+                                            (a, b) => (b.market?.liquidity ?? 0) - (a.market?.liquidity ?? 0),
+                                        )
                                   : null;
 
                               return {
@@ -1140,18 +1137,8 @@ export const GET = route(
                                   imageUrl,
                                   stats: effectiveStats,
                                   ...(canonicalMarket ? { canonicalMarket } : {}),
-                                  primaryVariant: primaryVariant
-                                      ? withDerivedVariantTier(
-                                            {
-                                                ...primaryVariant,
-                                                ...(variantSymbol ? { symbol: variantSymbol } : {}),
-                                                ...(variantName ? { name: variantName } : {}),
-                                                market,
-                                                executionQuality,
-                                            },
-                                            market?.liquidity,
-                                        )
-                                      : null,
+                                  primaryVariant: primaryVariant ? buildVariantWithMarket(primaryVariant) : null,
+                                  ...(variants ? { variants } : {}),
                               };
                           })
                           .sort((a, b) => (b.stats?.volume24hUSD ?? 0) - (a.stats?.volume24hUSD ?? 0));

--- a/apps/docs/content/docs/v1/endpoints/assets.mdx
+++ b/apps/docs/content/docs/v1/endpoints/assets.mdx
@@ -592,12 +592,14 @@ Get curated assets from a list.
 - `groupBy` (optional): `asset` (default) or `mint`
 - `limit` (optional): opt into pagination with this page size (default `250` when `offset` is provided, max `500`)
 - `offset` (optional): opt into pagination from this zero-based result offset
-- `variantsMode=all` (optional): disable the default Solana LST liquidity filter for `groupBy=mint`
+- `variantsMode=all` (optional): disable the default Solana LST liquidity filter (applies to `groupBy=mint` rows and to nested `variants[]`)
+- `variants=all` (optional): include every known variant for each canonical asset as `variants[]` (each with per-variant `market` and `executionQuality`, sorted by `market.liquidity` descending). Only applies to `groupBy=asset`; ignored for `groupBy=mint`. By default only `primaryVariant` is returned.
 - `primaryVariantStrategy` (optional): `liquidity` (default), `execution_quality`, or `stock_redeemability`
 
 ### Notes
 
 - Results are sorted by `stats.volume24hUSD` descending when available.
+- With `variants=all`, the `solana` asset's nested LST variants follow the same active-LST plus `$250k` liquidity filter as `groupBy=mint` rows; pass `variantsMode=all` to disable the liquidity floor. `primaryVariant` also appears within `variants[]` (no dedup).
 - `list=lsts` is backed by the same dynamic, capped Solana yield-variant set used by the variants API, rather than a fixed static mint list. `list=all` includes that same dynamic LST membership.
 - For Solana LST mint rows, the default response only includes active LSTs with at least `$250k` liquidity. Pass `variantsMode=all` to return all active LST rows.
 - `groupBy=mint` expands the response to one row per variant mint.
@@ -671,6 +673,9 @@ interface AssetsCuratedResponse {
             };
             executionQuality: VariantExecutionQuality;
         };
+        // Present when variants=all and groupBy=asset. Same element shape as
+        // primaryVariant, sorted by market.liquidity descending.
+        variants?: Array<NonNullable<AssetsCuratedResponse['assets'][number]['primaryVariant']>>;
     }>;
 }
 ```
@@ -695,6 +700,11 @@ curl -sS "$API_BASE_URL/v1/assets/curated?list=all&groupBy=asset&limit=250" \
 
 ```bash
 curl -sS "$API_BASE_URL/v1/assets/curated?list=lsts&groupBy=mint&variantsMode=all" \
+  -H "x-api-key: $API_KEY"
+```
+
+```bash
+curl -sS "$API_BASE_URL/v1/assets/curated?list=stocks&variants=all" \
   -H "x-api-key: $API_KEY"
 ```
 

--- a/scripts/verify-assets-api-v1-contract.ts
+++ b/scripts/verify-assets-api-v1-contract.ts
@@ -176,7 +176,7 @@ async function verifyCurated(baseUrl: string, apiKey: string, prefix: string): P
     for (let i = 0; i < data.assets.length; i++) {
         const row = data.assets[i];
         assertObject(row, `curated.assets[${i}]`);
-        assertNoKeys(row, ['aliases', 'symbols'], `curated.assets[${i}]`);
+        assertNoKeys(row, ['aliases', 'symbols', 'variants'], `curated.assets[${i}]`);
         const assetId = row.assetId;
         assertNotMintAssetId(assetId, `curated.assets[${i}].assetId`);
         assertStatsSnapshot(row.stats ?? null, `curated.assets[${i}].stats`);
@@ -190,6 +190,40 @@ async function verifyCurated(baseUrl: string, apiKey: string, prefix: string): P
         }
 
         assetIds.push(assetId);
+    }
+
+    const withVariants = await fetchJson(
+        baseUrl,
+        `${prefix}/assets/curated?list=majors&groupBy=asset&variants=all`,
+        apiKey,
+    );
+    assertObject(withVariants, 'curated variants=all response');
+    assert(Array.isArray(withVariants.assets), 'curated variants=all assets must be an array');
+    for (let i = 0; i < withVariants.assets.length; i++) {
+        const row = withVariants.assets[i];
+        const path = `curated(variants=all).assets[${i}]`;
+        assertObject(row, path);
+        assert(Array.isArray(row.variants), `${path}.variants must be an array`);
+        for (let j = 0; j < row.variants.length; j++) {
+            const variant = row.variants[j];
+            assertObject(variant, `${path}.variants[${j}]`);
+            assert(typeof variant.mint === 'string', `${path}.variants[${j}].mint must be a string`);
+            assert('market' in variant, `${path}.variants[${j}].market must exist (null allowed)`);
+            assertMarketSnapshot(variant.market ?? null, `${path}.variants[${j}].market`);
+        }
+        const primary = row.primaryVariant ?? null;
+        if (primary !== null) {
+            assertObject(primary, `${path}.primaryVariant`);
+            assert(
+                row.variants.some(
+                    variant =>
+                        typeof variant === 'object' &&
+                        variant !== null &&
+                        (variant as Record<string, unknown>).mint === primary.mint,
+                ),
+                `${path}.variants must include the primaryVariant mint`,
+            );
+        }
     }
 
     return assetIds;


### PR DESCRIPTION
## Why

There's no single call that returns all curated canonicals with their variant mints nested. `groupBy=asset` returns one row per canonical with only the selected `primaryVariant`; `groupBy=mint` returns a flat row per variant mint that callers have to group by `assetId` themselves.

Devs integrating stock tokens want every variant regardless of which one we pick as primary, so they can choose the mint on their end. This matters concretely: for `list=stocks`, 78 of 398 assets have more than one variant, and for several the primary is *not* the highest-liquidity mint (e.g. `micron`, `microstrategy` — the `stock_redeemability` strategy picks it). Without the full list, a caller can't see the alternatives.

## What

Adds `variants=all`, mirroring the param already supported on `/v1/assets/search`. With `groupBy=asset`, each row gains a `variants[]` array whose elements have the same shape as `primaryVariant` (per-variant `market` and `executionQuality`), sorted by `market.liquidity` descending. Ignored for `groupBy=mint`, where rows are already one-per-mint.

```
GET /v1/assets/curated?list=stocks&variants=all
```
```json
"spacex": { "primaryVariant": { "mint": "SPCXxcqXj…imGb", … }, "variants": [
    { "mint": "SPCXxcqXj…imGb", "label": "Backpack Securities", "market": { "liquidity": 5517935, … } },
    { "mint": "Xs3oZwbHvq…qpH8", "label": "xStock",             "market": { "liquidity": 2968758, … } },
    { "mint": "TSPXcLV76s…d99v", "label": "TSPX",               "market": { "liquidity": 567248,  … } },
    { "mint": "wzAyQTorWy…ondo", "label": "Ondo",               "market": { "liquidity": 199193,  … } },
    { "mint": "PreANxuXjs…sfTh", "label": "PreStocks",          "market": { "liquidity": 12170,   … } } ]}
```

No new data fetching — the curated prefetch already loads every list member's variants (that's how `groupBy=mint` works); this nests them instead of flattening.

## No breaking changes

- Responses **without** the param are byte-identical. Verified by diffing a full live asset row with `variants[]` stripped against the same request without the param: identical.
- Per-asset keys go from `[assetId, canonicalMarket, category, imageUrl, name, primaryVariant, stats, symbol]` to the same set plus `variants`, only when the param is passed. Top-level keys unchanged.
- The Redis last-good stale-cache key gains its new field **conditionally**, so every existing key hash — including the warmer's — is unchanged (no cold-cache window on deploy), and the two shapes can never cross-serve.

## Also in this diff

Hoists the ~60-line per-variant builder that was inlined twice (mint and asset branches, itself duplicating search's `buildVariantWithMarket`) into one local factory. Confirmed a no-op by diffing a stable projection of `groupBy=mint` output before/after the refactor.

## Solana mega-asset

Nested variants reuse `shouldIncludeMintRow` — the same active-LST + $250k liquidity gate as mint rows — so nested counts match `groupBy=mint` counts for the same params (verified: **58 both ways** for `list=lsts`) and `list=all` doesn't balloon with ~1.5k illiquid LSTs. `variantsMode=all` disables the floor exactly as today, which required also loading sanctum ranks in the asset-grouping path.

## Verification

All run against a live local dev server:

- `bun run typecheck`, `bun run lint`, `bun test src` (209 pass / 0 fail)
- `bun run verify:assets-api-v1` → passed, with new assertions: default response must **not** grow a `variants` key; `variants=all` rows have a valid array, each entry's market snapshot validates, and `primaryVariant`'s mint appears in `variants[]`
- `variants=all` returns nested mints; default has no `variants` key; `groupBy=mint&variants=all` ignores the param
- Pagination carries `variants` per row; liquidity-desc order verified across all multi-variant stocks

Docs (`assets.mdx`) updated: query param, solana-LST note, `variants?` on `AssetsCuratedResponse`, curl example.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
