### PR TITLE
feat(cloudrun-assets): depth-sampling pipeline for price-impact curves (dark launch)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -48,3 +48,9 @@ CLICKHOUSE_DATABASE=
 CLICKHOUSE_REQUEST_TIMEOUT_MS=180000
 CLICKHOUSE_SOLANA_TRADES_TABLE=trades_anza_final
 CLICKHOUSE_SOLANA_TRADES_REFRESH_ENABLED=false
+
+# Depth-sampling job (variant_depth_curves_latest ← Titan quote API).
+# Keep disabled until curves are validated against live quotes.
+TITAN_WS_URL=
+TITAN_API_KEY=
+DEPTH_REFRESH_ENABLED=false

--- a/apps/cloudrun-assets/package.json
+++ b/apps/cloudrun-assets/package.json
@@ -15,10 +15,12 @@
     "node": ">=20"
   },
   "dependencies": {
+    "@titanexchange/sdk-ts": "0.1.5",
     "@tokens/asset-registry": "workspace:*",
     "@tokens/cloudrun-shutdown": "workspace:*",
     "@tokens/effect": "workspace:*",
     "@tokens/token-risk-helpers": "workspace:*",
+    "bs58": "6.0.0",
     "effect": "4.0.0-rc.108",
     "hono": "^4.13.0",
     "jose": "^5.9.6",

--- a/apps/cloudrun-assets/src/clients.ts
+++ b/apps/cloudrun-assets/src/clients.ts
@@ -1,7 +1,10 @@
 import { Effect, Schema } from 'effect';
+import bs58 from 'bs58';
+import { V1Client as TitanV1Client } from '@titanexchange/sdk-ts';
 import { fetchJsonWithRetry } from '@tokens/effect';
 import { decodeUpstreamOrWarn } from '@tokens/effect/schema';
 import { withExternalTiming } from './externalTiming';
+import type { DepthQuote, DepthQuoteClient } from './handlers/crons.depth';
 import type {
     BirdeyeClient,
     BirdeyeInterval,
@@ -1171,6 +1174,168 @@ export function makeBirdeyeMarketsClient(opts: MakeBirdeyeMarketsOptions): Birde
                 byAddress.set(market.address, market);
             }
             return Array.from(byAddress.values());
+        },
+    };
+}
+
+// ---------------------------------------------------------------------------
+// Depth-sampling quote sources (see handlers/crons.depth.ts)
+// ---------------------------------------------------------------------------
+
+const JupiterQuoteEnvelopeSchema = Schema.Struct({
+    inAmount: Schema.optionalKey(Schema.Unknown),
+    outAmount: Schema.optionalKey(Schema.Unknown),
+    priceImpactPct: Schema.optionalKey(Schema.Unknown),
+    routePlan: Schema.optionalKey(Schema.Unknown),
+    contextSlot: Schema.optionalKey(Schema.Unknown),
+    errorCode: Schema.optionalKey(Schema.Unknown),
+});
+
+function toFinitePositiveNumber(value: unknown): number | null {
+    const parsed =
+        typeof value === 'number'
+            ? value
+            : typeof value === 'bigint'
+              ? Number(value)
+              : typeof value === 'string'
+                ? Number(value)
+                : NaN;
+    return Number.isFinite(parsed) && parsed > 0 ? parsed : null;
+}
+
+interface MakeJupiterQuoteOptions {
+    baseUrl?: string;
+    apiKey?: string;
+}
+
+/**
+ * Jupiter quote client (lite tier by default). Cross-check / fallback source
+ * for depth sampling; untradable pairs degrade to null like the Birdeye
+ * clients, transport failures throw after retries.
+ */
+export function makeJupiterQuoteClient(opts: MakeJupiterQuoteOptions = {}): DepthQuoteClient {
+    const baseUrl = (opts.baseUrl ?? (opts.apiKey ? 'https://api.jup.ag' : 'https://lite-api.jup.ag')).replace(
+        /\/+$/,
+        '',
+    );
+    const headers: Record<string, string> = { Accept: 'application/json' };
+    if (opts.apiKey) headers['x-api-key'] = opts.apiKey;
+
+    return {
+        id: 'jupiter_lite',
+        async fetchQuote(args): Promise<DepthQuote | null> {
+            const url =
+                `${baseUrl}/swap/v1/quote?inputMint=${encodeURIComponent(args.inputMint)}` +
+                `&outputMint=${encodeURIComponent(args.outputMint)}` +
+                `&amount=${Math.round(args.amount)}` +
+                `&slippageBps=${args.slippageBps ?? 50}`;
+            const json = await Effect.runPromise(
+                fetchJsonWithRetry<Record<string, unknown> | null>({
+                    url,
+                    service: 'jupiter',
+                    init: { headers },
+                    maxRetries: 2,
+                    timeout: '15 seconds',
+                    schema: JupiterQuoteEnvelopeSchema,
+                }).pipe(
+                    // 400s (TOKEN_NOT_TRADABLE, COULD_NOT_FIND_ANY_ROUTE, ...)
+                    // keep the null-degrade contract; 429/5xx retry then throw.
+                    Effect.catchTag('UpstreamHttpError', () => Effect.succeed(null)),
+                ),
+            );
+            if (!json) return null;
+            const inAmount = toFinitePositiveNumber(json.inAmount);
+            const outAmount = toFinitePositiveNumber(json.outAmount);
+            if (inAmount === null || outAmount === null) return null;
+
+            const routeVenues: string[] = [];
+            if (Array.isArray(json.routePlan)) {
+                for (const step of json.routePlan) {
+                    const label = (step as { swapInfo?: { label?: unknown } } | null)?.swapInfo?.label;
+                    if (typeof label === 'string' && label && !routeVenues.includes(label)) routeVenues.push(label);
+                }
+            }
+            const contextSlot = toFinitePositiveNumber(json.contextSlot);
+
+            return {
+                inAmount,
+                outAmount,
+                routeVenues,
+                ...(contextSlot !== null ? { contextSlot: contextSlot } : {}),
+            };
+        },
+        async close(): Promise<void> {
+            // HTTP client: nothing to release.
+        },
+    };
+}
+
+interface MakeTitanQuoteOptions {
+    /** WebSocket endpoint, e.g. wss://.../ws — auth token is appended as ?auth=. */
+    wsUrl: string;
+    authToken: string;
+}
+
+const TITAN_NO_ROUTE_PATTERN = /no.?route|not.?tradable|unsupported|unknown.?(mint|token)/i;
+
+/**
+ * Titan quote client — primary depth source. Titan's API is
+ * WebSocket-streaming; we use the one-shot getSwapPrice call (best simulated
+ * route, no transaction) over a lazily opened connection that the cron closes
+ * at the end of each tick.
+ */
+export function makeTitanQuoteClient(opts: MakeTitanQuoteOptions): DepthQuoteClient {
+    const url = `${opts.wsUrl}${opts.wsUrl.includes('?') ? '&' : '?'}auth=${encodeURIComponent(opts.authToken)}`;
+    let clientPromise: Promise<TitanV1Client> | null = null;
+
+    async function getClient(): Promise<TitanV1Client> {
+        if (clientPromise) {
+            const existing = await clientPromise.catch(() => null);
+            if (existing && !existing.closed) return existing;
+        }
+        clientPromise = TitanV1Client.connect(url);
+        return clientPromise;
+    }
+
+    async function priceOnce(args: { inputMint: string; outputMint: string; amount: number }) {
+        const client = await getClient();
+        return client.getSwapPrice({
+            inputMint: bs58.decode(args.inputMint),
+            outputMint: bs58.decode(args.outputMint),
+            amount: Math.round(args.amount),
+        });
+    }
+
+    return {
+        id: 'titan',
+        async fetchQuote(args): Promise<DepthQuote | null> {
+            try {
+                const price = await withExternalTiming('titan', url, async () => {
+                    try {
+                        return await priceOnce(args);
+                    } catch (error) {
+                        // One reconnect attempt: the pooled connection may have
+                        // idled out between shards.
+                        clientPromise = null;
+                        if (error instanceof Error && TITAN_NO_ROUTE_PATTERN.test(error.message)) throw error;
+                        return await priceOnce(args);
+                    }
+                });
+                const inAmount = toFinitePositiveNumber(price.amountIn);
+                const outAmount = toFinitePositiveNumber(price.amountOut);
+                if (inAmount === null || outAmount === null) return null;
+                return { inAmount, outAmount, routeVenues: [] };
+            } catch (error) {
+                if (error instanceof Error && TITAN_NO_ROUTE_PATTERN.test(error.message)) return null;
+                throw error;
+            }
+        },
+        async close(): Promise<void> {
+            const pending = clientPromise;
+            clientPromise = null;
+            if (!pending) return;
+            const client = await pending.catch(() => null);
+            if (client && !client.closed) await client.close().catch(() => undefined);
         },
     };
 }

