### PR TITLE
feat(api): GET /v2/execution/links + execution:read scope

### DIFF
--- a/apps/api/next.config.ts
+++ b/apps/api/next.config.ts
@@ -6,9 +6,10 @@ const nextConfig: NextConfig = {
     },
     async rewrites() {
         return [
-            // Public API contract is `/v1/...` (see docs). Internally this app
-            // namespaces route handlers under `/api/v1/...`.
+            // Public API contract is `/v1/...` / `/v2/...` (see docs). Internally
+            // this app namespaces route handlers under `/api/v1/...` etc.
             { source: '/v1/:path*', destination: '/api/v1/:path*' },
+            { source: '/v2/:path*', destination: '/api/v2/:path*' },
         ];
     },
 };

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -18,6 +18,7 @@
     "@clerk/nextjs": "^6.39.5",
     "@tokens/asset-registry": "workspace:*",
     "@tokens/effect": "workspace:*",
+    "@tokens/execution-links": "workspace:*",
     "@tokens/token-risk-helpers": "workspace:*",
     "@upstash/redis": "^1.36.2",
     "effect": "4.0.0-rc.108",

--- a/apps/api/src/app/api/v2/execution/links/route.test.ts
+++ b/apps/api/src/app/api/v2/execution/links/route.test.ts
@@ -1,0 +1,169 @@
+import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test';
+
+mock.module('server-only', () => ({}));
+
+const { resetEnvForTests } = await import('@/lib/env');
+const { signPlaygroundProxyAuthPayload } = await import('@/effect/playground-proxy-auth');
+const { GET: linksGet } = await import('./route');
+
+const ORIGINAL_LOG = console.log;
+const ORIGINAL_WARN = console.warn;
+const ORIGINAL_ERROR = console.error;
+
+const ENV_KEYS = ['TOKENS_PLAYGROUND_PROXY_SECRET', 'TOKENS_USAGE_LOG_MODE', 'EXECUTION_LINKS_ICON_BASE_URL'] as const;
+const savedEnv: Partial<Record<(typeof ENV_KEYS)[number], string>> = {};
+
+const SOL_MINT = 'So11111111111111111111111111111111111111112';
+const USDC_MINT = 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v';
+const CBBTC_MINT = 'cbbtcf3aa214zXHbiAZQwf4122FBYbraNdFqgw4iMij';
+
+beforeEach(() => {
+    for (const key of ENV_KEYS) {
+        const value = process.env[key];
+        if (value !== undefined) savedEnv[key] = value;
+        else delete savedEnv[key];
+        delete process.env[key];
+    }
+    process.env.TOKENS_PLAYGROUND_PROXY_SECRET = 'test-playground-secret';
+    process.env.TOKENS_USAGE_LOG_MODE = 'off';
+    resetEnvForTests();
+
+    console.log = () => undefined;
+    console.warn = () => undefined;
+    console.error = () => undefined;
+});
+
+afterEach(() => {
+    console.log = ORIGINAL_LOG;
+    console.warn = ORIGINAL_WARN;
+    console.error = ORIGINAL_ERROR;
+
+    for (const key of ENV_KEYS) {
+        const value = savedEnv[key];
+        if (value === undefined) delete process.env[key];
+        else process.env[key] = value;
+    }
+    resetEnvForTests();
+});
+
+async function authHeader(scopes: string[]): Promise<string> {
+    const now = Date.now();
+    return signPlaygroundProxyAuthPayload({
+        apiKeyId: 'test-key',
+        keyPrefix: 'tk_test',
+        projectId: 'test-project',
+        ownerClerkUserId: 'test-user',
+        scopes,
+        iat: now,
+        exp: now + 60_000,
+    });
+}
+
+async function request(path: string, scopes: string[] = ['execution:read']): Promise<Response> {
+    return linksGet(
+        new Request(`https://api.example.test${path}`, {
+            headers: { 'x-tokens-playground-auth': await authHeader(scopes) },
+        }),
+        {} as never,
+    );
+}
+
+describe('GET /api/v2/execution/links', () => {
+    it('returns all venues with an absolutized icon and titan primary for a mint', async () => {
+        const response = await request(`/api/v2/execution/links?mint=${CBBTC_MINT}`);
+        expect(response.status).toBe(200);
+        expect(response.headers.get('cache-control')).toBe('private, max-age=3600');
+
+        const body = await response.json();
+        expect(body.buyMint).toBe(CBBTC_MINT);
+        expect(body.sellMint).toBe(SOL_MINT);
+        expect(body.primary).toBe('titan');
+        expect(body.meta).toEqual({ kinds: ['swap'] });
+        expect(body.links.map((link: { id: string }) => link.id)).toEqual([
+            'titan',
+            'jupiter',
+            'dflow',
+            'sunrise',
+            'omfg',
+            'kamino',
+            'orca',
+            'raydium',
+            'byreal',
+        ]);
+        for (const link of body.links) {
+            expect(link.kind).toBe('swap');
+            expect(['aggregator', 'dex']).toContain(link.venueType);
+            expect(new URL(link.url).href.length).toBeGreaterThan(0);
+            if (link.iconUrl) expect(link.iconUrl.startsWith('https://')).toBe(true);
+        }
+        const titan = body.links.find((link: { id: string }) => link.id === 'titan');
+        expect(titan.iconUrl).toBe('https://tokens.xyz/logos/popular/titan.png');
+        expect(body.asset?.assetId).toBe('bitcoin');
+    });
+
+    it('sells USDC when buying SOL', async () => {
+        const response = await request(`/api/v2/execution/links?mint=${SOL_MINT}`);
+        const body = await response.json();
+        expect(body.sellMint).toBe(USDC_MINT);
+    });
+
+    it('honors the venues filter and nulls primary when titan is excluded', async () => {
+        const response = await request(`/api/v2/execution/links?mint=${CBBTC_MINT}&venues=orca,jupiter`);
+        const body = await response.json();
+        expect(body.links.map((link: { id: string }) => link.id)).toEqual(['jupiter', 'orca']);
+        expect(body.primary).toBeNull();
+    });
+
+    it('rejects unknown venues with valid ids in the message', async () => {
+        const response = await request(`/api/v2/execution/links?mint=${CBBTC_MINT}&venues=orca,uniswap`);
+        expect(response.status).toBe(400);
+        const body = await response.json();
+        expect(body.error._tag).toBe('BadRequestError');
+        expect(body.error.message).toContain('uniswap');
+        expect(body.error.message).toContain('titan');
+    });
+
+    it('rejects unknown kinds', async () => {
+        const response = await request(`/api/v2/execution/links?mint=${CBBTC_MINT}&kinds=perps`);
+        expect(response.status).toBe(400);
+    });
+
+    it('requires exactly one of mint and assetId', async () => {
+        const both = await request(`/api/v2/execution/links?mint=${CBBTC_MINT}&assetId=bitcoin`);
+        expect(both.status).toBe(400);
+
+        const neither = await request('/api/v2/execution/links');
+        expect(neither.status).toBe(400);
+    });
+
+    it('resolves assetId to the primary variant mint', async () => {
+        const response = await request('/api/v2/execution/links?assetId=bitcoin');
+        expect(response.status).toBe(200);
+        const body = await response.json();
+        expect(body.asset?.assetId).toBe('bitcoin');
+        expect(typeof body.buyMint).toBe('string');
+        expect(body.links.length).toBeGreaterThan(0);
+    });
+
+    it('404s for an unknown assetId', async () => {
+        const response = await request('/api/v2/execution/links?assetId=not-a-real-asset');
+        expect(response.status).toBe(404);
+        const body = await response.json();
+        expect(body.error._tag).toBe('NotFoundError');
+    });
+
+    it('rejects an invalid mint', async () => {
+        const response = await request('/api/v2/execution/links?mint=not-a-mint');
+        expect(response.status).toBe(400);
+    });
+
+    it('rejects a non-decimal amount', async () => {
+        const response = await request(`/api/v2/execution/links?mint=${CBBTC_MINT}&amount=1,5`);
+        expect(response.status).toBe(400);
+    });
+
+    it('403s without the execution:read scope', async () => {
+        const response = await request(`/api/v2/execution/links?mint=${CBBTC_MINT}`, ['assets:read']);
+        expect(response.status).toBe(403);
+    });
+});

