### PR TITLE
feat(api): GET /v2/execution/route — ranked best-variant recommendation (Phase A)

### DIFF
--- a/apps/api/src/app/api/v2/execution/route/route.test.ts
+++ b/apps/api/src/app/api/v2/execution/route/route.test.ts
@@ -1,0 +1,228 @@
+import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test';
+
+mock.module('server-only', () => ({}));
+
+const { __resetCloudRunClientForTesting } = await import('@/lib/cloudrun/client');
+const { resetEnvForTests } = await import('@/lib/env');
+const { signPlaygroundProxyAuthPayload } = await import('@/effect/playground-proxy-auth');
+const { GET: routeGet } = await import('./route');
+
+const ORIGINAL_FETCH = globalThis.fetch;
+const ORIGINAL_LOG = console.log;
+const ORIGINAL_WARN = console.warn;
+const ORIGINAL_ERROR = console.error;
+
+const ENV_KEYS = [
+    'TOKENS_CLOUDRUN_AUTH_TOKEN',
+    'TOKENS_CLOUDRUN_ASSETS_URL',
+    'TOKENS_CLOUDRUN_PRICES_URL',
+    'TOKENS_CLOUDRUN_USAGE_URL',
+    'TOKENS_PLAYGROUND_PROXY_SECRET',
+    'TOKENS_USAGE_LOG_MODE',
+    'TOKENS_REDIS_TARGET',
+    'UPSTASH_REDIS_REST_URL',
+    'UPSTASH_REDIS_REST_TOKEN',
+] as const;
+
+const savedEnv: Partial<Record<(typeof ENV_KEYS)[number], string>> = {};
+
+const CBBTC_MINT = 'cbbtcf3aa214zXHbiAZQwf4122FBYbraNdFqgw4iMij';
+const WBTC_MINT = '3NZ9JMVBmGAqocybic2c7LQCJScmgsAZ6vQqTDzcqmJh';
+
+function marketRow(mint: string, liquidity: number, volume24hUSD: number) {
+    return {
+        mint,
+        market: {
+            mint,
+            source: 'birdeye',
+            liquidity,
+            volume24hUSD,
+            trade24h: 5_000,
+            lastFetchedAt: Date.now(),
+        },
+    };
+}
+
+function fillQualityRow(mint: string, executionScore: number) {
+    return {
+        mint,
+        fillQuality: {
+            source: 'clickhouse_fill_quality',
+            quoteMint: 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v',
+            volume24hUSD: 1_000_000,
+            trade24h: 2_000,
+            botVolumeRatio: 0.1,
+            feeBps: 3,
+            flowSourceCount: 5,
+            executionScore,
+            isEligibleForPrimary: true,
+            asOf: Math.floor(Date.now() / 1000),
+            lastComputedAt: Date.now(),
+        },
+    };
+}
+
+function stubCloudRun(): void {
+    globalThis.fetch = (async (input: string | URL | Request) => {
+        const url = String(input);
+        if (url.includes('/query/listDeletedRefs')) {
+            return new Response(JSON.stringify([]), { status: 200 });
+        }
+        if (url.includes('/query/variantMarketsGetLatestByMints')) {
+            return new Response(
+                JSON.stringify([marketRow(CBBTC_MINT, 40_000_000, 9_000_000), marketRow(WBTC_MINT, 5_000_000, 800_000)]),
+                { status: 200 },
+            );
+        }
+        if (url.includes('/query/variantFillQualityGetLatestByMints')) {
+            return new Response(
+                JSON.stringify([fillQualityRow(CBBTC_MINT, 80), fillQualityRow(WBTC_MINT, 55)]),
+                { status: 200 },
+            );
+        }
+        if (url.includes('/query/sanctumResolveRef')) {
+            return new Response('null', { status: 200 });
+        }
+        if (url.includes('/query/resolveAssetRefForApi')) {
+            return new Response('null', { status: 200 });
+        }
+        throw new Error(`Unexpected fetch: ${url}`);
+    }) as typeof fetch;
+}
+
+beforeEach(() => {
+    for (const key of ENV_KEYS) {
+        const value = process.env[key];
+        if (value !== undefined) savedEnv[key] = value;
+        else delete savedEnv[key];
+        delete process.env[key];
+    }
+    process.env.TOKENS_CLOUDRUN_AUTH_TOKEN = 'cloudrun-token';
+    process.env.TOKENS_CLOUDRUN_ASSETS_URL = 'https://assets.example.run.app';
+    process.env.TOKENS_CLOUDRUN_PRICES_URL = 'https://prices.example.run.app';
+    process.env.TOKENS_CLOUDRUN_USAGE_URL = 'https://usage.example.run.app';
+    process.env.TOKENS_PLAYGROUND_PROXY_SECRET = 'test-playground-secret';
+    process.env.TOKENS_USAGE_LOG_MODE = 'off';
+    resetEnvForTests();
+    __resetCloudRunClientForTesting();
+    stubCloudRun();
+
+    console.log = () => undefined;
+    console.warn = () => undefined;
+    console.error = () => undefined;
+});
+
+afterEach(() => {
+    globalThis.fetch = ORIGINAL_FETCH;
+    console.log = ORIGINAL_LOG;
+    console.warn = ORIGINAL_WARN;
+    console.error = ORIGINAL_ERROR;
+
+    for (const key of ENV_KEYS) {
+        const value = savedEnv[key];
+        if (value === undefined) delete process.env[key];
+        else process.env[key] = value;
+    }
+    resetEnvForTests();
+    __resetCloudRunClientForTesting();
+});
+
+async function request(path: string, scopes: string[] = ['execution:read']): Promise<Response> {
+    const now = Date.now();
+    const header = await signPlaygroundProxyAuthPayload({
+        apiKeyId: 'test-key',
+        keyPrefix: 'tk_test',
+        projectId: 'test-project',
+        ownerClerkUserId: 'test-user',
+        scopes,
+        iat: now,
+        exp: now + 60_000,
+    });
+    return routeGet(
+        new Request(`https://api.example.test${path}`, { headers: { 'x-tokens-playground-auth': header } }),
+        {} as never,
+    );
+}
+
+describe('GET /api/v2/execution/route', () => {
+    it('ranks bitcoin variants and recommends the top candidate as primary', async () => {
+        const response = await request('/api/v2/execution/route?asset=bitcoin');
+        expect(response.status).toBe(200);
+        expect(response.headers.get('cache-control')).toBe('private, max-age=60');
+
+        const body = await response.json();
+        expect(body.asset.assetId).toBe('bitcoin');
+        expect(body.side).toBe('buy');
+        expect(body.amountUsd).toBeNull();
+        expect(body.primary?.mint).toBe(CBBTC_MINT);
+        expect(body.variants.length).toBeGreaterThan(1);
+        expect(body.variants[0].mint).toBe(CBBTC_MINT);
+        expect(body.variants[0].rank).toBe(1);
+        expect(Array.isArray(body.variants[0].reasons)).toBe(true);
+        expect(body.variants[0].liquidityUsd).toBe(40_000_000);
+        expect(body.variants[0].executionScore).toBe(80);
+        expect(body.variants[0].isFillQualityEligible).toBe(true);
+        expect(body.variants[0].estimatedImpactBps).toBeNull();
+        expect(body.variants[0].sizeAwareScore).toBeNull();
+        expect(body.meta.scoringVersion).toBe('fill-quality-24h-5s-v1');
+        expect(body.meta.strategy).toBe('execution_quality');
+        expect(body.meta.sizeAwareScoringVersion).toBeNull();
+        expect(body.meta.depthSource).toBeNull();
+        expect(body.meta.depthCoverage).toBeNull();
+
+        // Ranks are contiguous and every variant appears exactly once.
+        const mints = body.variants.map((entry: { mint: string }) => entry.mint);
+        expect(new Set(mints).size).toBe(mints.length);
+        expect(body.variants.map((entry: { rank: number }) => entry.rank)).toEqual(
+            body.variants.map((_: unknown, index: number) => index + 1),
+        );
+    });
+
+    it('marks every variant depth_unavailable when amountUsd is given (Phase A)', async () => {
+        const response = await request('/api/v2/execution/route?asset=bitcoin&amountUsd=1000000');
+        expect(response.status).toBe(200);
+        const body = await response.json();
+        expect(body.amountUsd).toBe(1_000_000);
+        expect(body.meta.depthCoverage).toEqual({ withCurves: 0, total: body.variants.length });
+        for (const entry of body.variants) {
+            expect(entry.reasons).toContain('depth_unavailable');
+            expect(entry.estimatedImpactBps).toBeNull();
+        }
+    });
+
+    it('clamps amountUsd to the supported range', async () => {
+        const response = await request('/api/v2/execution/route?asset=bitcoin&amountUsd=999999999');
+        const body = await response.json();
+        expect(body.amountUsd).toBe(50_000_000);
+    });
+
+    it('accepts side=sell and defaults side to buy', async () => {
+        const sell = await request('/api/v2/execution/route?asset=bitcoin&side=sell');
+        expect((await sell.json()).side).toBe('sell');
+
+        const invalid = await request('/api/v2/execution/route?asset=bitcoin&side=hold');
+        expect(invalid.status).toBe(400);
+    });
+
+    it('rejects a non-positive amountUsd', async () => {
+        const response = await request('/api/v2/execution/route?asset=bitcoin&amountUsd=-5');
+        expect(response.status).toBe(400);
+    });
+
+    it('requires the asset param', async () => {
+        const response = await request('/api/v2/execution/route');
+        expect(response.status).toBe(400);
+    });
+
+    it('404s for an unknown asset', async () => {
+        const response = await request('/api/v2/execution/route?asset=not-a-real-asset');
+        expect(response.status).toBe(404);
+        const body = await response.json();
+        expect(body.error._tag).toBe('NotFoundError');
+    });
+
+    it('403s without the execution:read scope', async () => {
+        const response = await request('/api/v2/execution/route?asset=bitcoin', ['assets:read']);
+        expect(response.status).toBe(403);
+    });
+});