--- a/apps/cloudrun-assets/src/db.ts
+++ b/apps/cloudrun-assets/src/db.ts
@@ -55,6 +55,7 @@ import type {
 } from './handlers/tokensReads';
 import type { TrendingMarketRow, FreshTrendingMarketRow, TrendingReadsRepo } from './handlers/trendingReads';
 import type { FillQualityRow, FillQualityReadsRepo } from './handlers/fillQualityReads';
+import type { DepthCronRepo } from './handlers/crons.depth';
 import type { AssetCollectionMemberRow, AssetCollectionsReadsRepo } from './handlers/assetCollectionsReads';
 import type {
     TokenListMemberRow,
@@ -4605,6 +4606,60 @@ export function makePostgresClickhouseExtrasRepo(sql: Sql): ClickhouseExtrasRepo
                 symbol: r.symbol,
                 normalizedSymbol: r.normalized_symbol,
             }));
+        },
+    };
+}
+
+// ---------------------------------------------------------------------------
+// Depth curves (variant_depth_curves_latest) — see handlers/crons.depth.ts
+// ---------------------------------------------------------------------------
+
+export function makePostgresDepthCurvesRepo(sql: Sql): DepthCronRepo {
+    return {
+        async selectStalestDepthMints(args) {
+            if (args.mints.length === 0 || args.limit <= 0) return [];
+            const rows = await sql<{ mint: string }[]>`
+                SELECT m.mint
+                FROM unnest(${sql.array([...args.mints])}::text[]) AS m(mint)
+                LEFT JOIN variant_depth_curves_latest d
+                  ON d.mint = m.mint
+                 AND d.quote_mint = ${args.quoteMint}
+                 AND d.side = ${args.side}
+                 AND d.source = ${args.source}
+                ORDER BY d.last_computed_at ASC NULLS FIRST, m.mint ASC
+                LIMIT ${args.limit}
+            `;
+            return rows.map(r => r.mint);
+        },
+        async upsertVariantDepthCurve(row) {
+            await sql`
+                INSERT INTO variant_depth_curves_latest (
+                    id, mint, quote_mint, side, source,
+                    ladder, points, failed_points,
+                    as_of, last_computed_at
+                )
+                VALUES (
+                    coalesce(
+                        (
+                            SELECT id FROM variant_depth_curves_latest
+                            WHERE mint = ${row.mint}
+                              AND quote_mint = ${row.quoteMint}
+                              AND side = ${row.side}
+                              AND source = ${row.source}
+                        ),
+                        ${randomId('vdc')}
+                    ),
+                    ${row.mint}, ${row.quoteMint}, ${row.side}, ${row.source},
+                    ${sql.json(row.ladder as never)}, ${row.points}, ${row.failedPoints},
+                    ${row.asOf}, ${row.lastComputedAt}
+                )
+                ON CONFLICT (mint, quote_mint, side, source) DO UPDATE SET
+                    ladder = EXCLUDED.ladder,
+                    points = EXCLUDED.points,
+                    failed_points = EXCLUDED.failed_points,
+                    as_of = EXCLUDED.as_of,
+                    last_computed_at = EXCLUDED.last_computed_at
+            `;
         },
     };
 }

--- a/apps/cloudrun-assets/src/handlers/crons.depth.test.ts
+++ b/apps/cloudrun-assets/src/handlers/crons.depth.test.ts
@@ -1,0 +1,215 @@
+import { describe, expect, it } from 'bun:test';
+
+import {
+    computeLadderImpacts,
+    DEPTH_SIZE_LADDER_USD,
+    DEPTH_USDC_QUOTE_MINT,
+    listDepthUniverseMints,
+    refreshDepthCurves,
+    type DepthCronDeps,
+    type DepthCronRepo,
+    type DepthQuote,
+    type DepthQuoteClient,
+    type VariantDepthCurveUpsert,
+} from './crons.depth';
+
+const MINT_A = 'cbbtcf3aa214zXHbiAZQwf4122FBYbraNdFqgw4iMij';
+const MINT_B = '3NZ9JMVBmGAqocybic2c7LQCJScmgsAZ6vQqTDzcqmJh';
+
+function fakeRepo() {
+    const upserts: VariantDepthCurveUpsert[] = [];
+    const repo: DepthCronRepo = {
+        async selectStalestDepthMints(args) {
+            return args.mints.slice(0, args.limit);
+        },
+        async upsertVariantDepthCurve(row) {
+            upserts.push(row);
+        },
+    };
+    return { repo, upserts };
+}
+
+function fakeQuoteSource(
+    handler: (args: { outputMint: string; amount: number }) => Promise<DepthQuote | null>,
+): DepthQuoteClient & { closed: { count: number } } {
+    const closed = { count: 0 };
+    return {
+        id: 'titan',
+        closed,
+        async fetchQuote(args) {
+            return handler({ outputMint: args.outputMint, amount: args.amount });
+        },
+        async close() {
+            closed.count += 1;
+        },
+    };
+}
+
+function deps(overrides: {
+    quoteSource: DepthQuoteClient;
+    repo: DepthCronRepo;
+    enabled?: boolean;
+}): DepthCronDeps {
+    return {
+        quoteSource: overrides.quoteSource,
+        repo: overrides.repo,
+        now: () => 1_700_000_000_000,
+        env: () => ({ DEPTH_REFRESH_ENABLED: overrides.enabled === false ? 'false' : 'true' }) as NodeJS.ProcessEnv,
+    };
+}
+
+// Linear-impact quote: each doubling of size loses a bit of output per unit in.
+function syntheticQuote(amount: number, penaltyPerUsd: number): DepthQuote {
+    const sizeUsd = amount / 1_000_000;
+    const effective = 1 - penaltyPerUsd * sizeUsd;
+    return { inAmount: amount, outAmount: Math.floor(amount * effective), routeVenues: ['Fake'] };
+}
+
+describe('computeLadderImpacts', () => {
+    it('derives impact vs the smallest rung, clamped at zero', () => {
+        const ladder = computeLadderImpacts([
+            { sizeUsd: 10_000, inAmount: 1, outAmount: 1, effectivePrice: 1.0, routeVenues: [] },
+            { sizeUsd: 1_000_000, inAmount: 1, outAmount: 1, effectivePrice: 0.996, routeVenues: [] },
+            { sizeUsd: 100_000, inAmount: 1, outAmount: 1, effectivePrice: 1.001, routeVenues: [] },
+        ]);
+        const bySize = new Map(ladder.map(point => [point.sizeUsd, point.priceImpactBps]));
+        expect(bySize.get(10_000)).toBe(0);
+        expect(bySize.get(100_000)).toBe(0); // better-than-baseline clamps to 0
+        expect(bySize.get(1_000_000)).toBe(40);
+    });
+
+    it('returns null impacts when no usable baseline exists', () => {
+        const ladder = computeLadderImpacts([
+            { sizeUsd: 10_000, inAmount: 1, outAmount: 0, effectivePrice: 0, routeVenues: [] },
+        ]);
+        expect(ladder[0]?.priceImpactBps).toBeNull();
+    });
+
+    it('handles an empty ladder', () => {
+        expect(computeLadderImpacts([])).toEqual([]);
+    });
+});
+
+describe('listDepthUniverseMints', () => {
+    it('covers multi-variant assets, excludes stablecoin aggregates, dedupes', () => {
+        const mints = listDepthUniverseMints();
+        expect(mints.length).toBeGreaterThan(50);
+        expect(new Set(mints).size).toBe(mints.length);
+        expect(mints).toContain(MINT_A); // cbBTC (bitcoin group)
+    });
+});
+
+describe('refreshDepthCurves', () => {
+    it('no-ops when the refresh flag is off', async () => {
+        const { repo, upserts } = fakeRepo();
+        const source = fakeQuoteSource(async () => syntheticQuote(0, 0));
+        const result = await refreshDepthCurves(deps({ quoteSource: source, repo, enabled: false }), {});
+        expect(result.disabled).toBe(true);
+        expect(upserts).toHaveLength(0);
+    });
+
+    it('samples the full ladder and persists derived impacts', async () => {
+        const { repo, upserts } = fakeRepo();
+        const source = fakeQuoteSource(async ({ amount }) => syntheticQuote(amount, 0.0000000004));
+        const result = await refreshDepthCurves(deps({ quoteSource: source, repo }), {
+            mints: [MINT_A],
+            delayMs: 0,
+        });
+
+        expect(result.ok).toBe(true);
+        expect(result.refreshed).toBe(1);
+        expect(upserts).toHaveLength(1);
+        const row = upserts[0]!;
+        expect(row.mint).toBe(MINT_A);
+        expect(row.quoteMint).toBe(DEPTH_USDC_QUOTE_MINT);
+        expect(row.side).toBe('buy');
+        expect(row.source).toBe('titan');
+        expect(row.points).toBe(DEPTH_SIZE_LADDER_USD.length);
+        expect(row.failedPoints).toBe(0);
+        const impacts = row.ladder.map(point => point.priceImpactBps ?? 0);
+        // Impact grows with size and the smallest rung is the baseline.
+        expect(row.ladder[0]?.priceImpactBps).toBe(0);
+        expect([...impacts].sort((a, b) => a - b)).toEqual(impacts);
+        expect(source.closed.count).toBe(1);
+    });
+
+    it('drops failed rungs but keeps the rest of the ladder', async () => {
+        const { repo, upserts } = fakeRepo();
+        const source = fakeQuoteSource(async ({ amount }) =>
+            amount === 100_000 * 1_000_000 ? null : syntheticQuote(amount, 0.0000000004),
+        );
+        const result = await refreshDepthCurves(deps({ quoteSource: source, repo }), {
+            mints: [MINT_A],
+            delayMs: 0,
+        });
+        expect(result.refreshed).toBe(1);
+        expect(upserts[0]?.points).toBe(DEPTH_SIZE_LADDER_USD.length - 1);
+        expect(upserts[0]?.failedPoints).toBe(1);
+    });
+
+    it('skips a mint whose every rung fails without overwriting', async () => {
+        const { repo, upserts } = fakeRepo();
+        const source = fakeQuoteSource(async ({ outputMint, amount }) =>
+            outputMint === MINT_A ? null : syntheticQuote(amount, 0.0000000004),
+        );
+        const result = await refreshDepthCurves(deps({ quoteSource: source, repo }), {
+            mints: [MINT_A, MINT_B],
+            delayMs: 0,
+        });
+        expect(result.refreshed).toBe(1);
+        expect(result.skippedMissing).toBe(1);
+        expect(upserts).toHaveLength(1);
+        expect(upserts[0]?.mint).toBe(MINT_B);
+    });
+
+    it('counts transport failures per mint and stays ok on partial failure', async () => {
+        const { repo, upserts } = fakeRepo();
+        const source = fakeQuoteSource(async ({ outputMint, amount }) => {
+            if (outputMint === MINT_A) throw new Error('connection reset');
+            return syntheticQuote(amount, 0.0000000004);
+        });
+        const result = await refreshDepthCurves(deps({ quoteSource: source, repo }), {
+            mints: [MINT_A, MINT_B],
+            delayMs: 0,
+        });
+        expect(result.ok).toBe(true);
+        expect(result.failed).toBe(1);
+        expect(result.refreshed).toBe(1);
+        expect(upserts).toHaveLength(1);
+    });
+
+    it('reports ok: false when every mint fails', async () => {
+        const { repo } = fakeRepo();
+        const source = fakeQuoteSource(async () => {
+            throw new Error('connection reset');
+        });
+        const result = await refreshDepthCurves(deps({ quoteSource: source, repo }), {
+            mints: [MINT_A],
+            delayMs: 0,
+        });
+        expect(result.ok).toBe(false);
+        expect(result.failed).toBe(1);
+        expect(source.closed.count).toBe(1);
+    });
+
+    it('uses the stalest-first shard when no explicit mints are given', async () => {
+        const seen: string[] = [];
+        const repo: DepthCronRepo = {
+            async selectStalestDepthMints(args) {
+                expect(args.limit).toBe(2);
+                expect(args.source).toBe('titan');
+                return args.mints.slice(0, args.limit);
+            },
+            async upsertVariantDepthCurve(row) {
+                seen.push(row.mint);
+            },
+        };
+        const source = fakeQuoteSource(async ({ amount }) => syntheticQuote(amount, 0.0000000004));
+        const result = await refreshDepthCurves(deps({ quoteSource: source, repo }), {
+            maxMints: 2,
+            delayMs: 0,
+        });
+        expect(result.requested).toBe(2);
+        expect(seen).toHaveLength(2);
+    });
+});