--- a/apps/api/src/app/api/v2/execution/links/route.ts
+++ b/apps/api/src/app/api/v2/execution/links/route.ts
@@ -1,0 +1,155 @@
+import { Effect } from 'effect';
+
+import { route } from '@/effect/next-route';
+import { BadRequestError, NotFoundError, SolanaAddress, decodeUnknownOrBadRequest } from '@tokens/effect';
+import { getAsset, getVariantByMint, pickPrimaryVariantWithRanking, resolveAlias } from '@tokens/asset-registry';
+import { buildSwapLinks, VENUE_IDS, type VenueId } from '@tokens/execution-links';
+
+import { buildCuratedMintRank } from '../../../v1/assets/_asset-helpers';
+
+const SUPPORTED_LINK_KINDS = ['swap'] as const;
+type LinkKind = (typeof SUPPORTED_LINK_KINDS)[number];
+
+const VALID_VENUE_IDS = new Set<string>(VENUE_IDS);
+const VALID_LINK_KINDS = new Set<string>(SUPPORTED_LINK_KINDS);
+const AMOUNT_PATTERN = /^\d+(\.\d+)?$/;
+
+// Registry data is static per deploy; the curated rank never changes at runtime.
+const CURATED_MINT_RANK = buildCuratedMintRank();
+
+function iconBaseUrl(): string {
+    return (process.env.EXECUTION_LINKS_ICON_BASE_URL ?? 'https://tokens.xyz').replace(/\/+$/, '');
+}
+
+function absolutizeIcon(iconPath: string | null): string | null {
+    if (!iconPath) return null;
+    return iconPath.startsWith('/') ? `${iconBaseUrl()}${iconPath}` : iconPath;
+}
+
+function decodeCsvParam(args: {
+    raw: string | null;
+    key: string;
+    valid: ReadonlySet<string>;
+    validLabel: string;
+}): Effect.Effect<string[] | null, BadRequestError> {
+    if (args.raw == null) return Effect.succeed(null);
+    const values = [...new Set(args.raw.split(',').map(value => value.trim()).filter(Boolean))];
+    if (values.length === 0) {
+        return Effect.fail(new BadRequestError({ message: `${args.key} must name at least one value` }));
+    }
+    const unknown = values.filter(value => !args.valid.has(value));
+    if (unknown.length > 0) {
+        return Effect.fail(
+            new BadRequestError({
+                message: `Unknown ${args.key} value(s): ${unknown.join(', ')}. Valid: ${args.validLabel}`,
+            }),
+        );
+    }
+    return Effect.succeed(values);
+}
+
+function resolveBuyMint(args: {
+    mint: string | null;
+    assetId: string | null;
+}): Effect.Effect<string, BadRequestError | NotFoundError> {
+    return Effect.gen(function* () {
+        if (args.mint && args.assetId) {
+            return yield* Effect.fail(new BadRequestError({ message: 'Provide either mint or assetId, not both' }));
+        }
+        if (args.mint) return args.mint;
+        if (!args.assetId) {
+            return yield* Effect.fail(new BadRequestError({ message: 'Missing required query param: mint or assetId' }));
+        }
+
+        const asset = getAsset(args.assetId) ?? resolveAlias(args.assetId);
+        if (!asset) {
+            return yield* Effect.fail(new NotFoundError({ message: `Unknown asset: ${args.assetId}` }));
+        }
+        const { variant } = pickPrimaryVariantWithRanking({ asset, mintRank: CURATED_MINT_RANK });
+        if (!variant) {
+            return yield* Effect.fail(new NotFoundError({ message: `Asset has no Solana variant: ${asset.assetId}` }));
+        }
+        return variant.mint;
+    });
+}
+
+/**
+ * GET /api/v2/execution/links — venue deep links for buying a token.
+ *
+ * Generic execution-link contract: every link carries a `kind`; this
+ * deployment supports `swap` only (perps/pools extend the same shape later —
+ * see `meta.kinds`). `primary` is our global venue recommendation, null when
+ * filtered out. Output is deterministic from inputs + deployed code, so the
+ * cache window is wide and no stale fallback is needed.
+ */
+export const GET = route(
+    (request: Request) =>
+        Effect.gen(function* () {
+            const url = new URL(request.url);
+            const params = url.searchParams;
+
+            const mint = params.get('mint')
+                ? yield* decodeUnknownOrBadRequest(SolanaAddress, params.get('mint'), 'Invalid mint')
+                : null;
+            const assetId = params.get('assetId')?.trim() || null;
+            const sellMint = params.get('sellMint')
+                ? yield* decodeUnknownOrBadRequest(SolanaAddress, params.get('sellMint'), 'Invalid sellMint')
+                : null;
+
+            const venues = yield* decodeCsvParam({
+                raw: params.get('venues'),
+                key: 'venues',
+                valid: VALID_VENUE_IDS,
+                validLabel: VENUE_IDS.join(', '),
+            });
+            const kinds = yield* decodeCsvParam({
+                raw: params.get('kinds'),
+                key: 'kinds',
+                valid: VALID_LINK_KINDS,
+                validLabel: SUPPORTED_LINK_KINDS.join(', '),
+            });
+
+            const rawAmount = params.get('amount')?.trim() || null;
+            if (rawAmount && !AMOUNT_PATTERN.test(rawAmount)) {
+                return yield* Effect.fail(
+                    new BadRequestError({ message: 'Invalid amount: expected a positive decimal string' }),
+                );
+            }
+
+            const buyMint = yield* resolveBuyMint({ mint, assetId });
+
+            const includeSwap = !kinds || kinds.includes('swap');
+            const result = includeSwap
+                ? buildSwapLinks({
+                      buyMint,
+                      ...(sellMint ? { sellMint } : {}),
+                      ...(rawAmount ? { amount: rawAmount } : {}),
+                      ...(venues ? { venues: venues as VenueId[] } : {}),
+                  })
+                : null;
+
+            const variantMatch = getVariantByMint(result?.buyMint ?? buyMint);
+
+            return {
+                buyMint: result?.buyMint ?? buyMint,
+                sellMint: result?.sellMint ?? null,
+                asset: variantMatch
+                    ? {
+                          assetId: variantMatch.asset.assetId,
+                          symbol: variantMatch.variant.symbol ?? variantMatch.asset.symbol ?? null,
+                      }
+                    : null,
+                primary: result?.primary ?? null,
+                links: (result?.venues ?? []).map(venue => ({
+                    id: venue.id,
+                    name: venue.name,
+                    kind: 'swap' as LinkKind,
+                    venueType: venue.venueType,
+                    url: venue.url,
+                    iconUrl: absolutizeIcon(venue.iconPath),
+                })),
+                meta: { kinds: [...SUPPORTED_LINK_KINDS] },
+            };
+        }),
+    { platform: { requiredScopes: ['execution:read'] }, cache: { maxAge: 3600 } },
+);