--- a/apps/api/src/app/api/v2/execution/route/route.ts
+++ b/apps/api/src/app/api/v2/execution/route/route.ts
@@ -1,0 +1,185 @@
+import { Effect } from 'effect';
+
+import { route } from '@/effect/next-route';
+import { withStaleFallback } from '@/effect/stale-response-cache';
+import { BadRequestError } from '@tokens/effect';
+import {
+    FILL_QUALITY_SCORING_VERSION,
+    getAsset,
+    isFillQualityEligibleForPrimary,
+    rankVariantsWithReasons,
+    type VariantFillQualityRankingSnapshot,
+    type VariantMarketRankingSnapshot,
+} from '@tokens/asset-registry';
+import { variantFillQualityGetLatestByMints, variantMarketsGetLatestByMints } from '@/lib/cloudrun';
+
+import { buildCuratedMintRank, executionQualitySnapshotFromConvexFillQuality } from '../../../v1/assets/_asset-helpers';
+import { resolveAssetRefContext } from '../../../v1/assets/_resolve-asset-ref';
+
+const STALE_TTL_SECONDS = 10 * 60;
+const MIN_AMOUNT_USD = 1;
+const MAX_AMOUNT_USD = 50_000_000;
+const MAX_VARIANT_MINTS = 250;
+
+// Registry data is static per deploy; the curated rank never changes at runtime.
+const CURATED_MINT_RANK = buildCuratedMintRank();
+
+type Side = 'buy' | 'sell';
+
+function decodeAmountUsd(raw: string | null): Effect.Effect<number | null, BadRequestError> {
+    if (raw == null || raw.trim() === '') return Effect.succeed(null);
+    const parsed = Number(raw);
+    if (!Number.isFinite(parsed) || parsed <= 0) {
+        return Effect.fail(new BadRequestError({ message: 'Invalid amountUsd: expected a positive number' }));
+    }
+    return Effect.succeed(Math.min(MAX_AMOUNT_USD, Math.max(MIN_AMOUNT_USD, parsed)));
+}
+
+function decodeSide(raw: string | null): Effect.Effect<Side, BadRequestError> {
+    if (raw == null || raw.trim() === '') return Effect.succeed('buy');
+    const side = raw.trim().toLowerCase();
+    if (side !== 'buy' && side !== 'sell') {
+        return Effect.fail(new BadRequestError({ message: 'Invalid side: expected buy or sell' }));
+    }
+    return Effect.succeed(side);
+}
+
+/** Bucket the stale-fallback cache key to 2 significant figures to bound cardinality. */
+function amountCacheBucket(amountUsd: number | null): string {
+    if (amountUsd === null) return 'na';
+    return Number(amountUsd.toPrecision(2)).toString();
+}
+
+/**
+ * GET /api/v2/execution/route — ranked "best variant" recommendation for a
+ * canonical asset ("I want to buy bitcoin on Solana — which mint?").
+ *
+ * The full ranked list is always returned so callers render what they want;
+ * `primary` is our recommendation, consistent with the primary-variant
+ * concept used across v1. Size-aware fields (`estimatedImpactBps`,
+ * `sizeAwareScore`, ...) are part of the contract from day one and populate
+ * once the depth-sampling pipeline lands — until then they are null and
+ * `amountUsd` requests carry a `depth_unavailable` reason per variant.
+ */
+export const GET = route(
+    (request: Request) =>
+        Effect.gen(function* () {
+            const url = new URL(request.url);
+            const assetRef = url.searchParams.get('asset')?.trim() || null;
+            if (!assetRef) {
+                return yield* Effect.fail(new BadRequestError({ message: 'Missing required query param: asset' }));
+            }
+            const amountUsd = yield* decodeAmountUsd(url.searchParams.get('amountUsd'));
+            const side = yield* decodeSide(url.searchParams.get('side'));
+
+            const resolution = yield* resolveAssetRefContext(assetRef);
+
+            const main = Effect.gen(function* () {
+                const asset = getAsset(resolution.assetId);
+                const variants = asset?.variants ?? [];
+                const mints = variants.map(variant => variant.mint).slice(0, MAX_VARIANT_MINTS);
+
+                const [marketRows, fillQualityRows] =
+                    mints.length > 0
+                        ? yield* Effect.all(
+                              [
+                                  variantMarketsGetLatestByMints({ mints }),
+                                  variantFillQualityGetLatestByMints({ mints }),
+                              ],
+                              { concurrency: 'unbounded' },
+                          )
+                        : [[], []];
+
+                const marketByMint = new Map<string, VariantMarketRankingSnapshot | null>();
+                const marketDocByMint = new Map<string, (typeof marketRows)[number]['market']>();
+                for (const row of marketRows) {
+                    marketDocByMint.set(row.mint, row.market);
+                    marketByMint.set(
+                        row.mint,
+                        row.market
+                            ? {
+                                  liquidity: row.market.liquidity ?? null,
+                                  volume24hUSD: row.market.volume24hUSD ?? null,
+                                  trade24h: row.market.trade24h ?? null,
+                              }
+                            : null,
+                    );
+                }
+                const fillQualityByMint = new Map<string, VariantFillQualityRankingSnapshot | null>();
+                for (const row of fillQualityRows) {
+                    fillQualityByMint.set(row.mint, executionQualitySnapshotFromConvexFillQuality(row.fillQuality));
+                }
+
+                const ranked = asset
+                    ? rankVariantsWithReasons({
+                          asset,
+                          mintRank: CURATED_MINT_RANK,
+                          marketByMint,
+                          fillQualityByMint,
+                          options: { strategy: 'execution_quality' },
+                      })
+                    : [];
+
+                const first = ranked[0] ?? null;
+
+                return {
+                    asset: {
+                        assetId: resolution.assetId,
+                        name: asset?.name ?? null,
+                        symbol: asset?.symbol ?? null,
+                        category: asset?.category ?? null,
+                    },
+                    side,
+                    amountUsd,
+                    primary:
+                        first && first.isPrimaryCandidate
+                            ? { mint: first.variant.mint, variantId: first.variant.variantId, reason: first.reason }
+                            : null,
+                    variants: ranked.map(entry => {
+                        const market = marketDocByMint.get(entry.variant.mint) ?? null;
+                        const fillQuality = fillQualityByMint.get(entry.variant.mint) ?? null;
+                        return {
+                            rank: entry.rank,
+                            mint: entry.variant.mint,
+                            variantId: entry.variant.variantId,
+                            kind: entry.variant.kind,
+                            issuer: entry.variant.issuer ?? null,
+                            trustTier: entry.variant.trustTier,
+                            symbol: entry.variant.symbol ?? market?.symbol ?? null,
+                            name: entry.variant.name ?? market?.name ?? null,
+                            liquidityUsd: market?.liquidity ?? null,
+                            volume24hUSD: market?.volume24hUSD ?? null,
+                            executionScore: fillQuality?.executionScore ?? null,
+                            feeBps: fillQuality?.feeBps ?? null,
+                            isFillQualityEligible: isFillQualityEligibleForPrimary(fillQuality),
+                            // Size-aware fields populate when the depth pipeline lands.
+                            estimatedImpactBps: null as number | null,
+                            estimatedOutUsd: null as number | null,
+                            sizeAwareScore: null as number | null,
+                            depthAsOf: null as number | null,
+                            reasons: [entry.reason, ...(amountUsd !== null ? ['depth_unavailable'] : [])],
+                        };
+                    }),
+                    meta: {
+                        asOf: Math.floor(Date.now() / 1000),
+                        scoringVersion: FILL_QUALITY_SCORING_VERSION,
+                        sizeAwareScoringVersion: null as string | null,
+                        strategy: 'execution_quality' as const,
+                        sizeLadderUsd: null as number[] | null,
+                        depthSource: null as string | null,
+                        depthCoverage: amountUsd !== null ? { withCurves: 0, total: ranked.length } : null,
+                    },
+                };
+            });
+
+            return yield* withStaleFallback(
+                {
+                    operation: 'v2.execution.route',
+                    cacheKey: `v2:execution:route:${resolution.assetId}:${side}:${amountCacheBucket(amountUsd)}`,
+                    ttlSeconds: STALE_TTL_SECONDS,
+                },
+                main,
+            );
+        }),
+    { platform: { requiredScopes: ['execution:read'] }, cache: { maxAge: 60 } },
+);