--- a/apps/cloudrun-assets/src/handlers/crons.depth.ts
+++ b/apps/cloudrun-assets/src/handlers/crons.depth.ts
@@ -1,0 +1,292 @@
+import { Effect } from 'effect';
+import { isShuttingDown } from '@tokens/cloudrun-shutdown';
+import { runJobPool } from '@tokens/effect/job-runner';
+import { isSpotLikeVariantKind, listAssets } from '@tokens/asset-registry';
+
+import type { CronResult } from './crons';
+
+export const DEPTH_QUOTE_SOURCES = ['titan', 'jupiter_lite'] as const;
+export type DepthQuoteSourceId = (typeof DEPTH_QUOTE_SOURCES)[number];
+
+export const DEPTH_USDC_QUOTE_MINT = 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v';
+export const DEPTH_SIZE_LADDER_USD = [10_000, 100_000, 1_000_000, 5_000_000] as const;
+const USDC_DECIMALS_FACTOR = 1_000_000;
+
+/** Stablecoin aggregates: USDC-quoted USD-variant curves are degenerate. */
+const DEPTH_EXCLUDED_ASSET_IDS = new Set(['usd', 'eur']);
+
+export interface DepthQuote {
+    inAmount: number;
+    outAmount: number;
+    routeVenues: string[];
+    contextSlot?: number;
+}
+
+export interface DepthQuoteClient {
+    id: DepthQuoteSourceId;
+    /** Resolves null for untradable pairs / no-route; throws on transport failures. */
+    fetchQuote(args: {
+        inputMint: string;
+        outputMint: string;
+        amount: number;
+        slippageBps?: number;
+    }): Promise<DepthQuote | null>;
+    close(): Promise<void>;
+}
+
+export interface DepthLadderPoint {
+    sizeUsd: number;
+    inAmount: number;
+    outAmount: number;
+    priceImpactBps: number | null;
+    effectivePrice: number;
+    routeVenues: string[];
+    contextSlot?: number;
+}
+
+export interface VariantDepthCurveUpsert {
+    mint: string;
+    quoteMint: string;
+    side: 'buy' | 'sell';
+    source: DepthQuoteSourceId;
+    ladder: DepthLadderPoint[];
+    points: number;
+    failedPoints: number;
+    asOf: number;
+    lastComputedAt: number;
+}
+
+export interface DepthCronRepo {
+    /** Stalest-first shard selection; mints without a row lead. */
+    selectStalestDepthMints(args: {
+        mints: readonly string[];
+        quoteMint: string;
+        side: 'buy' | 'sell';
+        source: DepthQuoteSourceId;
+        limit: number;
+    }): Promise<string[]>;
+    upsertVariantDepthCurve(row: VariantDepthCurveUpsert): Promise<void>;
+}
+
+export interface DepthCronDeps {
+    quoteSource: DepthQuoteClient;
+    repo: DepthCronRepo;
+    now: () => number;
+    env: () => NodeJS.ProcessEnv;
+}
+
+function asObject(raw: unknown): Record<string, unknown> {
+    return raw !== null && typeof raw === 'object' && !Array.isArray(raw) ? (raw as Record<string, unknown>) : {};
+}
+
+function isRefreshEnabled(env: NodeJS.ProcessEnv, key: string): boolean {
+    return (env[key] ?? '').trim().toLowerCase() === 'true';
+}
+
+function clampNumber(value: unknown, fallback: number, min: number, max: number): number {
+    const parsed = typeof value === 'number' ? value : typeof value === 'string' ? Number(value) : NaN;
+    if (!Number.isFinite(parsed)) return fallback;
+    return Math.min(max, Math.max(min, Math.floor(parsed)));
+}
+
+function uniqueMints(values: readonly string[]): string[] {
+    const unique: string[] = [];
+    const seen = new Set<string>();
+    for (const value of values) {
+        const mint = value.trim();
+        if (!mint || seen.has(mint)) continue;
+        seen.add(mint);
+        unique.push(mint);
+    }
+    return unique;
+}
+
+/**
+ * The sampling universe: every mint of a spot-like multi-variant registry
+ * asset, minus the stablecoin aggregates. Registry data is compiled into the
+ * image, so this needs no DB round-trip.
+ */
+export function listDepthUniverseMints(): string[] {
+    const mints: string[] = [];
+    for (const asset of listAssets()) {
+        if (DEPTH_EXCLUDED_ASSET_IDS.has(asset.assetId)) continue;
+        const spotLike = asset.variants.filter(variant => isSpotLikeVariantKind(variant.kind));
+        if (spotLike.length < 2) continue;
+        for (const variant of spotLike) mints.push(variant.mint);
+    }
+    return uniqueMints(mints);
+}
+
+/**
+ * Derive per-rung price impact from the ladder itself: effective price at
+ * each rung vs. the smallest successful rung as baseline. Source-agnostic and
+ * more robust than trusting an aggregator's impact-vs-mid field.
+ */
+export function computeLadderImpacts(
+    points: Array<Omit<DepthLadderPoint, 'priceImpactBps'>>,
+): DepthLadderPoint[] {
+    const baseline = points.reduce<(typeof points)[number] | null>(
+        (best, point) => (best === null || point.sizeUsd < best.sizeUsd ? point : best),
+        null,
+    );
+    const baselinePrice = baseline && baseline.effectivePrice > 0 ? baseline.effectivePrice : null;
+
+    return points.map(point => ({
+        ...point,
+        priceImpactBps:
+            baselinePrice === null || point.effectivePrice <= 0
+                ? null
+                : Math.max(0, Math.round((1 - point.effectivePrice / baselinePrice) * 10_000)),
+    }));
+}
+
+async function sampleMintLadder(args: {
+    quoteSource: DepthQuoteClient;
+    mint: string;
+    delayMs: number;
+}): Promise<{ ladder: DepthLadderPoint[]; failedPoints: number }> {
+    const rawPoints: Array<Omit<DepthLadderPoint, 'priceImpactBps'>> = [];
+    let failedPoints = 0;
+
+    for (const [index, sizeUsd] of DEPTH_SIZE_LADDER_USD.entries()) {
+        if (index > 0 && args.delayMs > 0) {
+            await new Promise(resolve => setTimeout(resolve, args.delayMs));
+        }
+        const inAmount = sizeUsd * USDC_DECIMALS_FACTOR;
+        const quote = await args.quoteSource.fetchQuote({
+            inputMint: DEPTH_USDC_QUOTE_MINT,
+            outputMint: args.mint,
+            amount: inAmount,
+        });
+        if (!quote || !(quote.outAmount > 0) || !(quote.inAmount > 0)) {
+            failedPoints += 1;
+            continue;
+        }
+        rawPoints.push({
+            sizeUsd,
+            inAmount: quote.inAmount,
+            outAmount: quote.outAmount,
+            effectivePrice: quote.outAmount / quote.inAmount,
+            routeVenues: quote.routeVenues,
+            ...(quote.contextSlot !== undefined ? { contextSlot: quote.contextSlot } : {}),
+        });
+    }
+
+    return { ladder: computeLadderImpacts(rawPoints), failedPoints };
+}
+
+export async function refreshDepthCurves(deps: DepthCronDeps, rawArgs: unknown): Promise<CronResult> {
+    const args = asObject(rawArgs);
+    const start = deps.now();
+    const requireRefreshEnabled = args.requireRefreshEnabled !== false;
+    if (requireRefreshEnabled && !isRefreshEnabled(deps.env(), 'DEPTH_REFRESH_ENABLED')) {
+        return {
+            ok: true,
+            processed: 0,
+            durationMs: deps.now() - start,
+            requested: 0,
+            refreshed: 0,
+            skippedMissing: 0,
+            failed: 0,
+            disabled: true,
+        };
+    }
+
+    const maxMints = clampNumber(args.maxMints, 60, 1, 500);
+    const concurrency = clampNumber(args.concurrency, 1, 1, 4);
+    const delayMs = clampNumber(args.delayMs, 500, 0, 10_000);
+    const budgetMs = clampNumber(args.budgetMs, 0, 0, 3_600_000);
+
+    const explicitMints = Array.isArray(args.mints) ? uniqueMints(args.mints as string[]) : [];
+    const universe = explicitMints.length > 0 ? explicitMints : listDepthUniverseMints();
+    const mints =
+        explicitMints.length > 0
+            ? explicitMints.slice(0, maxMints)
+            : await deps.repo.selectStalestDepthMints({
+                  mints: universe,
+                  quoteMint: DEPTH_USDC_QUOTE_MINT,
+                  side: 'buy',
+                  source: deps.quoteSource.id,
+                  limit: maxMints,
+              });
+
+    if (mints.length === 0) {
+        return {
+            ok: true,
+            processed: 0,
+            durationMs: deps.now() - start,
+            requested: 0,
+            refreshed: 0,
+            skippedMissing: 0,
+            failed: 0,
+            disabled: false,
+        };
+    }
+
+    let refreshed = 0;
+    let skippedMissing = 0;
+    let failed = 0;
+
+    try {
+        await Effect.runPromise(
+            runJobPool({
+                label: 'refreshDepthCurves',
+                items: mints,
+                concurrency,
+                delayMs,
+                ...(budgetMs > 0 ? { budgetMs } : {}),
+                shouldStop: isShuttingDown,
+                process: mint =>
+                    Effect.tryPromise(async () => {
+                        const { ladder, failedPoints } = await sampleMintLadder({
+                            quoteSource: deps.quoteSource,
+                            mint,
+                            delayMs,
+                        });
+                        if (ladder.length === 0) {
+                            // Every rung failed: keep the last-good row; the read
+                            // path's freshness gate marks it stale naturally.
+                            skippedMissing += 1;
+                            return;
+                        }
+                        await deps.repo.upsertVariantDepthCurve({
+                            mint,
+                            quoteMint: DEPTH_USDC_QUOTE_MINT,
+                            side: 'buy',
+                            source: deps.quoteSource.id,
+                            ladder,
+                            points: ladder.length,
+                            failedPoints,
+                            asOf: Math.floor(deps.now() / 1000),
+                            lastComputedAt: deps.now(),
+                        });
+                        refreshed += 1;
+                    }),
+                onItemError: () =>
+                    Effect.sync(() => {
+                        failed += 1;
+                    }),
+            }),
+        );
+    } finally {
+        await deps.quoteSource.close().catch(() => undefined);
+    }
+
+    return {
+        ok: failed < mints.length,
+        processed: mints.length,
+        durationMs: deps.now() - start,
+        requested: mints.length,
+        refreshed,
+        skippedMissing,
+        failed,
+        disabled: false,
+        source: deps.quoteSource.id,
+    };
+}
+
+export type DepthJobHandler = (deps: DepthCronDeps, args: unknown) => Promise<CronResult>;
+
+export const depthJobs: Record<string, DepthJobHandler> = {
+    'refresh-depth-curves': refreshDepthCurves,
+};