--- a/apps/api/src/proxy.ts
+++ b/apps/api/src/proxy.ts
@@ -10,6 +10,7 @@ const isPublicRoute = createRouteMatcher([
     '/api/v1/assets(.*)',
     '/api/v1/news(.*)',
     '/api/v2/lists(.*)',
+    '/api/v2/execution(.*)',
     '/api/token(.*)',
     '/api/coingecko(.*)',
     '/api/x/tokens-feed',

--- a/apps/cloudrun-usage/src/handlers/platformAuth.test.ts
+++ b/apps/cloudrun-usage/src/handlers/platformAuth.test.ts
@@ -125,6 +125,10 @@ describe('authenticateApiKey', () => {
         }
     });
 
+    it('grants execution:read by default (keys with materialized scopes rely on the 0014 backfill)', () => {
+        expect(DEFAULT_LEGACY_SCOPES).toContain('execution:read');
+    });
+
     it('dedupes and trims scopes', async () => {
         const { repo } = makeRepo({
             keyByHash: { ...ACTIVE_KEY, scopes: [' assets:read ', 'assets:read', 'assets:ohlcv:read'] },

--- a/apps/cloudrun-usage/src/handlers/platformAuth.ts
+++ b/apps/cloudrun-usage/src/handlers/platformAuth.ts
@@ -25,6 +25,7 @@ export const DEFAULT_LEGACY_SCOPES: string[] = [
     'assets:risk:read',
     'assets:ohlcv:read',
     'assets:markets:read',
+    'execution:read',
 ];
 
 export interface ApiKeyByHashRow {

--- a/apps/docs/content/docs/v1/authentication.mdx
+++ b/apps/docs/content/docs/v1/authentication.mdx
@@ -31,6 +31,8 @@ Most v1 endpoints currently require:
 
 Some endpoints may accept a *fine-grained* scope in addition to `assets:read`. For example, `GET /v1/assets/risk-summary` accepts either `assets:read` or `assets:risk:read`.
 
+v2 execution endpoints require `execution:read`, which is granted to all keys by default.
+
 If your key doesn’t have the required scope, you’ll receive a `403` error.
 
 ## Request IDs

--- a/apps/docs/content/docs/v2/endpoints/execution.mdx
+++ b/apps/docs/content/docs/v2/endpoints/execution.mdx
@@ -1,0 +1,58 @@
+---
+title: Execution
+description: Venue deep links for adding a "buy X" action to your app.
+---
+
+All endpoints on this page are Platform API endpoints authenticated with `x-api-key` and
+require the `execution:read` scope (granted to all keys by default).
+
+## `GET /v2/execution/links`
+
+Deep links to swap venues for buying a token. Use it to power a "Buy" call-to-action:
+pick the venues you want to show, render them in any order, and treat `primary` as our
+recommendation. Links carry no quote — the venue computes the live price when your user
+lands there.
+
+The contract is kind-based: today every link has `kind: "swap"`; future kinds (perps,
+pools) will be added under the same shape. `meta.kinds` advertises what the deployment
+supports.
+
+- **Scope**: `execution:read`
+- **Query params**:
+  - `mint` — buy-side Solana mint. Exactly one of `mint` / `assetId` is required.
+  - `assetId` — canonical asset id or alias (e.g. `bitcoin`); resolves to the asset's
+    primary Solana variant. Unknown ids return `404`.
+  - `sellMint` (optional) — overrides the sell side. Defaults to SOL, or USDC when buying SOL.
+  - `venues` (optional) — comma-separated venue ids to include. Valid ids: `titan`,
+    `jupiter`, `dflow`, `sunrise`, `omfg`, `kamino`, `orca`, `raydium`, `byreal`.
+    Unknown ids return `400` listing the valid set.
+  - `kinds` (optional) — comma-separated link kinds. Currently only `swap`.
+  - `amount` (optional) — sell-side amount as a positive decimal string. Reserved:
+    currently accepted but not appended to any venue URL.
+
+```ts
+interface ExecutionLinksResponse {
+    buyMint: string;
+    sellMint: string | null;
+    asset: { assetId: string; symbol: string | null } | null; // registry match for the buy mint
+    primary: string | null; // our venue recommendation; null when filtered out
+    links: Array<{
+        id: string; // venue id, e.g. "titan"
+        name: string; // display name, e.g. "Titan"
+        kind: 'swap';
+        venueType: 'aggregator' | 'dex';
+        url: string;
+        iconUrl: string | null;
+    }>;
+    meta: { kinds: string[] }; // link kinds this deployment supports
+}
+```
+
+Some venues drop out per pair instead of erroring: symbol-based venues (Sunrise) are
+omitted when no display symbol can be resolved, and same-mint pairs are omitted where a
+venue can't express them.
+
+```bash
+curl -H "x-api-key: $API_KEY" \
+  "https://api.tokens.xyz/v2/execution/links?assetId=bitcoin&venues=titan,jupiter,orca"
+```

--- a/apps/docs/content/docs/v2/endpoints/meta.json
+++ b/apps/docs/content/docs/v2/endpoints/meta.json
@@ -1,5 +1,5 @@
 {
   "title": "Endpoints",
   "defaultOpen": true,
-  "pages": ["lists"]
+  "pages": ["lists", "execution"]
 }

--- a/apps/docs/content/docs/v2/overview.mdx
+++ b/apps/docs/content/docs/v2/overview.mdx
@@ -3,7 +3,8 @@ title: Overview
 description: API v2 introduces community token lists — curated, project-owned lists served as composable plugins.
 ---
 
-API v2 is additive: every v1 endpoint keeps working unchanged. v2 currently covers **token lists**.
+API v2 is additive: every v1 endpoint keeps working unchanged. v2 currently covers **token lists**
+and **execution links**.
 
 ## Token lists ("lists as plugins")
 
@@ -20,3 +21,12 @@ model.
   so your UI can render appropriate caution.
 
 See [Lists endpoints](/docs/v2/endpoints/lists) for the full reference.
+
+## Execution links
+
+`GET /v2/execution/links` returns venue deep links for buying a token — the building block
+for a "Buy" call-to-action in any app. Callers choose which venues to show; we return our
+recommendation as `primary`. Reads require the `execution:read` scope, granted to all keys
+by default.
+
+See [Execution endpoints](/docs/v2/endpoints/execution) for the full reference.

--- a/bun.lock
+++ b/bun.lock
@@ -59,6 +59,7 @@
         "@clerk/nextjs": "^6.39.5",
         "@tokens/asset-registry": "workspace:*",
         "@tokens/effect": "workspace:*",
+        "@tokens/execution-links": "workspace:*",
         "@tokens/token-risk-helpers": "workspace:*",
         "@upstash/redis": "^1.36.2",
         "effect": "4.0.0-rc.108",

--- a/db/migrations/0014_execution_read_scope.sql
+++ b/db/migrations/0014_execution_read_scope.sql
@@ -1,0 +1,11 @@
+-- Grant the new default `execution:read` scope to existing API keys with
+-- materialized scope arrays. Keys with NULL scopes need nothing — they fall
+-- back to DEFAULT_LEGACY_SCOPES (which now includes execution:read) at auth
+-- time via normalizeScopes.
+
+UPDATE api_keys
+SET scopes = scopes || '["execution:read"]'::jsonb
+WHERE scopes IS NOT NULL
+  AND NOT scopes ? 'execution:read';
+
+INSERT INTO schema_migrations(version) VALUES ('0014_execution_read_scope');

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
         "audit:deps": "bun audit",
         "verify:assets-api-v1": "bun scripts/verify-assets-api-v1-contract.ts",
         "verify:lists-api-v2": "bun scripts/verify-lists-api-v2-contract.ts",
+        "verify:execution-api-v2": "bun scripts/verify-execution-api-v2-contract.ts",
         "verify:asset-registry-hubs": "bun scripts/audit-asset-registry-hubs.ts",
         "format": "prettier --write \"**/*.{ts,tsx,md}\"",
         "postinstall": "node scripts/patch-liveline.mjs && node scripts/setup-git-hooks.mjs",

--- a/scripts/verify-execution-api-v2-contract.ts
+++ b/scripts/verify-execution-api-v2-contract.ts
@@ -1,0 +1,146 @@
+/* eslint-disable no-console */
+
+/**
+ * Live contract check for the v2 execution API.
+ *
+ * Usage:
+ *   API_BASE_URL=http://localhost:3002 API_KEY=... bun scripts/verify-execution-api-v2-contract.ts
+ *
+ * Exercises GET /v2/execution/links (execution:read). The route endpoint is
+ * added to this script when it ships (PR 4 of the execution stack).
+ */
+
+const SOL_MINT = 'So11111111111111111111111111111111111111112';
+const USDC_MINT = 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v';
+const CBBTC_MINT = 'cbbtcf3aa214zXHbiAZQwf4122FBYbraNdFqgw4iMij';
+
+function assert(condition: unknown, message: string): asserts condition {
+    if (!condition) throw new Error(message);
+}
+
+function assertObject(value: unknown, path: string): asserts value is Record<string, unknown> {
+    assert(value !== null && typeof value === 'object', `${path} must be an object`);
+}
+
+function coerceBaseUrl(value: string): string {
+    const trimmed = value.trim().replace(/\/$/, '');
+    assert(trimmed.length > 0, 'API_BASE_URL must be a non-empty string');
+    const hasScheme = /^https?:\/\//i.test(trimmed);
+    const withScheme = hasScheme
+        ? trimmed
+        : trimmed.startsWith('localhost') || trimmed.startsWith('127.0.0.1')
+          ? `http://${trimmed}`
+          : `https://${trimmed}`;
+    try {
+        return new URL(withScheme).toString().replace(/\/$/, '');
+    } catch {
+        throw new Error(`API_BASE_URL is not a valid URL: ${value}`);
+    }
+}
+
+async function getRaw(baseUrl: string, apiKey: string, path: string): Promise<Response> {
+    return fetch(new URL(path, baseUrl), { headers: { 'x-api-key': apiKey } });
+}
+
+async function getJson(baseUrl: string, apiKey: string, path: string): Promise<unknown> {
+    const res = await getRaw(baseUrl, apiKey, path);
+    assert(res.ok, `GET ${path} failed: HTTP ${res.status} ${await res.text().then(t => t.slice(0, 300))}`);
+    return res.json();
+}
+
+function assertLink(link: unknown, path: string): { id: string; url: string } {
+    assertObject(link, path);
+    assert(typeof link.id === 'string' && link.id.length > 0, `${path}.id must be a non-empty string`);
+    assert(typeof link.name === 'string' && link.name.length > 0, `${path}.name must be a non-empty string`);
+    assert(link.kind === 'swap', `${path}.kind must be "swap"`);
+    assert(
+        link.venueType === 'aggregator' || link.venueType === 'dex',
+        `${path}.venueType must be "aggregator" or "dex"`,
+    );
+    assert(typeof link.url === 'string', `${path}.url must be a string`);
+    try {
+        new URL(link.url as string);
+    } catch {
+        throw new Error(`${path}.url is not a valid URL: ${String(link.url)}`);
+    }
+    if (link.iconUrl !== null) {
+        assert(
+            typeof link.iconUrl === 'string' && /^https?:\/\//.test(link.iconUrl),
+            `${path}.iconUrl must be null or an absolute URL`,
+        );
+    }
+    return { id: link.id as string, url: link.url as string };
+}
+
+function assertLinksResponse(body: unknown, label: string): { linkIds: string[]; primary: string | null } {
+    assertObject(body, label);
+    assert(typeof body.buyMint === 'string' && body.buyMint.length > 0, `${label}.buyMint must be a string`);
+    assert(
+        body.sellMint === null || typeof body.sellMint === 'string',
+        `${label}.sellMint must be a string or null`,
+    );
+    assert(body.primary === null || typeof body.primary === 'string', `${label}.primary must be a string or null`);
+    assert(Array.isArray(body.links), `${label}.links must be an array`);
+    const linkIds = body.links.map((link, i) => assertLink(link, `${label}.links[${i}]`).id);
+    assertObject(body.meta, `${label}.meta`);
+    assert(Array.isArray(body.meta.kinds) && body.meta.kinds.includes('swap'), `${label}.meta.kinds must include swap`);
+    if (typeof body.primary === 'string') {
+        assert(linkIds.includes(body.primary), `${label}.primary must reference a returned link id`);
+    }
+    return { linkIds, primary: body.primary as string | null };
+}
+
+async function main(): Promise<void> {
+    const baseUrl = coerceBaseUrl(process.env.API_BASE_URL ?? '');
+    const apiKey = (process.env.API_KEY ?? '').trim();
+    assert(apiKey.length > 0, 'API_KEY must be set');
+
+    // 1. Full venue set for a mint.
+    const byMint = await getJson(baseUrl, apiKey, `api/v2/execution/links?mint=${CBBTC_MINT}`);
+    const { linkIds, primary } = assertLinksResponse(byMint, 'links(mint)');
+    assert(linkIds.length >= 5, `expected at least 5 venues, got ${linkIds.length}`);
+    assert(primary === 'titan', `expected primary=titan, got ${String(primary)}`);
+    console.log(`links(mint): ${linkIds.length} venues, primary=${primary}`);
+
+    // 2. Sell-side defaulting when buying SOL.
+    const solBody = await getJson(baseUrl, apiKey, `api/v2/execution/links?mint=${SOL_MINT}`);
+    assertObject(solBody, 'links(sol)');
+    assert(solBody.sellMint === USDC_MINT, 'buying SOL must default the sell side to USDC');
+    console.log('links(sol): sell side defaults to USDC');
+
+    // 3. Venue filter honored; filtered-out primary is null.
+    const filtered = await getJson(baseUrl, apiKey, `api/v2/execution/links?mint=${CBBTC_MINT}&venues=orca,jupiter`);
+    const filteredResult = assertLinksResponse(filtered, 'links(filtered)');
+    assert(
+        filteredResult.linkIds.join(',') === 'jupiter,orca',
+        `venues filter not honored: ${filteredResult.linkIds.join(',')}`,
+    );
+    assert(filteredResult.primary === null, 'primary must be null when the recommended venue is filtered out');
+    console.log('links(filtered): filter honored, primary nulled');
+
+    // 4. assetId resolution.
+    const byAsset = await getJson(baseUrl, apiKey, 'api/v2/execution/links?assetId=bitcoin');
+    const assetResult = assertLinksResponse(byAsset, 'links(assetId)');
+    assert(assetResult.linkIds.length > 0, 'assetId=bitcoin must resolve to venues');
+    console.log('links(assetId): bitcoin resolved');
+
+    // 5. Error envelopes.
+    const badVenue = await getRaw(baseUrl, apiKey, `api/v2/execution/links?mint=${CBBTC_MINT}&venues=uniswap`);
+    assert(badVenue.status === 400, `unknown venue must 400, got ${badVenue.status}`);
+    const badVenueBody = (await badVenue.json()) as { error?: { _tag?: string } };
+    assert(badVenueBody.error?._tag === 'BadRequestError', 'unknown venue must return the BadRequestError envelope');
+
+    const unknownAsset = await getRaw(baseUrl, apiKey, 'api/v2/execution/links?assetId=not-a-real-asset');
+    assert(unknownAsset.status === 404, `unknown asset must 404, got ${unknownAsset.status}`);
+
+    const missing = await getRaw(baseUrl, apiKey, 'api/v2/execution/links');
+    assert(missing.status === 400, `missing mint/assetId must 400, got ${missing.status}`);
+    console.log('links(errors): 400/404 envelopes verified');
+
+    console.log('v2 execution API contract OK');
+}
+
+main().catch(error => {
+    console.error(String(error instanceof Error ? error.message : error));
+    process.exit(1);
+});


### PR DESCRIPTION
## Summary

PR 2 of the v2 execution endpoints stack (base: `feat/execution-links-package`, #97).

Adds the first public execution endpoint, `GET /v2/execution/links`, serving venue deep links from `@tokens/execution-links`. The contract is kind-based: every link carries `kind: "swap"` today, and `meta.kinds` advertises supported kinds so perps/pools can extend the same shape later.

- Params: `mint` XOR `assetId` (registry primary-variant resolution, 404 on unknown), `sellMint`, `venues` CSV filter (400 with valid ids on unknown), `kinds` CSV, `amount` (reserved no-op)
- `primary` = our global venue recommendation (`titan`), `null` when filtered out
- Icon URLs absolutized against `https://tokens.xyz` (env-overridable via `EXECUTION_LINKS_ICON_BASE_URL`)
- **Plumbing:** `/v2/:path*` rewrite in `next.config.ts` (v2 was previously only reachable at `/api/v2/...` — this also exposes the documented `/v2/lists/*` paths), `/api/v2/execution(.*)` in the proxy public-route matcher
- **Scope:** `execution:read` added to `DEFAULT_LEGACY_SCOPES` (granted to all keys by default) + migration `0014_execution_read_scope.sql` backfilling existing keys with materialized scope arrays. Note: scope grants propagate after the `api-auth:v1:*` Redis TTL; the legacy Convex `apiKeys.ts` mirror (out of repo) needs the same default if still live.
- Docs: new v2 execution endpoints page, v2 overview section, v1 authentication scope note
- `scripts/verify-execution-api-v2-contract.ts` + `verify:execution-api-v2` root script

## Test plan

- [x] 11 route tests (shape, cache header, filter/primary semantics, 400/404/403 envelopes) via the playground-auth pattern
- [x] `platformAuth.test.ts` pins `execution:read` in the defaults
- [x] turbo typecheck + test + lint green for @tokens/api, @tokens/cloudrun-usage, @tokens/execution-links
- [ ] Live: `API_BASE_URL=... API_KEY=... bun run verify:execution-api-v2` after deploy; apply migration 0014 before relying on existing-key access

🤖 Generated with [Claude Code](https://claude.com/claude-code)