--- a/apps/docs/content/docs/v2/endpoints/execution.mdx
+++ b/apps/docs/content/docs/v2/endpoints/execution.mdx
@@ -56,3 +56,69 @@ venue can't express them.
 curl -H "x-api-key: $API_KEY" \
   "https://api.tokens.xyz/v2/execution/links?assetId=bitcoin&venues=titan,jupiter,orca"
 ```
+
+## `GET /v2/execution/route`
+
+Ranked "best variant" recommendation for a canonical asset — "I want to buy bitcoin on
+Solana, which mint?". Returns the full ranked variant list (render what you want) with
+our recommendation as `primary`, scored by the same execution-quality ranking that
+powers primary-variant selection across v1 (liquidity, volume, fill quality, trust tier).
+
+Size-aware fields are part of the contract from day one and populate once the
+depth-sampling pipeline is live: with `amountUsd`, variants gain `estimatedImpactBps` /
+`estimatedOutUsd` / `sizeAwareScore` interpolated from sampled price-impact curves.
+Until a variant has a fresh curve, those fields are `null` and its `reasons` include
+`depth_unavailable`.
+
+- **Scope**: `execution:read`
+- **Query params**:
+  - `asset` (required) — canonical asset id, alias, or Solana mint (e.g. `bitcoin`).
+  - `amountUsd` (optional) — intended trade size in USD, clamped to `[1, 50000000]`.
+  - `side` (optional) — `buy` (default) or `sell`.
+
+```ts
+interface ExecutionRouteResponse {
+    asset: { assetId: string; name: string | null; symbol: string | null; category: string | null };
+    side: 'buy' | 'sell';
+    amountUsd: number | null;
+    primary: { mint: string; variantId: string; reason: string } | null;
+    variants: Array<{
+        rank: number; // 1-based
+        mint: string;
+        variantId: string;
+        kind: string; // native | wrapped | bridged | spot | lst | ...
+        issuer: string | null;
+        trustTier: string;
+        symbol: string | null;
+        name: string | null;
+        liquidityUsd: number | null;
+        volume24hUSD: number | null;
+        executionScore: number | null; // 0-100 fill-quality score
+        feeBps: number | null;
+        isFillQualityEligible: boolean;
+        estimatedImpactBps: number | null; // populated with amountUsd + fresh depth data
+        estimatedOutUsd: number | null;
+        sizeAwareScore: number | null;
+        depthAsOf: number | null; // unix seconds of the depth sample
+        reasons: string[]; // e.g. ["liquidity"], ["execution_quality_override", "depth_unavailable"]
+    }>;
+    meta: {
+        asOf: number; // unix seconds
+        scoringVersion: string;
+        sizeAwareScoringVersion: string | null;
+        strategy: 'execution_quality' | 'size_aware';
+        sizeLadderUsd: number[] | null;
+        depthSource: string | null;
+        depthCoverage: { withCurves: number; total: number } | null; // present when amountUsd given
+    };
+}
+```
+
+Single-variant assets return one entry with `primary.reason: "only_candidate"`; assets
+with no Solana variants return an empty `variants` array and `primary: null`. Unknown
+assets return `404`.
+
+```bash
+curl -H "x-api-key: $API_KEY" \
+  "https://api.tokens.xyz/v2/execution/route?asset=bitcoin&amountUsd=1000000"
+```

--- a/packages/asset-registry/src/index.ts
+++ b/packages/asset-registry/src/index.ts
@@ -21,8 +21,10 @@ export type {
     PrimaryVariantSelectionReason,
     PrimaryVariantSelectionResult,
     PrimaryVariantStrategy,
+    RankedVariantEntry,
     VariantFillQualityRankingSnapshot,
     VariantMarketRankingSnapshot,
+    VariantRankingExclusionReason,
 } from './primary-variant-ranking';
 export {
     FILL_QUALITY_SCORING_VERSION,
@@ -30,6 +32,7 @@ export {
     isFillQualityEligibleForPrimary,
     isSpotLikeVariantKind,
     pickPrimaryVariantWithRanking,
+    rankVariantsWithReasons,
 } from './primary-variant-ranking';
 
 export {

--- a/packages/asset-registry/src/primary-variant-ranking.test.ts
+++ b/packages/asset-registry/src/primary-variant-ranking.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'bun:test';
 import {
     isSpotLikeVariantKind,
     pickPrimaryVariantWithRanking,
+    rankVariantsWithReasons,
     type PrimaryVariantStrategy,
     type VariantFillQualityRankingSnapshot,
     type VariantMarketRankingSnapshot,
@@ -332,5 +333,158 @@ describe('pickPrimaryVariantWithRanking', () => {
         });
 
         expect(selected?.mint).toBe(MINT_A);
+    });
+});
+
+describe('rankVariantsWithReasons', () => {
+    function rank(params: {
+        variants: AssetVariant[];
+        marketByMint?: Map<string, VariantMarketRankingSnapshot>;
+        fillQualityByMint?: Map<string, VariantFillQualityRankingSnapshot>;
+        strategy?: PrimaryVariantStrategy;
+    }) {
+        return rankVariantsWithReasons({
+            asset: asset(params.variants),
+            mintRank: new Map([
+                [MINT_A, 0],
+                [MINT_B, 1],
+                [MINT_C, 2],
+                [MINT_D, 3],
+            ]),
+            ...(params.marketByMint ? { marketByMint: params.marketByMint } : {}),
+            ...(params.fillQualityByMint ? { fillQualityByMint: params.fillQualityByMint } : {}),
+            options: { nowSeconds: NOW, ...(params.strategy ? { strategy: params.strategy } : {}) },
+        });
+    }
+
+    it('matches the pickPrimaryVariantWithRanking winner across strategies and data shapes', () => {
+        const configs: Array<{
+            variants: AssetVariant[];
+            marketByMint: Map<string, VariantMarketRankingSnapshot>;
+            fillQualityByMint?: Map<string, VariantFillQualityRankingSnapshot>;
+            strategy?: PrimaryVariantStrategy;
+        }> = [
+            {
+                variants: [variant(MINT_A, 'tesla:ondo'), variant(MINT_B, 'tesla:xstock')],
+                marketByMint: new Map([
+                    [MINT_A, market({ liquidity: 100_000 })],
+                    [MINT_B, market({ liquidity: 5_000_000 })],
+                ]),
+            },
+            {
+                variants: [
+                    variant(MINT_A, 'tesla:ondo'),
+                    variant(MINT_B, 'tesla:xstock'),
+                    variant(MINT_C, 'tesla:c'),
+                ],
+                marketByMint: new Map([
+                    [MINT_A, market({ liquidity: 2_000_000 })],
+                    [MINT_B, market({ liquidity: 1_900_000 })],
+                    [MINT_C, market({ liquidity: 40, volume24hUSD: 10, trade24h: 1 })],
+                ]),
+            },
+            {
+                variants: [variant(MINT_A, 'tesla:ondo'), variant(MINT_B, 'tesla:xstock')],
+                marketByMint: new Map([
+                    [MINT_A, market({ liquidity: 1_000_000 })],
+                    [MINT_B, market({ liquidity: 900_000 })],
+                ]),
+                fillQualityByMint: new Map([
+                    [MINT_A, fill({ executionScore: 30 })],
+                    [MINT_B, fill({ executionScore: 80 })],
+                ]),
+                strategy: 'execution_quality' as PrimaryVariantStrategy,
+            },
+        ];
+
+        for (const config of configs) {
+            const ranked = rankVariantsWithReasons({
+                asset: asset(config.variants),
+                mintRank: new Map([
+                    [MINT_A, 0],
+                    [MINT_B, 1],
+                    [MINT_C, 2],
+                ]),
+                marketByMint: config.marketByMint,
+                ...(config.fillQualityByMint ? { fillQualityByMint: config.fillQualityByMint } : {}),
+                options: { nowSeconds: NOW, ...(config.strategy ? { strategy: config.strategy } : {}) },
+            });
+            const picked = pickPrimaryVariantWithRanking({
+                asset: asset(config.variants),
+                mintRank: new Map([
+                    [MINT_A, 0],
+                    [MINT_B, 1],
+                    [MINT_C, 2],
+                ]),
+                marketByMint: config.marketByMint,
+                ...(config.fillQualityByMint ? { fillQualityByMint: config.fillQualityByMint } : {}),
+                options: { nowSeconds: NOW, ...(config.strategy ? { strategy: config.strategy } : {}) },
+            });
+            expect(ranked[0]?.variant.mint).toBe(picked.variant!.mint);
+            expect(ranked[0]?.reason).toBe(picked.reason!);
+        }
+    });
+
+    it('orders candidates by liquidity and covers every variant exactly once with 1-based ranks', () => {
+        const ranked = rank({
+            variants: [variant(MINT_A, 'tesla:a'), variant(MINT_B, 'tesla:b'), variant(MINT_C, 'tesla:c')],
+            marketByMint: new Map([
+                [MINT_A, market({ liquidity: 1_000_000 })],
+                [MINT_B, market({ liquidity: 3_000_000 })],
+                [MINT_C, market({ liquidity: 2_000_000 })],
+            ]),
+        });
+
+        expect(ranked.map(entry => entry.variant.mint)).toEqual([MINT_B, MINT_C, MINT_A]);
+        expect(ranked.map(entry => entry.rank)).toEqual([1, 2, 3]);
+        expect(ranked[0]?.reason).toBe('liquidity');
+        expect(ranked.every(entry => entry.isPrimaryCandidate)).toBe(true);
+    });
+
+    it('trails activity-filtered variants with an exclusion reason', () => {
+        const ranked = rank({
+            variants: [variant(MINT_A, 'tesla:a'), variant(MINT_B, 'tesla:b'), variant(MINT_C, 'tesla:c')],
+            marketByMint: new Map([
+                [MINT_A, market({ liquidity: 1_000_000 })],
+                [MINT_B, market({ liquidity: 3_000_000 })],
+                [MINT_C, market({ liquidity: 2_000_000, volume24hUSD: 10, trade24h: 1 })],
+            ]),
+        });
+
+        const last = ranked[ranked.length - 1]!;
+        expect(last.variant.mint).toBe(MINT_C);
+        expect(last.reason).toBe('excluded_by_activity_filter');
+        expect(last.isPrimaryCandidate).toBe(false);
+        expect(ranked.filter(entry => entry.isPrimaryCandidate).length).toBe(2);
+    });
+
+    it('trails non-spot-like variants when spot-like variants exist', () => {
+        const spot: AssetVariant = { ...variant(MINT_A, 'gold:spot'), kind: 'spot' };
+        const etf: AssetVariant = { ...variant(MINT_B, 'gold:etf'), kind: 'etf' };
+        const ranked = rank({
+            variants: [spot, etf],
+            marketByMint: new Map([
+                [MINT_A, market({ liquidity: 100_000 })],
+                [MINT_B, market({ liquidity: 5_000_000 })],
+            ]),
+        });
+
+        expect(ranked.map(entry => entry.variant.mint)).toEqual([MINT_A, MINT_B]);
+        expect(ranked[0]?.reason).toBe('only_candidate');
+        expect(ranked[1]?.reason).toBe('non_spot_like');
+        expect(ranked[1]?.isPrimaryCandidate).toBe(false);
+    });
+
+    it('reports only_candidate for a single-variant asset', () => {
+        const ranked = rank({
+            variants: [variant(MINT_A, 'tesla:a')],
+            marketByMint: new Map([[MINT_A, market()]]),
+        });
+        expect(ranked).toHaveLength(1);
+        expect(ranked[0]?.reason).toBe('only_candidate');
+    });
+
+    it('returns an empty list for an asset with no variants', () => {
+        expect(rank({ variants: [] })).toEqual([]);
     });
 });

--- a/packages/asset-registry/src/primary-variant-ranking.ts
+++ b/packages/asset-registry/src/primary-variant-ranking.ts
@@ -177,6 +177,111 @@ export function pickPrimaryVariantWithRanking(params: {
     return { variant: best, reason };
 }
 
+export type VariantRankingExclusionReason = 'excluded_by_activity_filter' | 'non_spot_like';
+
+export interface RankedVariantEntry {
+    variant: AssetVariant;
+    /** 1-based position in the ranked list. */
+    rank: number;
+    reason: PrimaryVariantSelectionReason | VariantRankingExclusionReason;
+    /** True for variants that survived candidate filtering (spot-like preference + activity gate). */
+    isPrimaryCandidate: boolean;
+}
+
+/**
+ * List-producing counterpart of `pickPrimaryVariantWithRanking`: the full
+ * variant set in recommendation order with a per-variant reason. Ordering is
+ * derived by repeated selection with the exact pick-loop semantics, so the
+ * first entry is always the variant `pickPrimaryVariantWithRanking` returns
+ * for identical inputs (unit-tested invariant). Variants excluded from the
+ * candidate set (activity-filtered, or non-spot-like when spot-like variants
+ * exist) trail the candidates, ordered by liquidity.
+ */
+export function rankVariantsWithReasons(params: {
+    asset: CanonicalAsset;
+    mintRank: ReadonlyMap<string, number>;
+    marketByMint?: ReadonlyMap<string, VariantMarketRankingSnapshot | null | undefined>;
+    fillQualityByMint?: ReadonlyMap<string, VariantFillQualityRankingSnapshot | null | undefined>;
+    /**
+     * Reserved for size-aware ranking: interpolated price impact (bps) per
+     * mint. Informational-only until size-aware reordering is activated —
+     * it never affects ordering today.
+     */
+    impactByMint?: ReadonlyMap<string, number | null>;
+    options?: PrimaryVariantRankingOptions;
+}): RankedVariantEntry[] {
+    if (params.asset.variants.length === 0) return [];
+
+    const spotLikeVariants = params.asset.variants.filter(v => isSpotLikeVariantKind(v.kind));
+    const baseCandidates = spotLikeVariants.length > 0 ? spotLikeVariants : params.asset.variants;
+    const candidates = filterPrimaryCandidatesByActivity({
+        candidates: baseCandidates,
+        marketByMint: params.marketByMint,
+        fillQualityByMint: params.fillQualityByMint,
+    });
+
+    const nowSeconds = params.options?.nowSeconds ?? Math.floor(Date.now() / 1000);
+    const lexicalTieBreak = params.options?.lexicalTieBreak ?? false;
+    const strategy = params.options?.strategy ?? 'liquidity';
+    const activityFiltered = candidates.length !== baseCandidates.length;
+
+    const entries: RankedVariantEntry[] = [];
+    const remaining = [...candidates];
+    while (remaining.length > 0) {
+        // Each round replicates the pick loop over the remaining candidates,
+        // including its initial-reason semantics for the first round.
+        let best = remaining[0]!;
+        let reason: PrimaryVariantSelectionReason;
+        if (entries.length === 0) {
+            reason = candidates.length === 1 ? 'only_candidate' : activityFiltered ? 'activity_filter' : 'first_candidate';
+        } else {
+            reason = 'first_candidate';
+        }
+        for (let i = 1; i < remaining.length; i++) {
+            const next = remaining[i]!;
+            const comparison = comparePrimaryVariantCandidates({
+                next,
+                best,
+                assetCategory: params.asset.category,
+                mintRank: params.mintRank,
+                marketByMint: params.marketByMint,
+                fillQualityByMint: params.fillQualityByMint,
+                nowSeconds,
+                lexicalTieBreak,
+                strategy,
+            });
+            if (comparison.isBetter) {
+                best = next;
+                reason = comparison.reason;
+            }
+        }
+        entries.push({ variant: best, rank: entries.length + 1, reason, isPrimaryCandidate: true });
+        remaining.splice(remaining.indexOf(best), 1);
+    }
+
+    const rankedMints = new Set(entries.map(entry => entry.variant.mint));
+    const byLiquidityDesc = (a: AssetVariant, b: AssetVariant) =>
+        getLiquidity(params.marketByMint, b.mint) - getLiquidity(params.marketByMint, a.mint);
+
+    const activityExcluded = baseCandidates.filter(v => !rankedMints.has(v.mint)).sort(byLiquidityDesc);
+    for (const variant of activityExcluded) {
+        entries.push({
+            variant,
+            rank: entries.length + 1,
+            reason: 'excluded_by_activity_filter',
+            isPrimaryCandidate: false,
+        });
+        rankedMints.add(variant.mint);
+    }
+
+    const nonSpotLike = params.asset.variants.filter(v => !rankedMints.has(v.mint)).sort(byLiquidityDesc);
+    for (const variant of nonSpotLike) {
+        entries.push({ variant, rank: entries.length + 1, reason: 'non_spot_like', isPrimaryCandidate: false });
+    }
+
+    return entries;
+}
+
 function comparePrimaryVariantCandidates(params: {
     next: AssetVariant;
     best: AssetVariant;

--- a/scripts/verify-execution-api-v2-contract.ts
+++ b/scripts/verify-execution-api-v2-contract.ts
@@ -6,8 +6,9 @@
  * Usage:
  *   API_BASE_URL=http://localhost:3002 API_KEY=... bun scripts/verify-execution-api-v2-contract.ts
  *
- * Exercises GET /v2/execution/links (execution:read). The route endpoint is
- * added to this script when it ships (PR 4 of the execution stack).
+ * Exercises GET /v2/execution/links and GET /v2/execution/route
+ * (execution:read). Route checks tolerate depthCoverage.withCurves = 0 so the
+ * script passes before the depth-sampling cron warms.
  */
 
 const SOL_MINT = 'So11111111111111111111111111111111111111112';
@@ -137,7 +138,86 @@ async function main(): Promise<void> {
     assert(missing.status === 400, `missing mint/assetId must 400, got ${missing.status}`);
     console.log('links(errors): 400/404 envelopes verified');
 
+    // 6. Route: size-agnostic ranking.
+    const routeBody = await getJson(baseUrl, apiKey, 'api/v2/execution/route?asset=bitcoin');
+    const ranked = assertRouteResponse(routeBody, 'route(bitcoin)', { expectAmount: null });
+    assert(ranked.variantMints.length > 1, 'bitcoin must rank multiple variants');
+    console.log(`route(bitcoin): ${ranked.variantMints.length} variants, primary=${ranked.primaryMint ?? 'null'}`);
+
+    // 7. Route: size-aware request (fields typed, tolerant of no depth data yet).
+    const sized = await getJson(baseUrl, apiKey, 'api/v2/execution/route?asset=bitcoin&amountUsd=1000000');
+    assertRouteResponse(sized, 'route(bitcoin, $1M)', { expectAmount: 1_000_000 });
+    console.log('route(bitcoin, $1M): size-aware contract verified');
+
+    // 8. Route errors.
+    const routeUnknown = await getRaw(baseUrl, apiKey, 'api/v2/execution/route?asset=not-a-real-asset');
+    assert(routeUnknown.status === 404, `unknown asset must 404, got ${routeUnknown.status}`);
+    const routeMissing = await getRaw(baseUrl, apiKey, 'api/v2/execution/route');
+    assert(routeMissing.status === 400, `missing asset must 400, got ${routeMissing.status}`);
+    const routeBadAmount = await getRaw(baseUrl, apiKey, 'api/v2/execution/route?asset=bitcoin&amountUsd=-1');
+    assert(routeBadAmount.status === 400, `negative amountUsd must 400, got ${routeBadAmount.status}`);
+    console.log('route(errors): 400/404 envelopes verified');
+
     console.log('v2 execution API contract OK');
+}
+
+function assertNullableNumber(value: unknown, path: string): void {
+    if (value === null) return;
+    assert(typeof value === 'number' && Number.isFinite(value), `${path} must be a finite number or null`);
+}
+
+function assertRouteResponse(
+    body: unknown,
+    label: string,
+    opts: { expectAmount: number | null },
+): { variantMints: string[]; primaryMint: string | null } {
+    assertObject(body, label);
+    assertObject(body.asset, `${label}.asset`);
+    assert(typeof body.asset.assetId === 'string', `${label}.asset.assetId must be a string`);
+    assert(body.side === 'buy' || body.side === 'sell', `${label}.side must be buy or sell`);
+    assert(body.amountUsd === opts.expectAmount, `${label}.amountUsd must echo ${String(opts.expectAmount)}`);
+    assert(Array.isArray(body.variants), `${label}.variants must be an array`);
+
+    const variantMints: string[] = [];
+    body.variants.forEach((entry, i) => {
+        const path = `${label}.variants[${i}]`;
+        assertObject(entry, path);
+        assert(typeof entry.mint === 'string' && entry.mint.length > 0, `${path}.mint must be a string`);
+        assert(typeof entry.variantId === 'string', `${path}.variantId must be a string`);
+        assert(entry.rank === i + 1, `${path}.rank must be ${i + 1}`);
+        assertNullableNumber(entry.liquidityUsd, `${path}.liquidityUsd`);
+        assertNullableNumber(entry.executionScore, `${path}.executionScore`);
+        assertNullableNumber(entry.estimatedImpactBps, `${path}.estimatedImpactBps`);
+        assertNullableNumber(entry.sizeAwareScore, `${path}.sizeAwareScore`);
+        assert(typeof entry.isFillQualityEligible === 'boolean', `${path}.isFillQualityEligible must be boolean`);
+        assert(Array.isArray(entry.reasons) && entry.reasons.length > 0, `${path}.reasons must be non-empty`);
+        variantMints.push(entry.mint);
+    });
+
+    let primaryMint: string | null = null;
+    if (body.primary !== null) {
+        assertObject(body.primary, `${label}.primary`);
+        assert(typeof body.primary.mint === 'string', `${label}.primary.mint must be a string`);
+        assert(variantMints.includes(body.primary.mint), `${label}.primary.mint must be a ranked variant`);
+        primaryMint = body.primary.mint as string;
+    }
+
+    assertObject(body.meta, `${label}.meta`);
+    assert(typeof body.meta.scoringVersion === 'string', `${label}.meta.scoringVersion must be a string`);
+    assert(
+        body.meta.strategy === 'execution_quality' || body.meta.strategy === 'size_aware',
+        `${label}.meta.strategy must be execution_quality or size_aware`,
+    );
+    if (opts.expectAmount !== null) {
+        assertObject(body.meta.depthCoverage, `${label}.meta.depthCoverage`);
+        assert(
+            typeof body.meta.depthCoverage.withCurves === 'number' &&
+                typeof body.meta.depthCoverage.total === 'number',
+            `${label}.meta.depthCoverage must have numeric withCurves/total`,
+        );
+    }
+
+    return { variantMints, primaryMint };
 }
 
 main().catch(error => {


### PR DESCRIPTION
## Summary

PR 4 of the v2 execution endpoints stack (base: `feat/execution-links-web-dogfood`, #99).

Answers "I want to buy bitcoin on Solana — which mint?" from existing data (variant markets + ClickHouse fill quality), no new infra.

- **`rankVariantsWithReasons`** in `@tokens/asset-registry`: full ranked list via repeated selection with exact pick-loop semantics — element [0] ≡ `pickPrimaryVariantWithRanking().variant` (unit-tested invariant), per-variant reason, excluded variants (activity-filtered / non-spot-like) trail by liquidity. Reserved `impactByMint` param documented for the size-aware phase.
- **`GET /v2/execution/route?asset=bitcoin[&amountUsd=1000000][&side=buy|sell]`**: resolves any asset ref via `resolveAssetRefContext`, parallel market/fill-quality fetch, `execution_quality` strategy, full ranked list + `primary` recommendation, stale fallback (amount bucketed to 2 sig figs for the cache key only).
- **Contract is phase-stable:** size-aware fields ship null; `amountUsd` requests get `depth_unavailable` reasons + `depthCoverage: {withCurves: 0, total}` until the depth pipeline (PR 5/6) populates them.
- Docs section + contract verify script extended (tolerates zero depth coverage pre-warm).

## Test plan

- [x] 25 ranking tests incl. winner-equivalence across strategies, exclusion ordering, only_candidate/empty cases
- [x] 8 route tests (ranking + primary, depth_unavailable, clamping, side validation, 400/404/403)
- [x] turbo typecheck + test + lint green for @tokens/api and @tokens/asset-registry
- [ ] Live: `bun run verify:execution-api-v2` after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)