--- a/apps/cloudrun-assets/src/index.ts
+++ b/apps/cloudrun-assets/src/index.ts
@@ -9,6 +9,7 @@ import {
     makePreStocksClient,
     makeRwaXyzClient,
     makeSanctumClient,
+    makeTitanQuoteClient,
     makeWebacyClient,
 } from './clients';
 import { parseAdminClerkUserIds, parseAdminEmails } from './adminAuth';
@@ -39,6 +40,7 @@ import {
     makePostgresTrendingReadsRepo,
     makePostgresTrendingRepo,
     makePostgresClickhouseExtrasRepo,
+    makePostgresDepthCurvesRepo,
     makePostgresPrestocksReadsRepo,
     makePostgresPrestocksRepo,
     makePostgresStockReadsRepo,
@@ -54,6 +56,7 @@ import type { SeedCronDeps } from './handlers/crons.seed';
 import type { TrendingCronDeps } from './handlers/crons.trending';
 import type { ClickhouseExtrasCronDeps } from './handlers/crons.clickhouse.extras';
 import type { PrestocksCronDeps } from './handlers/crons.prestocks';
+import type { DepthCronDeps } from './handlers/crons.depth';
 import { makeGoogleOidcVerifier } from './oidc';
 import { createApp, type ServiceRole } from './server';
 
@@ -93,6 +96,7 @@ let seedCronDeps: SeedCronDeps | undefined;
 let trendingCronDeps: TrendingCronDeps | undefined;
 let clickhouseExtrasCronDeps: ClickhouseExtrasCronDeps | undefined;
 let prestocksCronDeps: PrestocksCronDeps | undefined;
+let depthCronDeps: DepthCronDeps | undefined;
 let verifyOidc: ReturnType<typeof makeGoogleOidcVerifier> | undefined;
 if (birdeyeApiKey) {
     if (!cronAudience && !cronInvokerSa) {
@@ -232,6 +236,21 @@ if (birdeyeApiKey) {
     console.warn('[cloudrun-assets] BIRDEYE_API_KEY not set — /jobs/* endpoints disabled');
 }
 
+// Depth sampling has its own credentials (not coupled to BIRDEYE_API_KEY);
+// the job additionally no-ops unless DEPTH_REFRESH_ENABLED=true is set.
+const titanWsUrl = process.env.TITAN_WS_URL?.trim();
+const titanApiKey = process.env.TITAN_API_KEY?.trim();
+if (titanWsUrl && titanApiKey) {
+    depthCronDeps = {
+        quoteSource: makeTitanQuoteClient({ wsUrl: titanWsUrl, authToken: titanApiKey }),
+        repo: makePostgresDepthCurvesRepo(sql),
+        now: () => Date.now(),
+        env: () => process.env,
+    };
+} else {
+    console.warn('[cloudrun-assets] TITAN_WS_URL/TITAN_API_KEY not set — depth /jobs/* disabled');
+}
+
 let cacheWarmDeps: CacheWarmDeps | undefined;
 if (cronDeps && miscCronDeps && seedCronDeps) {
     cacheWarmDeps = {
@@ -319,6 +338,7 @@ const app = createApp({
     ...(trendingCronDeps ? { trendingCronDeps } : {}),
     ...(clickhouseExtrasCronDeps ? { clickhouseExtrasCronDeps } : {}),
     ...(prestocksCronDeps ? { prestocksCronDeps } : {}),
+    ...(depthCronDeps ? { depthCronDeps } : {}),
     ...(cacheWarmDeps ? { cacheWarmDeps } : {}),
     ...(adminActionsDeps ? { adminActionsDeps } : {}),
 });

--- a/apps/cloudrun-assets/src/server.ts
+++ b/apps/cloudrun-assets/src/server.ts
@@ -124,6 +124,7 @@ import {
 } from './handlers/crons.assetVariants';
 import { seedJobs, type SeedCronDeps, type SeedJobHandler } from './handlers/crons.seed';
 import { prestocksJobs, type PrestocksCronDeps, type PrestocksJobHandler } from './handlers/crons.prestocks';
+import { depthJobs, type DepthCronDeps, type DepthJobHandler } from './handlers/crons.depth';
 import { trendingJobs, type TrendingCronDeps, type TrendingJobHandler } from './handlers/crons.trending';
 import {
     clickhouseExtrasJobs,
@@ -190,6 +191,7 @@ export interface ServerDeps {
     trendingCronDeps?: TrendingCronDeps;
     clickhouseExtrasCronDeps?: ClickhouseExtrasCronDeps;
     prestocksCronDeps?: PrestocksCronDeps;
+    depthCronDeps?: DepthCronDeps;
     cacheWarmDeps?: CacheWarmDeps;
     adminActionsDeps?: AdminActionsDeps;
     verifyOidc?: VerifyOidc;
@@ -607,6 +609,7 @@ export function createApp(deps: ServerDeps) {
     const prestocksJobsTable: Record<string, PrestocksJobHandler> = {
         ...prestocksJobs,
     };
+    const depthJobsTable: Record<string, DepthJobHandler> = { ...depthJobs };
 
     interface JobGroup {
         has(name: string): boolean;
@@ -656,6 +659,11 @@ export function createApp(deps: ServerDeps) {
             run: deps.prestocksCronDeps
                 ? (name, args) => prestocksJobsTable[name]!(deps.prestocksCronDeps!, args)
                 : null,
+        },
+        {
+            has: name => Object.hasOwn(depthJobsTable, name),
+            run: deps.depthCronDeps ? (name, args) => depthJobsTable[name]!(deps.depthCronDeps!, args) : null,
+            disabledError: 'depth_jobs_disabled',
         },
     ];
 

--- a/bun.lock
+++ b/bun.lock
@@ -141,10 +141,12 @@
       "name": "@tokens/cloudrun-assets",
       "version": "0.0.0",
       "dependencies": {
+        "@titanexchange/sdk-ts": "0.1.5",
         "@tokens/asset-registry": "workspace:*",
         "@tokens/cloudrun-shutdown": "workspace:*",
         "@tokens/effect": "workspace:*",
         "@tokens/token-risk-helpers": "workspace:*",
+        "bs58": "6.0.0",
         "effect": "4.0.0-rc.108",
         "hono": "^4.13.0",
         "jose": "^5.9.6",
@@ -666,6 +668,8 @@
 
     "@mdx-js/react": ["@mdx-js/react@3.1.1", "", { "dependencies": { "@types/mdx": "^2.0.0" }, "peerDependencies": { "@types/react": ">=16", "react": ">=16" } }, "sha512-f++rKLQgUVYDAtECQ6fn/is15GkEH9+nZPM3MS0RcxVqoTfawHvDlSCH7JbMhAM6uJ32v3eXLvLmLvjGu7PTQw=="],
 
+    "@msgpack/msgpack": ["@msgpack/msgpack@3.1.3", "", {}, "sha512-47XIizs9XZXvuJgoaJUIE2lFoID8ugvc0jzSHP+Ptfk8nTbnR8g788wv48N03Kx0UkAv559HWRQ3yzOgzlRNUA=="],
+
     "@msgpackr-extract/msgpackr-extract-darwin-arm64": ["@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-LCkGo6JDfaBhgST7UpPWgNgLINpcpabaHfyz5OBx75nUYxBsaEPxjnyNjWpeb/xBup/682QnBfRBy2/LvPutZQ=="],
 
     "@msgpackr-extract/msgpackr-extract-darwin-x64": ["@msgpackr-extract/msgpackr-extract-darwin-x64@3.0.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-zExlW9zUJKZH/tOtVMttwjKa4Xm/3KcNjnE3dPN92uCktwavMxpgCA3MoJK/DOnTWsQgo224OaST27/mPNAf+w=="],
@@ -988,6 +992,8 @@
 
     "@testing-library/user-event": ["@testing-library/user-event@14.5.2", "", { "peerDependencies": { "@testing-library/dom": ">=7.21.4" } }, "sha512-YAh82Wh4TIrxYLmfGcixwD18oIjyC1pFQC2Y01F2lzV2HTMiYrI0nze0FD0ocB//CKS/7jIUgae+adPqxK5yCQ=="],
 
+    "@titanexchange/sdk-ts": ["@titanexchange/sdk-ts@0.1.5", "", { "dependencies": { "@msgpack/msgpack": "^3.1.2", "http-encoding": "^2.1.1", "websocket": "^1.0.35" } }, "sha512-zZr9uZaOOdzUqQnSIPNo2y3dTdtRuGwGrTUis5Xjs4A0GhdweWbg81A5YlY7miR/qkc+IWsMZDZe+8c9dSRxyA=="],
+
     "@tokens/admin": ["@tokens/admin@workspace:apps/admin"],
 
     "@tokens/api": ["@tokens/api@workspace:apps/api"],
@@ -1216,6 +1222,8 @@
 
     "balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
 
+    "base-x": ["base-x@5.0.1", "", {}, "sha512-M7uio8Zt++eg3jPj+rHMfCC+IuygQHHCOU+IYsVtik6FWjuYpVt/+MRKcgsAMHh8mMFAwnB+Bs+mTrFiXjMzKg=="],
+
     "base64-js": ["base64-js@1.5.1", "", {}, "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="],
 
     "baseline-browser-mapping": ["baseline-browser-mapping@2.10.7", "", { "bin": { "baseline-browser-mapping": "dist/cli.cjs" } }, "sha512-1ghYO3HnxGec0TCGBXiDLVns4eCSx4zJpxnHrlqFQajmhfKMQBzUGDdkMK7fUW7PTHTeLf+j87aTuKuuwWzMGw=="],
@@ -1226,11 +1234,17 @@
 
     "brace-expansion": ["brace-expansion@5.0.9", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg=="],
 
+    "brotli-wasm": ["brotli-wasm@3.0.1", "", {}, "sha512-U3K72/JAi3jITpdhZBqzSUq+DUY697tLxOuFXB+FpAE/Ug+5C3VZrv4uA674EUZHxNAuQ9wETXNqQkxZD6oL4A=="],
+
     "browser-assert": ["browser-assert@1.2.1", "", {}, "sha512-nfulgvOR6S4gt9UKCeGJOuSGBPGiFT6oQ/2UBnvTY/5aQ1PnksW72fhZkM30DzoRRv2WpwZf1vHHEr3mtuXIWQ=="],
 
     "browserslist": ["browserslist@4.28.1", "", { "dependencies": { "baseline-browser-mapping": "^2.9.0", "caniuse-lite": "^1.0.30001759", "electron-to-chromium": "^1.5.263", "node-releases": "^2.0.27", "update-browserslist-db": "^1.2.0" }, "bin": { "browserslist": "cli.js" } }, "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA=="],
 
+    "bs58": ["bs58@6.0.0", "", { "dependencies": { "base-x": "^5.0.0" } }, "sha512-PD0wEnEYg6ijszw/u8s+iI3H17cTymlrwkKhDhPZq+Sokl3AU4htyBFTjAeNAlCCmg0f53g6ih3jATyCKftTfw=="],
+
     "buffer-equal-constant-time": ["buffer-equal-constant-time@1.0.1", "", {}, "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="],
+
+    "bufferutil": ["bufferutil@4.1.0", "", { "dependencies": { "node-gyp-build": "^4.3.0" } }, "sha512-ZMANVnAixE6AWWnPzlW2KpUrxhm9woycYvPOo67jWHyFowASTEd9s+QN1EIMsSDtwhIxN4sWE1jotpuDUIgyIw=="],
 
     "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
 
@@ -1293,6 +1307,8 @@
     "css.escape": ["css.escape@1.5.1", "", {}, "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg=="],
 
     "csstype": ["csstype@3.2.3", "", {}, "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="],
+
+    "d": ["d@1.0.2", "", { "dependencies": { "es5-ext": "^0.10.64", "type": "^2.7.2" } }, "sha512-MOqHvMWF9/9MX6nza0KgvFH4HpMU0EF5uUDXqX/BtxtU8NfB0QzRtJ8Oe/6SuS4kbhyzVJwjd97EA4PKrzJ8bw=="],
 
     "d3-array": ["d3-array@3.2.4", "", { "dependencies": { "internmap": "1 - 2" } }, "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg=="],
 
@@ -1396,6 +1412,12 @@
 
     "es-toolkit": ["es-toolkit@1.45.1", "", {}, "sha512-/jhoOj/Fx+A+IIyDNOvO3TItGmlMKhtX8ISAHKE90c4b/k1tqaqEZ+uUqfpU8DMnW5cgNJv606zS55jGvza0Xw=="],
 
+    "es5-ext": ["es5-ext@0.10.64", "", { "dependencies": { "es6-iterator": "^2.0.3", "es6-symbol": "^3.1.3", "esniff": "^2.0.1", "next-tick": "^1.1.0" } }, "sha512-p2snDhiLaXe6dahss1LddxqEm+SkuDvV8dnIQG0MWjyHpcMNfXKPE+/Cc0y+PhxJX3A4xGNeFCj5oc0BUh6deg=="],
+
+    "es6-iterator": ["es6-iterator@2.0.3", "", { "dependencies": { "d": "1", "es5-ext": "^0.10.35", "es6-symbol": "^3.1.1" } }, "sha512-zw4SRzoUkd+cl+ZoE15A9o1oQd920Bb0iOJMQkQhl3jNc03YqVjAhG7scf9C5KWRU/R13Orf588uCC6525o02g=="],
+
+    "es6-symbol": ["es6-symbol@3.1.4", "", { "dependencies": { "d": "^1.0.2", "ext": "^1.7.0" } }, "sha512-U9bFFjX8tFiATgtkJ1zg25+KviIXpgRvRHS8sau3GfhVzThRQrOeksPeT0BWW2MNZs1OEWJ1DPXOQMn0KKRkvg=="],
+
     "esast-util-from-estree": ["esast-util-from-estree@2.0.0", "", { "dependencies": { "@types/estree-jsx": "^1.0.0", "devlop": "^1.0.0", "estree-util-visit": "^2.0.0", "unist-util-position-from-estree": "^2.0.0" } }, "sha512-4CyanoAudUSBAn5K13H4JhsMH6L9ZP7XbLVe/dKybkxMO7eDyLsT8UHl9TRNrU2Gr9nz+FovfSIjuXWJ81uVwQ=="],
 
     "esast-util-from-js": ["esast-util-from-js@2.0.1", "", { "dependencies": { "@types/estree-jsx": "^1.0.0", "acorn": "^8.0.0", "esast-util-from-estree": "^2.0.0", "vfile-message": "^4.0.0" } }, "sha512-8Ja+rNJ0Lt56Pcf3TAmpBZjmx8ZcK5Ts4cAzIOjsjevg9oSXJnl6SUQ2EevU8tv3h6ZLWmoKL5H4fgWvdvfETw=="],
@@ -1417,6 +1439,8 @@
     "eslint-scope": ["eslint-scope@8.4.0", "", { "dependencies": { "esrecurse": "^4.3.0", "estraverse": "^5.2.0" } }, "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg=="],
 
     "eslint-visitor-keys": ["eslint-visitor-keys@4.2.1", "", {}, "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ=="],
+
+    "esniff": ["esniff@2.0.1", "", { "dependencies": { "d": "^1.0.1", "es5-ext": "^0.10.62", "event-emitter": "^0.3.5", "type": "^2.7.2" } }, "sha512-kTUIGKQ/mDPFoJ0oVfcmyJn4iBDRptjNVIzwIFR7tqWXdVI9xfA2RMwY/gbSpJG3lkdWNEjLap/NqVHZiJsdfg=="],
 
     "espree": ["espree@10.4.0", "", { "dependencies": { "acorn": "^8.15.0", "acorn-jsx": "^5.3.2", "eslint-visitor-keys": "^4.2.1" } }, "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ=="],
 
@@ -1446,11 +1470,15 @@
 
     "esutils": ["esutils@2.0.3", "", {}, "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="],
 
+    "event-emitter": ["event-emitter@0.3.5", "", { "dependencies": { "d": "1", "es5-ext": "~0.10.14" } }, "sha512-D9rRn9y7kLPnJ+hMq7S/nhvoKwwvVJahBi2BPmx3bvbsEdK3W9ii8cBSGjP+72/LnM4n6fo3+dkCX5FeTQruXA=="],
+
     "event-target-shim": ["event-target-shim@5.0.1", "", {}, "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ=="],
 
     "eventemitter3": ["eventemitter3@5.0.4", "", {}, "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw=="],
 
     "execa": ["execa@5.1.1", "", { "dependencies": { "cross-spawn": "^7.0.3", "get-stream": "^6.0.0", "human-signals": "^2.1.0", "is-stream": "^2.0.0", "merge-stream": "^2.0.0", "npm-run-path": "^4.0.1", "onetime": "^5.1.2", "signal-exit": "^3.0.3", "strip-final-newline": "^2.0.0" } }, "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg=="],
+
+    "ext": ["ext@1.7.0", "", { "dependencies": { "type": "^2.7.2" } }, "sha512-6hxeJYaL110a9b5TEJSj0gojyHQAmA2ch5Os+ySCiA1QGdS697XWY1pzsrSjqA9LDEEgdB/KypIlR59RcLuHYw=="],
 
     "extend": ["extend@3.0.2", "", {}, "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="],
 
@@ -1584,6 +1612,8 @@
 
     "html-void-elements": ["html-void-elements@3.0.0", "", {}, "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg=="],
 
+    "http-encoding": ["http-encoding@2.2.0", "", { "dependencies": { "brotli-wasm": "^3.0.0", "pify": "^5.0.0", "zstd-codec": "^0.1.5" } }, "sha512-sotL89NNHWS7TjaoswmKkNKf57+nAYCg3fbGCclpNLriVGkOSgrAWQ9DLqahnwacY+gednJk+HFdZrpKw/Ff6w=="],
+
     "http-proxy-agent": ["http-proxy-agent@5.0.0", "", { "dependencies": { "@tootallnate/once": "2", "agent-base": "6", "debug": "4" } }, "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w=="],
 
     "https-proxy-agent": ["https-proxy-agent@7.0.6", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "4" } }, "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw=="],
@@ -1669,6 +1699,8 @@
     "is-symbol": ["is-symbol@1.1.1", "", { "dependencies": { "call-bound": "^1.0.2", "has-symbols": "^1.1.0", "safe-regex-test": "^1.1.0" } }, "sha512-9gGx6GTtCQM73BgmHQXfDmLtfjjTUDSyoxTCbp5WtoixAhfgsDirWIcVQ/IHpvI5Vgd5i/J5F7B9cN/WlVbC/w=="],
 
     "is-typed-array": ["is-typed-array@1.1.15", "", { "dependencies": { "which-typed-array": "^1.1.16" } }, "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ=="],
+
+    "is-typedarray": ["is-typedarray@1.0.0", "", {}, "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA=="],
 
     "is-unsafe": ["is-unsafe@2.0.0", "", {}, "sha512-2LdV822R+wmI86unXA93WCFpL6g+av8ynWk0nrHyJqGop5VoocYsSLFgN8jrfalT6iGeLNM4KXuVSsULP53kEA=="],
 
@@ -1922,9 +1954,13 @@
 
     "next-themes": ["next-themes@0.4.6", "", { "peerDependencies": { "react": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc", "react-dom": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc" } }, "sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA=="],
 
+    "next-tick": ["next-tick@1.1.0", "", {}, "sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ=="],
+
     "node-exports-info": ["node-exports-info@1.6.0", "", { "dependencies": { "array.prototype.flatmap": "^1.3.3", "es-errors": "^1.3.0", "object.entries": "^1.1.9", "semver": "^6.3.1" } }, "sha512-pyFS63ptit/P5WqUkt+UUfe+4oevH+bFeIiPPdfb0pFeYEu/1ELnJu5l+5EcTKYL5M7zaAa7S8ddywgXypqKCw=="],
 
     "node-fetch": ["node-fetch@2.7.0", "", { "dependencies": { "whatwg-url": "^5.0.0" }, "peerDependencies": { "encoding": "^0.1.0" }, "optionalPeers": ["encoding"] }, "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A=="],
+
+    "node-gyp-build": ["node-gyp-build@4.8.4", "", { "bin": { "node-gyp-build": "bin.js", "node-gyp-build-optional": "optional.js", "node-gyp-build-test": "build-test.js" } }, "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ=="],
 
     "node-gyp-build-optional-packages": ["node-gyp-build-optional-packages@5.2.2", "", { "dependencies": { "detect-libc": "^2.0.1" }, "bin": { "node-gyp-build-optional-packages": "bin.js", "node-gyp-build-optional-packages-optional": "optional.js", "node-gyp-build-optional-packages-test": "build-test.js" } }, "sha512-s+w+rBWnpTMwSFbaE0UXsRlg7hU4FjekKU4eyAih5T8nJuNZT1nNsskXpxmeqSK9UzkBl6UgRlnKc8hz8IEqOw=="],
 
@@ -1991,6 +2027,8 @@
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 
     "picomatch": ["picomatch@2.3.2", "", {}, "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="],
+
+    "pify": ["pify@5.0.0", "", {}, "sha512-eW/gHNMlxdSP6dmG6uJip6FXN0EQBwm2clYYd8Wul42Cwu/DK8HEftzsapcNdYe2MfLiIwZqsDk2RDEsTE79hA=="],
 
     "polished": ["polished@4.3.1", "", { "dependencies": { "@babel/runtime": "^7.17.8" } }, "sha512-OBatVyC/N7SCW/FaDHrSd+vn0o5cS855TOmYi4OkdWUMSJCET/xip//ch8xGUvtr3i44X9LVyWwQlRMTN3pwSA=="],
 
@@ -2252,6 +2290,8 @@
 
     "turbo": ["turbo@2.10.8", "", { "optionalDependencies": { "@turbo/darwin-64": "2.10.8", "@turbo/darwin-arm64": "2.10.8", "@turbo/linux-64": "2.10.8", "@turbo/linux-arm64": "2.10.8", "@turbo/windows-64": "2.10.8", "@turbo/windows-arm64": "2.10.8" }, "bin": { "turbo": "bin/turbo" } }, "sha512-9+8YX5QOkGXzZxcIykTHgaooRHGMWO+jfdyRK0o+rN0U7hBIig2MrJ8r/aNzIPDPhdA73SGb0O+tIztaModTMg=="],
 
+    "type": ["type@2.7.3", "", {}, "sha512-8j+1QmAbPvLZow5Qpi6NCaN8FB60p/6x8/vfNqOk/hC+HuvFZhL4+WfekuhQLiqFZXOgQdrs3B+XxEmCc6b3FQ=="],
+
     "type-check": ["type-check@0.4.0", "", { "dependencies": { "prelude-ls": "^1.2.1" } }, "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew=="],
 
     "typed-array-buffer": ["typed-array-buffer@1.0.3", "", { "dependencies": { "call-bound": "^1.0.3", "es-errors": "^1.3.0", "is-typed-array": "^1.1.14" } }, "sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw=="],
@@ -2261,6 +2301,8 @@
     "typed-array-byte-offset": ["typed-array-byte-offset@1.0.4", "", { "dependencies": { "available-typed-arrays": "^1.0.7", "call-bind": "^1.0.8", "for-each": "^0.3.3", "gopd": "^1.2.0", "has-proto": "^1.2.0", "is-typed-array": "^1.1.15", "reflect.getprototypeof": "^1.0.9" } }, "sha512-bTlAFB/FBYMcuX81gbL4OcpH5PmlFHqlCCpAl8AlEzMz5k53oNDvN8p1PNOWLEmI2x4orp3raOFB51tv9X+MFQ=="],
 
     "typed-array-length": ["typed-array-length@1.0.7", "", { "dependencies": { "call-bind": "^1.0.7", "for-each": "^0.3.3", "gopd": "^1.0.1", "is-typed-array": "^1.1.13", "possible-typed-array-names": "^1.0.0", "reflect.getprototypeof": "^1.0.6" } }, "sha512-3KS2b+kL7fsuk/eJZ7EQdnEmQoaho/r6KUef7hxvltNA5DR8NAUM+8wJMbJyZ4G9/7i3v5zPBIMN5aybAh2/Jg=="],
+
+    "typedarray-to-buffer": ["typedarray-to-buffer@3.1.5", "", { "dependencies": { "is-typedarray": "^1.0.0" } }, "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q=="],
 
     "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
@@ -2300,6 +2342,8 @@
 
     "use-sync-external-store": ["use-sync-external-store@1.6.0", "", { "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w=="],
 
+    "utf-8-validate": ["utf-8-validate@5.0.10", "", { "dependencies": { "node-gyp-build": "^4.3.0" } }, "sha512-Z6czzLq4u8fPOyx7TU6X3dvUZVvoJmxSQ+IcrlmagKhilxlhZgxPK6C5Jqbkw1IDUmFTM+cz9QDnnLTwDz/2gQ=="],
+
     "util": ["util@0.12.5", "", { "dependencies": { "inherits": "^2.0.3", "is-arguments": "^1.0.4", "is-generator-function": "^1.0.7", "is-typed-array": "^1.1.3", "which-typed-array": "^1.1.2" } }, "sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA=="],
 
     "util-deprecate": ["util-deprecate@1.0.2", "", {}, "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="],
@@ -2325,6 +2369,8 @@
     "webidl-conversions": ["webidl-conversions@3.0.1", "", {}, "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="],
 
     "webpack-virtual-modules": ["webpack-virtual-modules@0.6.2", "", {}, "sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ=="],
+
+    "websocket": ["websocket@1.0.35", "", { "dependencies": { "bufferutil": "^4.0.1", "debug": "^2.2.0", "es5-ext": "^0.10.63", "typedarray-to-buffer": "^3.1.5", "utf-8-validate": "^5.0.2", "yaeti": "^0.0.6" } }, "sha512-/REy6amwPZl44DDzvRCkaI1q1bIiQB0mEFQLUrhz3z2EK91cp3n72rAjUlrTP0zV22HJIUOVHQGPxhFRjxjt+Q=="],
 
     "whatwg-url": ["whatwg-url@5.0.0", "", { "dependencies": { "tr46": "~0.0.3", "webidl-conversions": "^3.0.0" } }, "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw=="],
 
@@ -2354,11 +2400,15 @@
 
     "xml-naming": ["xml-naming@0.3.0", "", {}, "sha512-ghig2TBE/H11aOVgmahA3MhimvkBr6JIYknH/Dhdk10nXwdbIqBJsbfMxpvFPG8bAw77gN29aQWvKpmVoPlvPQ=="],
 
+    "yaeti": ["yaeti@0.0.6", "", {}, "sha512-MvQa//+KcZCUkBTIC9blM+CU9J2GzuTytsOUwf2lidtvkx/6gnEp1QvJv34t9vdjhFmha/mUiNDbN0D0mJWdug=="],
+
     "yallist": ["yallist@3.1.1", "", {}, "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="],
 
     "yocto-queue": ["yocto-queue@0.1.0", "", {}, "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="],
 
     "zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
+
+    "zstd-codec": ["zstd-codec@0.1.5", "", {}, "sha512-v3fyjpK8S/dpY/X5WxqTK3IoCnp/ZOLxn144GZVlNUjtwAchzrVo03h+oMATFhCIiJ5KTr4V3vDQQYz4RU684g=="],
 
     "zwitch": ["zwitch@2.0.4", "", {}, "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="],
 
@@ -2554,6 +2604,8 @@
 
     "teeny-request/https-proxy-agent": ["https-proxy-agent@5.0.1", "", { "dependencies": { "agent-base": "6", "debug": "4" } }, "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA=="],
 
+    "websocket/debug": ["debug@2.6.9", "", { "dependencies": { "ms": "2.0.0" } }, "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA=="],
+
     "wrap-ansi/ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
 
     "wrap-ansi-cjs/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
@@ -2629,6 +2681,8 @@
     "fumadocs-ui/shiki/@shikijs/types": ["@shikijs/types@4.0.2", "", { "dependencies": { "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-qzbeRooUTPnLE+sHD/Z8DStmaDgnbbc/pMrU203950aRqjX/6AFHeDYT+j00y2lPdz0ywJKx7o/7qnqTivtlXg=="],
 
     "teeny-request/https-proxy-agent/agent-base": ["agent-base@6.0.2", "", { "dependencies": { "debug": "4" } }, "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ=="],
+
+    "websocket/debug/ms": ["ms@2.0.0", "", {}, "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="],
 
     "wrap-ansi-cjs/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
 

--- a/db/migrations/0015_depth_curves.sql
+++ b/db/migrations/0015_depth_curves.sql
@@ -1,0 +1,28 @@
+-- Price-impact curves per variant mint, sampled from an aggregator quote API
+-- at a ladder of USD sizes (see refresh-depth-curves in cloudrun-assets).
+-- Backs the size-aware fields of GET /v2/execution/route. Impact is derived
+-- from the ladder itself (effective price per rung vs. the smallest rung),
+-- so rows are comparable across sources.
+
+CREATE TABLE variant_depth_curves_latest (
+    id               text PRIMARY KEY,
+    mint             text NOT NULL,
+    quote_mint       text NOT NULL,
+    side             text NOT NULL CHECK (side IN ('buy', 'sell')),
+    source           text NOT NULL CHECK (source IN ('titan', 'jupiter_lite')),
+    -- [{sizeUsd, inAmount, outAmount, priceImpactBps, effectivePrice, routeVenues, contextSlot?}]
+    ladder           jsonb NOT NULL,
+    points           integer NOT NULL,
+    failed_points    integer NOT NULL,
+    as_of            bigint NOT NULL,   -- sampling wall-clock, unix seconds
+    last_computed_at bigint NOT NULL,   -- unix ms, matches fill-quality convention
+    created_at       timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE UNIQUE INDEX variant_depth_curves_latest_by_mint_quote_side_source
+    ON variant_depth_curves_latest (mint, quote_mint, side, source);
+
+CREATE INDEX variant_depth_curves_latest_by_computed
+    ON variant_depth_curves_latest (source, side, last_computed_at);
+
+INSERT INTO schema_migrations(version) VALUES ('0015_depth_curves');

--- a/terraform/modules/env/crons_depth.tf
+++ b/terraform/modules/env/crons_depth.tf
@@ -1,0 +1,26 @@
+locals {
+  depth_cron_jobs = [
+    {
+      # Price-impact curves for multi-variant assets (variant_depth_curves_latest),
+      # sampled from the Titan quote API at a $10k/$100k/$1M/$5M ladder. Backs
+      # the size-aware fields of GET /v2/execution/route. Rotating stalest-first
+      # shard of 60 mints per tick over a ~180-mint universe → full-fleet
+      # freshness ≈ 90 min. The handler is a no-op unless DEPTH_REFRESH_ENABLED=true
+      # and TITAN_WS_URL/TITAN_API_KEY are set on the assets service (managed
+      # out-of-band, like the other refresh flags).
+      name      = "refresh-depth-curves"
+      schedule  = "*/30 * * * *"
+      http_path = "/jobs/refresh-depth-curves"
+      body_json = jsonencode({
+        maxMints              = 60
+        concurrency           = 1
+        delayMs               = 500
+        requireRefreshEnabled = true
+        budgetMs              = 500000
+      })
+      attempt_deadline = "540s"
+      # High-frequency job: the next scheduled tick is the retry.
+      retry_count = 0
+    },
+  ]
+}

--- a/terraform/modules/env/main.tf
+++ b/terraform/modules/env/main.tf
@@ -251,7 +251,7 @@ module "scheduler_jobs" {
   service_url      = local.assets_jobs_service_url
   invoker_sa_email = module.iam.scheduler_sa_email
 
-  jobs = concat(local.coingecko_cron_jobs, local.clickhouse_cron_jobs, local.prestocks_cron_jobs, [
+  jobs = concat(local.coingecko_cron_jobs, local.clickhouse_cron_jobs, local.prestocks_cron_jobs, local.depth_cron_jobs, [
     {
       name      = "refresh-asset-variant-markets"
       schedule  = var.env == "stg" ? "15 2 * * *" : "*/10 * * * *"


### PR DESCRIPTION
## Summary

PR 5 of the v2 execution endpoints stack (base: `feat/execution-route-endpoint`, #100).

The data pipeline behind size-aware routing ("buy $1M of bitcoin"): a cron samples aggregator quotes at a $10k/$100k/$1M/$5M USDC ladder per variant mint and persists price-impact curves. **Ships dark** — the scheduler entry exists but the handler no-ops until `DEPTH_REFRESH_ENABLED=true` + `TITAN_WS_URL`/`TITAN_API_KEY` are set on the assets service (out-of-band, like the other refresh flags).

- **Migration `0015_depth_curves.sql`**: `variant_depth_curves_latest`, unique on `(mint, quote_mint, side, source)`
- **Titan client (primary source)**: one-shot `getSwapPrice` via the official `@titanexchange/sdk-ts` WebSocket client — lazy connect, one reconnect on idle-out, connection closed per tick. No streams held open.
- **Jupiter lite client (cross-check/fallback)**: plain HTTP `/swap/v1/quote`, 400s (untradable/no-route) degrade to null, 429/5xx retry-then-throw
- **Impact derived from the ladder itself** (effective price per rung vs the smallest rung) — source-agnostic, no reliance on any aggregator's impact-vs-mid field
- **Universe**: registry-computed (~180 mints: multi-variant spot-like assets minus `usd`/`eur`), stalest-first shard of 60/tick via `selectStalestDepthMints` → full-fleet freshness ≈ 90 min at `*/30` cadence
- **Failure semantics**: failed rungs counted in `failed_points`; all-rungs-failed skips the write so last-good rows survive and age out via the read-path gate

## Rollout (in order)
1. Apply migration 0015 (one-off Cloud Run job in the VPC, per the prod migration runbook)
2. Set `TITAN_WS_URL`/`TITAN_API_KEY` on the assets service — **confirm key provenance (direct Titan vs Triton/QuickNode) and rate limits first**; tune `delayMs`/`maxMints` if needed
3. One-off validation run: `POST /jobs/refresh-depth-curves` with `{"mints": [8 BTC mints], "requireRefreshEnabled": false}`, inspect rows, cross-check with `lite-api.jup.ag` quotes
4. Flip `DEPTH_REFRESH_ENABLED=true`

## Test plan

- [x] 11 handler tests with fake quote source/repo: flag gate, full-ladder persist + monotone impacts, partial-rung failure, all-failed no-overwrite, transport failure counting, ok:false on total failure, stalest-shard selection, client closed per tick
- [x] turbo typecheck + test + lint green for @tokens/cloudrun-assets

🤖 Generated with [Claude Code](https://claude.com/claude-code)