### PR TITLE
feat(execution): depth-curve read path + informational size-aware fields

### DIFF
--- a/apps/api/src/app/api/v2/execution/route/route.test.ts
+++ b/apps/api/src/app/api/v2/execution/route/route.test.ts
@@ -62,11 +62,40 @@ function fillQualityRow(mint: string, executionScore: number) {
     };
 }
 
+function depthCurveRow(mint: string, asOfSecondsAgo: number) {
+    const asOf = Math.floor(Date.now() / 1000) - asOfSecondsAgo;
+    return {
+        mint,
+        depthCurve: {
+            mint,
+            quoteMint: 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v',
+            side: 'buy',
+            source: 'titan',
+            ladder: [
+                { sizeUsd: 10_000, inAmount: 1, outAmount: 1, priceImpactBps: 0, effectivePrice: 1, routeVenues: [] },
+                { sizeUsd: 100_000, inAmount: 1, outAmount: 1, priceImpactBps: 10, effectivePrice: 1, routeVenues: [] },
+                { sizeUsd: 1_000_000, inAmount: 1, outAmount: 1, priceImpactBps: 40, effectivePrice: 1, routeVenues: [] },
+                { sizeUsd: 5_000_000, inAmount: 1, outAmount: 1, priceImpactBps: 120, effectivePrice: 1, routeVenues: [] },
+            ],
+            points: 4,
+            failedPoints: 0,
+            asOf,
+            lastComputedAt: asOf * 1000,
+        },
+    };
+}
+
+let depthResponder: (() => unknown) | null = null;
+
 function stubCloudRun(): void {
     globalThis.fetch = (async (input: string | URL | Request) => {
         const url = String(input);
         if (url.includes('/query/listDeletedRefs')) {
             return new Response(JSON.stringify([]), { status: 200 });
+        }
+        if (url.includes('/query/variantDepthCurvesGetLatestByMints')) {
+            if (!depthResponder) throw new Error('depth query not stubbed');
+            return new Response(JSON.stringify(depthResponder()), { status: 200 });
         }
         if (url.includes('/query/variantMarketsGetLatestByMints')) {
             return new Response(
@@ -105,6 +134,7 @@ beforeEach(() => {
     process.env.TOKENS_USAGE_LOG_MODE = 'off';
     resetEnvForTests();
     __resetCloudRunClientForTesting();
+    depthResponder = null;
     stubCloudRun();
 
     console.log = () => undefined;
@@ -176,6 +206,61 @@ describe('GET /api/v2/execution/route', () => {
         expect(body.variants.map((entry: { rank: number }) => entry.rank)).toEqual(
             body.variants.map((_: unknown, index: number) => index + 1),
         );
+    });
+
+    it('populates informational depth fields from a fresh curve without reordering', async () => {
+        depthResponder = () => [depthCurveRow(CBBTC_MINT, 60)];
+        const response = await request('/api/v2/execution/route?asset=bitcoin&amountUsd=1000000');
+        expect(response.status).toBe(200);
+        const body = await response.json();
+
+        const top = body.variants[0];
+        expect(top.mint).toBe(CBBTC_MINT); // ordering unchanged (informational-only)
+        expect(top.estimatedImpactBps).toBe(40);
+        expect(top.estimatedOutUsd).toBe(996_000);
+        expect(top.sizeAwareScore).not.toBeNull();
+        expect(top.depthAsOf).toBeGreaterThan(0);
+        expect(top.reasons).not.toContain('depth_unavailable');
+
+        const second = body.variants[1];
+        expect(second.estimatedImpactBps).toBeNull();
+        expect(second.reasons).toContain('depth_unavailable');
+
+        expect(body.meta.depthSource).toBe('titan');
+        expect(body.meta.sizeLadderUsd).toEqual([10_000, 100_000, 1_000_000, 5_000_000]);
+        expect(body.meta.depthCoverage.withCurves).toBe(1);
+        expect(body.meta.sizeAwareScoringVersion).toBeNull(); // informational phase
+        expect(body.meta.strategy).toBe('execution_quality');
+    });
+
+    it('flags extrapolation above the sampled ladder', async () => {
+        depthResponder = () => [depthCurveRow(CBBTC_MINT, 60)];
+        const response = await request('/api/v2/execution/route?asset=bitcoin&amountUsd=20000000');
+        const body = await response.json();
+        const top = body.variants[0];
+        expect(top.estimatedImpactBps).toBe(120);
+        expect(top.reasons).toContain('beyond_sampled_depth');
+    });
+
+    it('treats stale curves as absent', async () => {
+        depthResponder = () => [depthCurveRow(CBBTC_MINT, 7 * 60 * 60)];
+        const response = await request('/api/v2/execution/route?asset=bitcoin&amountUsd=1000000');
+        const body = await response.json();
+        expect(body.variants[0].estimatedImpactBps).toBeNull();
+        expect(body.variants[0].reasons).toContain('depth_unavailable');
+        expect(body.meta.depthCoverage.withCurves).toBe(0);
+        expect(body.meta.depthSource).toBeNull();
+    });
+
+    it('degrades to depth_unavailable when the depth read fails', async () => {
+        depthResponder = () => {
+            throw new Error('depth read down');
+        };
+        const response = await request('/api/v2/execution/route?asset=bitcoin&amountUsd=1000000');
+        expect(response.status).toBe(200);
+        const body = await response.json();
+        expect(body.variants[0].estimatedImpactBps).toBeNull();
+        expect(body.variants[0].reasons).toContain('depth_unavailable');
     });
 
     it('marks every variant depth_unavailable when amountUsd is given (Phase A)', async () => {

--- a/apps/api/src/app/api/v2/execution/route/route.ts
+++ b/apps/api/src/app/api/v2/execution/route/route.ts
@@ -4,14 +4,22 @@ import { route } from '@/effect/next-route';
 import { withStaleFallback } from '@/effect/stale-response-cache';
 import { BadRequestError } from '@tokens/effect';
 import {
+    computeSizeAwareScore,
     FILL_QUALITY_SCORING_VERSION,
     getAsset,
+    interpolateImpactBps,
     isFillQualityEligibleForPrimary,
     rankVariantsWithReasons,
     type VariantFillQualityRankingSnapshot,
     type VariantMarketRankingSnapshot,
 } from '@tokens/asset-registry';
-import { variantFillQualityGetLatestByMints, variantMarketsGetLatestByMints } from '@/lib/cloudrun';
+import {
+    variantDepthCurvesGetLatestByMints,
+    variantFillQualityGetLatestByMints,
+    variantMarketsGetLatestByMints,
+    type VariantDepthCurvesGetLatestByMintsResult,
+} from '@/lib/cloudrun';
+import { tapErrorAndDefault } from '@tokens/effect';
 
 import { buildCuratedMintRank, executionQualitySnapshotFromConvexFillQuality } from '../../../v1/assets/_asset-helpers';
 import { resolveAssetRefContext } from '../../../v1/assets/_resolve-asset-ref';
@@ -20,6 +28,8 @@ const STALE_TTL_SECONDS = 10 * 60;
 const MIN_AMOUNT_USD = 1;
 const MAX_AMOUNT_USD = 50_000_000;
 const MAX_VARIANT_MINTS = 250;
+/** Curves older than this are treated as absent (depth_unavailable). */
+const MAX_DEPTH_AGE_SECONDS = 6 * 60 * 60;
 
 // Registry data is static per deploy; the curated rank never changes at runtime.
 const CURATED_MINT_RANK = buildCuratedMintRank();
@@ -79,16 +89,27 @@ export const GET = route(
                 const variants = asset?.variants ?? [];
                 const mints = variants.map(variant => variant.mint).slice(0, MAX_VARIANT_MINTS);
 
-                const [marketRows, fillQualityRows] =
+                const wantsDepth = amountUsd !== null && mints.length > 0;
+                const [marketRows, fillQualityRows, depthRows] =
                     mints.length > 0
                         ? yield* Effect.all(
                               [
                                   variantMarketsGetLatestByMints({ mints }),
                                   variantFillQualityGetLatestByMints({ mints }),
+                                  // Depth is additive: a read failure degrades to
+                                  // depth_unavailable instead of failing the request.
+                                  wantsDepth
+                                      ? variantDepthCurvesGetLatestByMints({ mints, side }).pipe(
+                                            tapErrorAndDefault(
+                                                'v2.execution.route.depthCurves',
+                                                [] as VariantDepthCurvesGetLatestByMintsResult,
+                                            ),
+                                        )
+                                      : Effect.succeed([] as VariantDepthCurvesGetLatestByMintsResult),
                               ],
                               { concurrency: 'unbounded' },
                           )
-                        : [[], []];
+                        : [[], [], [] as VariantDepthCurvesGetLatestByMintsResult];
 
                 const marketByMint = new Map<string, VariantMarketRankingSnapshot | null>();
                 const marketDocByMint = new Map<string, (typeof marketRows)[number]['market']>();
@@ -109,6 +130,22 @@ export const GET = route(
                 for (const row of fillQualityRows) {
                     fillQualityByMint.set(row.mint, executionQualitySnapshotFromConvexFillQuality(row.fillQuality));
                 }
+
+                const nowSeconds = Math.floor(Date.now() / 1000);
+                const freshCurveByMint = new Map<string, (typeof depthRows)[number]['depthCurve']>();
+                for (const row of depthRows) {
+                    const curve = row.depthCurve;
+                    if (!curve || curve.ladder.length === 0) continue;
+                    if (nowSeconds - curve.asOf > MAX_DEPTH_AGE_SECONDS) continue;
+                    freshCurveByMint.set(row.mint, curve);
+                }
+                const depthSource = freshCurveByMint.values().next().value?.source ?? null;
+                const sizeLadderUsd =
+                    freshCurveByMint.size > 0
+                        ? [...freshCurveByMint.values().next().value!.ladder]
+                              .map(point => point.sizeUsd)
+                              .sort((a, b) => a - b)
+                        : null;
 
                 const ranked = asset
                     ? rankVariantsWithReasons({
@@ -138,6 +175,14 @@ export const GET = route(
                     variants: ranked.map(entry => {
                         const market = marketDocByMint.get(entry.variant.mint) ?? null;
                         const fillQuality = fillQualityByMint.get(entry.variant.mint) ?? null;
+
+                        const curve = amountUsd !== null ? (freshCurveByMint.get(entry.variant.mint) ?? null) : null;
+                        const impact =
+                            curve && amountUsd !== null ? interpolateImpactBps(curve.ladder, amountUsd) : null;
+                        const reasons: string[] = [entry.reason];
+                        if (amountUsd !== null && impact === null) reasons.push('depth_unavailable');
+                        if (impact?.extrapolated) reasons.push('beyond_sampled_depth');
+
                         return {
                             rank: entry.rank,
                             mint: entry.variant.mint,
@@ -152,22 +197,40 @@ export const GET = route(
                             executionScore: fillQuality?.executionScore ?? null,
                             feeBps: fillQuality?.feeBps ?? null,
                             isFillQualityEligible: isFillQualityEligibleForPrimary(fillQuality),
-                            // Size-aware fields populate when the depth pipeline lands.
-                            estimatedImpactBps: null as number | null,
-                            estimatedOutUsd: null as number | null,
-                            sizeAwareScore: null as number | null,
-                            depthAsOf: null as number | null,
-                            reasons: [entry.reason, ...(amountUsd !== null ? ['depth_unavailable'] : [])],
+                            // Informational until size-aware reordering activates:
+                            // these never affect ordering today.
+                            estimatedImpactBps: impact ? impact.impactBps : null,
+                            estimatedOutUsd:
+                                impact && amountUsd !== null
+                                    ? Math.round(amountUsd * (1 - impact.impactBps / 10_000) * 100) / 100
+                                    : null,
+                            sizeAwareScore: impact
+                                ? computeSizeAwareScore({
+                                      executionScore: fillQuality?.executionScore ?? 0,
+                                      impactBps: impact.impactBps,
+                                  })
+                                : null,
+                            depthAsOf: curve?.asOf ?? null,
+                            reasons,
                         };
                     }),
                     meta: {
-                        asOf: Math.floor(Date.now() / 1000),
+                        asOf: nowSeconds,
                         scoringVersion: FILL_QUALITY_SCORING_VERSION,
+                        // Reported once size-aware reordering activates; the
+                        // informational fields never influence ordering today.
                         sizeAwareScoringVersion: null as string | null,
                         strategy: 'execution_quality' as const,
-                        sizeLadderUsd: null as number[] | null,
-                        depthSource: null as string | null,
-                        depthCoverage: amountUsd !== null ? { withCurves: 0, total: ranked.length } : null,
+                        sizeLadderUsd: amountUsd !== null ? sizeLadderUsd : null,
+                        depthSource: amountUsd !== null ? depthSource : null,
+                        depthCoverage:
+                            amountUsd !== null
+                                ? {
+                                      withCurves: ranked.filter(entry => freshCurveByMint.has(entry.variant.mint))
+                                          .length,
+                                      total: ranked.length,
+                                  }
+                                : null,
                     },
                 };
             });

--- a/apps/api/src/lib/cloudrun/depthCurveReads.ts
+++ b/apps/api/src/lib/cloudrun/depthCurveReads.ts
@@ -1,0 +1,24 @@
+import type { GetLatestByMintsEntry } from '../../../../cloudrun-assets/src/handlers/depthCurveReads';
+
+import type { Effect } from 'effect';
+
+import { cloudRunQuery } from './client';
+import type { CloudRunError } from './errors';
+
+export type VariantDepthCurvesGetLatestByMintsArgs = {
+    mints: string[];
+    side?: 'buy' | 'sell';
+    quoteMint?: string;
+    source?: 'titan' | 'jupiter_lite';
+};
+export type VariantDepthCurvesGetLatestByMintsResult = GetLatestByMintsEntry[];
+
+export function variantDepthCurvesGetLatestByMints(
+    args: VariantDepthCurvesGetLatestByMintsArgs,
+): Effect.Effect<VariantDepthCurvesGetLatestByMintsResult, CloudRunError> {
+    return cloudRunQuery<VariantDepthCurvesGetLatestByMintsResult>(
+        'assets',
+        'variantDepthCurvesGetLatestByMints',
+        { ...args },
+    );
+}

--- a/apps/api/src/lib/cloudrun/index.ts
+++ b/apps/api/src/lib/cloudrun/index.ts
@@ -158,6 +158,12 @@ export {
 } from './fillQualityReads';
 
 export {
+    variantDepthCurvesGetLatestByMints,
+    type VariantDepthCurvesGetLatestByMintsArgs,
+    type VariantDepthCurvesGetLatestByMintsResult,
+} from './depthCurveReads';
+
+export {
     assetCollectionsGetMembers,
     type AssetCollectionsGetMembersArgs,
     type AssetCollectionsGetMembersResult,

--- a/apps/cloudrun-assets/src/db.ts
+++ b/apps/cloudrun-assets/src/db.ts
@@ -56,6 +56,7 @@ import type {
 import type { TrendingMarketRow, FreshTrendingMarketRow, TrendingReadsRepo } from './handlers/trendingReads';
 import type { FillQualityRow, FillQualityReadsRepo } from './handlers/fillQualityReads';
 import type { DepthCronRepo } from './handlers/crons.depth';
+import type { DepthCurveReadsRepo, DepthCurveRow } from './handlers/depthCurveReads';
 import type { AssetCollectionMemberRow, AssetCollectionsReadsRepo } from './handlers/assetCollectionsReads';
 import type {
     TokenListMemberRow,
@@ -4660,6 +4661,23 @@ export function makePostgresDepthCurvesRepo(sql: Sql): DepthCronRepo {
                     as_of = EXCLUDED.as_of,
                     last_computed_at = EXCLUDED.last_computed_at
             `;
+        },
+    };
+}
+
+export function makePostgresDepthCurveReadsRepo(sql: Sql): DepthCurveReadsRepo {
+    return {
+        async findLatestByMints(args) {
+            if (args.mints.length === 0) return [];
+            const rows = await sql<DepthCurveRow[]>`
+                SELECT mint, quote_mint, side, source, ladder, points, failed_points, as_of, last_computed_at
+                FROM variant_depth_curves_latest
+                WHERE mint IN ${sql([...args.mints])}
+                  AND quote_mint = ${args.quoteMint}
+                  AND side = ${args.side}
+                  AND source = ${args.source}
+            `;
+            return rows;
         },
     };
 }

--- a/apps/cloudrun-assets/src/handlers/depthCurveReads.test.ts
+++ b/apps/cloudrun-assets/src/handlers/depthCurveReads.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from 'bun:test';
+
+import { getLatestByMints, type DepthCurveReadsRepo, type DepthCurveRow } from './depthCurveReads';
+
+const MINT_A = 'cbbtcf3aa214zXHbiAZQwf4122FBYbraNdFqgw4iMij';
+const MINT_B = '3NZ9JMVBmGAqocybic2c7LQCJScmgsAZ6vQqTDzcqmJh';
+
+function row(mint: string, overrides: Partial<DepthCurveRow> = {}): DepthCurveRow {
+    return {
+        mint,
+        quote_mint: 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v',
+        side: 'buy',
+        source: 'titan',
+        ladder: [
+            {
+                sizeUsd: 10_000,
+                inAmount: 10_000_000_000,
+                outAmount: 9_000_000,
+                priceImpactBps: 0,
+                effectivePrice: 0.0009,
+                routeVenues: ['Fake'],
+                contextSlot: 123,
+            },
+            { bogus: true },
+        ],
+        points: 1,
+        failed_points: 3,
+        as_of: 1_700_000_000,
+        last_computed_at: 1_700_000_000_000,
+        ...overrides,
+    };
+}
+
+function repoWith(rows: DepthCurveRow[], onArgs?: (args: unknown) => void): DepthCurveReadsRepo {
+    return {
+        async findLatestByMints(args) {
+            onArgs?.(args);
+            return rows;
+        },
+    };
+}
+
+describe('depthCurveReads.getLatestByMints', () => {
+    it('validates args', async () => {
+        const repo = repoWith([]);
+        await expect(getLatestByMints(repo, null)).rejects.toThrow('args must be an object');
+        await expect(getLatestByMints(repo, {})).rejects.toThrow('mints must be an array of strings');
+        await expect(getLatestByMints(repo, { mints: [42] })).rejects.toThrow('mints must be an array of strings');
+        await expect(getLatestByMints(repo, { mints: [MINT_A], side: 'hold' })).rejects.toThrow(
+            'side must be buy or sell',
+        );
+        await expect(getLatestByMints(repo, { mints: [MINT_A], source: 'other' })).rejects.toThrow(
+            'source must be one of',
+        );
+        await expect(getLatestByMints(repo, { mints: [MINT_A], quoteMint: ' ' })).rejects.toThrow(
+            'quoteMint must be a non-empty string',
+        );
+    });
+
+    it('defaults side/source/quoteMint and preserves request order with nulls', async () => {
+        let seen: unknown;
+        const repo = repoWith([row(MINT_B)], args => {
+            seen = args;
+        });
+        const entries = await getLatestByMints(repo, { mints: [MINT_A, MINT_B] });
+        expect(seen).toEqual({
+            mints: [MINT_A, MINT_B],
+            quoteMint: 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v',
+            side: 'buy',
+            source: 'titan',
+        });
+        expect(entries.map(entry => entry.mint)).toEqual([MINT_A, MINT_B]);
+        expect(entries[0]?.depthCurve).toBeNull();
+        expect(entries[1]?.depthCurve?.mint).toBe(MINT_B);
+    });
+
+    it('maps rows to docs and drops malformed ladder points', async () => {
+        const repo = repoWith([row(MINT_A)]);
+        const [entry] = await getLatestByMints(repo, { mints: [MINT_A] });
+        const doc = entry!.depthCurve!;
+        expect(doc.side).toBe('buy');
+        expect(doc.source).toBe('titan');
+        expect(doc.ladder).toHaveLength(1); // the bogus point is dropped
+        expect(doc.ladder[0]).toEqual({
+            sizeUsd: 10_000,
+            inAmount: 10_000_000_000,
+            outAmount: 9_000_000,
+            priceImpactBps: 0,
+            effectivePrice: 0.0009,
+            routeVenues: ['Fake'],
+            contextSlot: 123,
+        });
+        expect(doc.failedPoints).toBe(3);
+    });
+
+    it('nulls docs with an unknown source and caps mints at 250', async () => {
+        const repo = repoWith([row(MINT_A, { source: 'mystery' })]);
+        const [entry] = await getLatestByMints(repo, { mints: [MINT_A] });
+        expect(entry?.depthCurve).toBeNull();
+
+        const manyMints = Array.from({ length: 300 }, (_, i) => `${MINT_A.slice(0, -3)}${String(i).padStart(3, '0')}`);
+        let seen: { mints: readonly string[] } | undefined;
+        const capRepo = repoWith([], args => {
+            seen = args as { mints: readonly string[] };
+        });
+        await getLatestByMints(capRepo, { mints: manyMints });
+        expect(seen?.mints).toHaveLength(250);
+    });
+
+    it('returns empty for an empty mints list without a repo call', async () => {
+        const repo = repoWith([], () => {
+            throw new Error('should not be called');
+        });
+        expect(await getLatestByMints(repo, { mints: [] })).toEqual([]);
+    });
+});

--- a/apps/cloudrun-assets/src/handlers/depthCurveReads.ts
+++ b/apps/cloudrun-assets/src/handlers/depthCurveReads.ts
@@ -1,0 +1,138 @@
+import { InvalidArgsError } from './assets';
+import { DEPTH_QUOTE_SOURCES, DEPTH_USDC_QUOTE_MINT, type DepthQuoteSourceId } from './crons.depth';
+
+export interface DepthCurveRow {
+    mint: string;
+    quote_mint: string;
+    side: string;
+    source: string;
+    ladder: unknown;
+    points: number;
+    failed_points: number;
+    as_of: number;
+    last_computed_at: number;
+}
+
+export interface DepthCurveReadsRepo {
+    findLatestByMints(args: {
+        mints: readonly string[];
+        quoteMint: string;
+        side: 'buy' | 'sell';
+        source: DepthQuoteSourceId;
+    }): Promise<DepthCurveRow[]>;
+}
+
+export interface DepthCurveLadderPoint {
+    sizeUsd: number;
+    inAmount: number;
+    outAmount: number;
+    priceImpactBps: number | null;
+    effectivePrice: number;
+    routeVenues: string[];
+    contextSlot?: number;
+}
+
+export interface DepthCurveDoc {
+    mint: string;
+    quoteMint: string;
+    side: 'buy' | 'sell';
+    source: DepthQuoteSourceId;
+    ladder: DepthCurveLadderPoint[];
+    points: number;
+    failedPoints: number;
+    asOf: number;
+    lastComputedAt: number;
+}
+
+export interface GetLatestByMintsEntry {
+    mint: string;
+    depthCurve: DepthCurveDoc | null;
+}
+
+function toFiniteNumber(value: unknown): number | null {
+    return typeof value === 'number' && Number.isFinite(value) ? value : null;
+}
+
+function normalizeLadderPoint(raw: unknown): DepthCurveLadderPoint | null {
+    if (raw === null || typeof raw !== 'object' || Array.isArray(raw)) return null;
+    const record = raw as Record<string, unknown>;
+    const sizeUsd = toFiniteNumber(record.sizeUsd);
+    const inAmount = toFiniteNumber(record.inAmount);
+    const outAmount = toFiniteNumber(record.outAmount);
+    const effectivePrice = toFiniteNumber(record.effectivePrice);
+    if (sizeUsd === null || inAmount === null || outAmount === null || effectivePrice === null) return null;
+    const contextSlot = toFiniteNumber(record.contextSlot);
+    return {
+        sizeUsd,
+        inAmount,
+        outAmount,
+        priceImpactBps: toFiniteNumber(record.priceImpactBps),
+        effectivePrice,
+        routeVenues: Array.isArray(record.routeVenues)
+            ? record.routeVenues.filter((venue): venue is string => typeof venue === 'string')
+            : [],
+        ...(contextSlot !== null ? { contextSlot } : {}),
+    };
+}
+
+function rowToDoc(row: DepthCurveRow): DepthCurveDoc | null {
+    if (row.side !== 'buy' && row.side !== 'sell') return null;
+    if (!DEPTH_QUOTE_SOURCES.includes(row.source as DepthQuoteSourceId)) return null;
+    const ladder = Array.isArray(row.ladder)
+        ? row.ladder.map(normalizeLadderPoint).filter((point): point is DepthCurveLadderPoint => point !== null)
+        : [];
+    return {
+        mint: row.mint,
+        quoteMint: row.quote_mint,
+        side: row.side,
+        source: row.source as DepthQuoteSourceId,
+        ladder,
+        points: row.points,
+        failedPoints: row.failed_points,
+        asOf: row.as_of,
+        lastComputedAt: row.last_computed_at,
+    };
+}
+
+export async function getLatestByMints(repo: DepthCurveReadsRepo, args: unknown): Promise<GetLatestByMintsEntry[]> {
+    if (typeof args !== 'object' || args === null) {
+        throw new InvalidArgsError('args must be an object');
+    }
+    const a = args as { mints?: unknown; side?: unknown; quoteMint?: unknown; source?: unknown };
+    if (!Array.isArray(a.mints)) {
+        throw new InvalidArgsError('mints must be an array of strings');
+    }
+    for (const item of a.mints) {
+        if (typeof item !== 'string') {
+            throw new InvalidArgsError('mints must be an array of strings');
+        }
+    }
+    const side = a.side === undefined ? 'buy' : a.side;
+    if (side !== 'buy' && side !== 'sell') {
+        throw new InvalidArgsError('side must be buy or sell');
+    }
+    const source = a.source === undefined ? 'titan' : a.source;
+    if (typeof source !== 'string' || !DEPTH_QUOTE_SOURCES.includes(source as DepthQuoteSourceId)) {
+        throw new InvalidArgsError(`source must be one of ${DEPTH_QUOTE_SOURCES.join(', ')}`);
+    }
+    const quoteMint = a.quoteMint === undefined ? DEPTH_USDC_QUOTE_MINT : a.quoteMint;
+    if (typeof quoteMint !== 'string' || !quoteMint.trim()) {
+        throw new InvalidArgsError('quoteMint must be a non-empty string');
+    }
+
+    const mints = (a.mints as string[]).slice(0, 250).map(m => m.trim()).filter(Boolean);
+    if (mints.length === 0) return [];
+
+    const rows = await repo.findLatestByMints({
+        mints,
+        quoteMint: quoteMint.trim(),
+        side,
+        source: source as DepthQuoteSourceId,
+    });
+    const byMint = new Map(rows.map(r => [r.mint, r] as const));
+    return mints.map(mint => {
+        const row = byMint.get(mint);
+        if (!row) return { mint, depthCurve: null };
+        return { mint, depthCurve: rowToDoc(row) };
+    });
+}

--- a/apps/cloudrun-assets/src/index.ts
+++ b/apps/cloudrun-assets/src/index.ts
@@ -40,6 +40,7 @@ import {
     makePostgresTrendingReadsRepo,
     makePostgresTrendingRepo,
     makePostgresClickhouseExtrasRepo,
+    makePostgresDepthCurveReadsRepo,
     makePostgresDepthCurvesRepo,
     makePostgresPrestocksReadsRepo,
     makePostgresPrestocksRepo,
@@ -311,6 +312,7 @@ const app = createApp({
     tokensReadsRepo: makePostgresTokensReadsRepo(sql),
     trendingReadsRepo: makePostgresTrendingReadsRepo(sql),
     fillQualityReadsRepo: makePostgresFillQualityReadsRepo(sql),
+    depthCurveReadsRepo: makePostgresDepthCurveReadsRepo(sql),
     assetCollectionsReadsRepo: makePostgresAssetCollectionsReadsRepo(sql),
     tokenListsReadsRepo: makePostgresTokenListsReadsRepo(sql),
     tokenListsMutationsDeps: {

--- a/apps/cloudrun-assets/src/server.jobs.test.ts
+++ b/apps/cloudrun-assets/src/server.jobs.test.ts
@@ -14,6 +14,7 @@ import type { PrestocksReadsRepo } from './handlers/prestocksReads';
 import type { TokensReadsRepo } from './handlers/tokensReads';
 import type { TrendingReadsRepo } from './handlers/trendingReads';
 import type { FillQualityReadsRepo } from './handlers/fillQualityReads';
+import type { DepthCurveReadsRepo } from './handlers/depthCurveReads';
 import type { AssetCollectionsReadsRepo } from './handlers/assetCollectionsReads';
 import type { TokenListsReadsRepo } from './handlers/tokenListsReads';
 import type { TokenListsMutationsDeps } from './handlers/tokenListsMutations';
@@ -99,6 +100,9 @@ const noopTrendingReadsRepo: TrendingReadsRepo = {
 const noopFillQualityReadsRepo: FillQualityReadsRepo = {
     async findLatestByMints() { return []; },
 };
+const noopDepthCurveReadsRepo: DepthCurveReadsRepo = {
+    async findLatestByMints() { return []; },
+};
 const noopTokenListsReadsRepo: TokenListsReadsRepo = {
     async listPublished() { return []; },
     async getBySlug() { return null; },
@@ -139,6 +143,7 @@ const baseDeps = {
     tokensReadsRepo: noopTokensReadsRepo,
     trendingReadsRepo: noopTrendingReadsRepo,
     fillQualityReadsRepo: noopFillQualityReadsRepo,
+    depthCurveReadsRepo: noopDepthCurveReadsRepo,
     assetCollectionsReadsRepo: noopAssetCollectionsReadsRepo,
     tokenListsReadsRepo: noopTokenListsReadsRepo,
     tokenListsMutationsDeps: noopTokenListsMutationsDeps,

--- a/apps/cloudrun-assets/src/server.test.ts
+++ b/apps/cloudrun-assets/src/server.test.ts
@@ -36,6 +36,7 @@ import type {
 } from './handlers/tokensReads';
 import type { TrendingMarketRow, FreshTrendingMarketRow, TrendingReadsRepo } from './handlers/trendingReads';
 import type { FillQualityRow, FillQualityReadsRepo } from './handlers/fillQualityReads';
+import type { DepthCurveReadsRepo } from './handlers/depthCurveReads';
 import type { AssetCollectionMemberRow, AssetCollectionsReadsRepo } from './handlers/assetCollectionsReads';
 import type { TokenListsReadsRepo } from './handlers/tokenListsReads';
 import type { TokenListsMutationsDeps } from './handlers/tokenListsMutations';
@@ -318,6 +319,7 @@ function deps(overrides: Partial<ServerDeps> = {}): ServerDeps {
         tokensReadsRepo: overrides.tokensReadsRepo ?? emptyTokensReadsRepo(),
         trendingReadsRepo: overrides.trendingReadsRepo ?? emptyTrendingReadsRepo(),
         fillQualityReadsRepo: overrides.fillQualityReadsRepo ?? emptyFillQualityReadsRepo(),
+        depthCurveReadsRepo: overrides.depthCurveReadsRepo ?? emptyDepthCurveReadsRepo(),
         assetCollectionsReadsRepo: overrides.assetCollectionsReadsRepo ?? emptyAssetCollectionsReadsRepo(),
         tokenListsReadsRepo: overrides.tokenListsReadsRepo ?? emptyTokenListsReadsRepo(),
         tokenListsMutationsDeps: overrides.tokenListsMutationsDeps ?? emptyTokenListsMutationsDeps(),
@@ -3418,6 +3420,14 @@ function emptyTrendingReadsRepo(): TrendingReadsRepo {
 }
 
 function emptyFillQualityReadsRepo(): FillQualityReadsRepo {
+    return {
+        async findLatestByMints() {
+            return [];
+        },
+    };
+}
+
+function emptyDepthCurveReadsRepo(): DepthCurveReadsRepo {
     return {
         async findLatestByMints() {
             return [];

--- a/apps/cloudrun-assets/src/server.ts
+++ b/apps/cloudrun-assets/src/server.ts
@@ -125,6 +125,10 @@ import {
 import { seedJobs, type SeedCronDeps, type SeedJobHandler } from './handlers/crons.seed';
 import { prestocksJobs, type PrestocksCronDeps, type PrestocksJobHandler } from './handlers/crons.prestocks';
 import { depthJobs, type DepthCronDeps, type DepthJobHandler } from './handlers/crons.depth';
+import {
+    getLatestByMints as variantDepthCurvesGetLatestByMints,
+    type DepthCurveReadsRepo,
+} from './handlers/depthCurveReads';
 import { trendingJobs, type TrendingCronDeps, type TrendingJobHandler } from './handlers/crons.trending';
 import {
     clickhouseExtrasJobs,
@@ -169,6 +173,7 @@ export interface ServerDeps {
     tokensReadsRepo: TokensReadsRepo;
     trendingReadsRepo: TrendingReadsRepo;
     fillQualityReadsRepo: FillQualityReadsRepo;
+    depthCurveReadsRepo: DepthCurveReadsRepo;
     assetCollectionsReadsRepo: AssetCollectionsReadsRepo;
     tokenListsReadsRepo: TokenListsReadsRepo;
     tokenListsMutationsDeps: TokenListsMutationsDeps;
@@ -246,6 +251,7 @@ const ATOMIC_RETRY_QUERY_NAMES = new Set([
     'trendingMarketsList',
     'freshTrendingMarketsList',
     'variantFillQualityGetLatestByMints',
+    'variantDepthCurvesGetLatestByMints',
     'assetCollectionsGetMembers',
     'assetCollectionsGetMemberMints',
     'assetCollectionsGetSummaries',
@@ -424,6 +430,8 @@ export function createApp(deps: ServerDeps) {
     queries.freshTrendingMarketsList = args => freshTrendingMarketsList(deps.trendingReadsRepo, args);
     queries.variantFillQualityGetLatestByMints = args =>
         variantFillQualityGetLatestByMints(deps.fillQualityReadsRepo, args);
+    queries.variantDepthCurvesGetLatestByMints = args =>
+        variantDepthCurvesGetLatestByMints(deps.depthCurveReadsRepo, args);
     queries.assetCollectionsGetMembers = args => assetCollectionsGetMembers(deps.assetCollectionsReadsRepo, args);
     queries.assetCollectionsGetMemberMints = args =>
         assetCollectionsGetMemberMints(deps.assetCollectionsReadsRepo, args);

--- a/packages/asset-registry/src/index.ts
+++ b/packages/asset-registry/src/index.ts
@@ -17,6 +17,8 @@ export {
     normalizeLegacyTier,
 } from './liquidity-tier';
 export type {
+    DepthLadderRung,
+    InterpolatedImpact,
     PrimaryVariantRankingOptions,
     PrimaryVariantSelectionReason,
     PrimaryVariantSelectionResult,
@@ -28,7 +30,12 @@ export type {
 } from './primary-variant-ranking';
 export {
     FILL_QUALITY_SCORING_VERSION,
+    SIZE_AWARE_IMPACT_FLOOR_BPS,
+    SIZE_AWARE_OVERRIDE_DELTA,
+    SIZE_AWARE_SCORING_VERSION,
+    computeSizeAwareScore,
     computeVariantExecutionScore,
+    interpolateImpactBps,
     isFillQualityEligibleForPrimary,
     isSpotLikeVariantKind,
     pickPrimaryVariantWithRanking,

--- a/packages/asset-registry/src/primary-variant-ranking.test.ts
+++ b/packages/asset-registry/src/primary-variant-ranking.test.ts
@@ -1,8 +1,11 @@
 import { describe, expect, it } from 'bun:test';
 import {
+    computeSizeAwareScore,
+    interpolateImpactBps,
     isSpotLikeVariantKind,
     pickPrimaryVariantWithRanking,
     rankVariantsWithReasons,
+    SIZE_AWARE_IMPACT_FLOOR_BPS,
     type PrimaryVariantStrategy,
     type VariantFillQualityRankingSnapshot,
     type VariantMarketRankingSnapshot,
@@ -486,5 +489,74 @@ describe('rankVariantsWithReasons', () => {
 
     it('returns an empty list for an asset with no variants', () => {
         expect(rank({ variants: [] })).toEqual([]);
+    });
+});
+
+describe('interpolateImpactBps', () => {
+    const LADDER = [
+        { sizeUsd: 10_000, priceImpactBps: 0 },
+        { sizeUsd: 100_000, priceImpactBps: 10 },
+        { sizeUsd: 1_000_000, priceImpactBps: 40 },
+        { sizeUsd: 5_000_000, priceImpactBps: 120 },
+    ];
+
+    it('returns exact rung values', () => {
+        expect(interpolateImpactBps(LADDER, 100_000)).toEqual({ impactBps: 10, extrapolated: false });
+        expect(interpolateImpactBps(LADDER, 5_000_000)).toEqual({ impactBps: 120, extrapolated: false });
+    });
+
+    it('interpolates log-linearly between rungs', () => {
+        // Halfway between 100k and 1M in log space is ~316k.
+        const mid = interpolateImpactBps(LADDER, Math.sqrt(100_000 * 1_000_000));
+        expect(mid?.extrapolated).toBe(false);
+        expect(mid?.impactBps).toBe(25);
+    });
+
+    it('clamps below the smallest rung without flagging extrapolation', () => {
+        expect(interpolateImpactBps(LADDER, 1_000)).toEqual({ impactBps: 0, extrapolated: false });
+    });
+
+    it('clamps above the largest rung and flags extrapolation', () => {
+        expect(interpolateImpactBps(LADDER, 20_000_000)).toEqual({ impactBps: 120, extrapolated: true });
+    });
+
+    it('ignores rungs without usable impact and handles unsorted input', () => {
+        const sparse = [
+            { sizeUsd: 1_000_000, priceImpactBps: 40 },
+            { sizeUsd: 10_000, priceImpactBps: null },
+            { sizeUsd: 100_000, priceImpactBps: 10 },
+        ];
+        expect(interpolateImpactBps(sparse, 1_000_000)).toEqual({ impactBps: 40, extrapolated: false });
+        expect(interpolateImpactBps(sparse, 50_000)).toEqual({ impactBps: 10, extrapolated: false });
+    });
+
+    it('returns null for unusable ladders and invalid amounts', () => {
+        expect(interpolateImpactBps([], 1_000_000)).toBeNull();
+        expect(interpolateImpactBps([{ sizeUsd: 10_000, priceImpactBps: null }], 1_000_000)).toBeNull();
+        expect(interpolateImpactBps(LADDER, 0)).toBeNull();
+        expect(interpolateImpactBps(LADDER, Number.NaN)).toBeNull();
+    });
+});
+
+describe('computeSizeAwareScore', () => {
+    it('is monotone: higher impact never raises the score', () => {
+        let previous = Number.POSITIVE_INFINITY;
+        for (const impactBps of [0, 10, 50, 100, 250, 500, 1_000]) {
+            const score = computeSizeAwareScore({ executionScore: 80, impactBps });
+            expect(score).toBeLessThanOrEqual(previous);
+            previous = score;
+        }
+    });
+
+    it('blends 60/40 with the impact floor', () => {
+        expect(computeSizeAwareScore({ executionScore: 100, impactBps: 0 })).toBe(100);
+        expect(computeSizeAwareScore({ executionScore: 100, impactBps: SIZE_AWARE_IMPACT_FLOOR_BPS })).toBe(60);
+        expect(computeSizeAwareScore({ executionScore: 0, impactBps: 0 })).toBe(40);
+        expect(computeSizeAwareScore({ executionScore: 50, impactBps: 250 })).toBe(50);
+    });
+
+    it('clamps out-of-range inputs', () => {
+        expect(computeSizeAwareScore({ executionScore: 150, impactBps: -10 })).toBe(100);
+        expect(computeSizeAwareScore({ executionScore: -5, impactBps: 10_000 })).toBe(0);
     });
 });

--- a/packages/asset-registry/src/primary-variant-ranking.ts
+++ b/packages/asset-registry/src/primary-variant-ranking.ts
@@ -2,6 +2,12 @@ import { liquidityTierPriority, normalizeLegacyTier } from './liquidity-tier';
 import type { AssetCategory, AssetVariant, CanonicalAsset, LiquidityTier, StockVariantTier } from './types';
 
 export const FILL_QUALITY_SCORING_VERSION = 'fill-quality-24h-5s-v1';
+export const SIZE_AWARE_SCORING_VERSION = 'size-aware-exec-v1';
+
+/** Impact at/above this many bps zeroes the impact component of the size-aware blend. */
+export const SIZE_AWARE_IMPACT_FLOOR_BPS = 500;
+/** Size-aware reordering (once activated) requires at least this score delta. */
+export const SIZE_AWARE_OVERRIDE_DELTA = 5;
 
 const EXECUTION_SCORE_OVERRIDE_DELTA = 10;
 const MAX_LIQUIDITY_OVERRIDE_RATIO = 3;
@@ -175,6 +181,71 @@ export function pickPrimaryVariantWithRanking(params: {
     }
 
     return { variant: best, reason };
+}
+
+export interface DepthLadderRung {
+    sizeUsd: number;
+    priceImpactBps: number | null;
+}
+
+export interface InterpolatedImpact {
+    impactBps: number;
+    /** True when amountUsd fell outside the sampled ladder and was clamped. */
+    extrapolated: boolean;
+}
+
+/**
+ * Interpolate price impact at `amountUsd` from a sampled ladder. Log-linear in
+ * size space (impact curves are near-power-law); clamps below the smallest and
+ * above the largest usable rung (`extrapolated: true` above). Returns null
+ * when no rung carries a usable impact.
+ */
+export function interpolateImpactBps(
+    ladder: ReadonlyArray<DepthLadderRung>,
+    amountUsd: number,
+): InterpolatedImpact | null {
+    if (!Number.isFinite(amountUsd) || amountUsd <= 0) return null;
+    const rungs = ladder
+        .filter(
+            (rung): rung is { sizeUsd: number; priceImpactBps: number } =>
+                Number.isFinite(rung.sizeUsd) &&
+                rung.sizeUsd > 0 &&
+                rung.priceImpactBps !== null &&
+                Number.isFinite(rung.priceImpactBps),
+        )
+        .sort((a, b) => a.sizeUsd - b.sizeUsd);
+    if (rungs.length === 0) return null;
+
+    const first = rungs[0]!;
+    const last = rungs[rungs.length - 1]!;
+    if (amountUsd <= first.sizeUsd) return { impactBps: first.priceImpactBps, extrapolated: false };
+    if (amountUsd >= last.sizeUsd) {
+        return { impactBps: last.priceImpactBps, extrapolated: amountUsd > last.sizeUsd };
+    }
+
+    for (let i = 1; i < rungs.length; i++) {
+        const lower = rungs[i - 1]!;
+        const upper = rungs[i]!;
+        if (amountUsd > upper.sizeUsd) continue;
+        const span = Math.log(upper.sizeUsd) - Math.log(lower.sizeUsd);
+        const t = span > 0 ? (Math.log(amountUsd) - Math.log(lower.sizeUsd)) / span : 0;
+        const impactBps = lower.priceImpactBps + t * (upper.priceImpactBps - lower.priceImpactBps);
+        return { impactBps: Math.round(impactBps * 100) / 100, extrapolated: false };
+    }
+
+    return { impactBps: last.priceImpactBps, extrapolated: false };
+}
+
+/**
+ * Blend the fill-quality execution score with interpolated price impact.
+ * Same clamp/blend idiom as `computeVariantExecutionScore`; bump
+ * `SIZE_AWARE_SCORING_VERSION` when weights change.
+ */
+export function computeSizeAwareScore(input: { executionScore: number; impactBps: number }): number {
+    const executionQuality = clamp(input.executionScore / 100, 0, 1);
+    const impactQuality = 1 - clamp(input.impactBps / SIZE_AWARE_IMPACT_FLOOR_BPS, 0, 1);
+    const score = 100 * (0.6 * executionQuality + 0.4 * impactQuality);
+    return Math.round(clamp(score, 0, 100) * 10_000) / 10_000;
 }
 
 export type VariantRankingExclusionReason = 'excluded_by_activity_filter' | 'non_spot_like';

--- a/scripts/check-depth-curves.mjs
+++ b/scripts/check-depth-curves.mjs
@@ -1,0 +1,111 @@
+/* eslint-disable no-console */
+
+/**
+ * Read-only validation of stored depth curves against live Jupiter lite quotes.
+ *
+ * For each variant returned by GET /v2/execution/route for an asset, compares
+ * the stored per-rung price impact (Titan-sampled) with a fresh Jupiter lite
+ * quote ladder computed the same way (effective price vs the smallest rung).
+ * Independent cross-check: different aggregator, same math.
+ *
+ * Usage:
+ *   API_BASE_URL=... API_KEY=... node scripts/check-depth-curves.mjs [assetId] [driftPct]
+ *
+ * Defaults: assetId=bitcoin, driftPct=25 (relative drift threshold per rung).
+ * Exits 1 when any rung drifts beyond the threshold.
+ */
+
+const USDC_MINT = 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v';
+const LADDER_USD = [10_000, 100_000, 1_000_000, 5_000_000];
+const JUPITER_BASE = process.env.JUPITER_BASE_URL ?? 'https://lite-api.jup.ag';
+const JUPITER_DELAY_MS = 1_100;
+
+const assetId = process.argv[2] ?? 'bitcoin';
+const driftThresholdPct = Number(process.argv[3] ?? '25');
+
+const baseUrl = (process.env.API_BASE_URL ?? '').trim().replace(/\/$/, '');
+const apiKey = (process.env.API_KEY ?? '').trim();
+if (!baseUrl || !apiKey) {
+    console.error('API_BASE_URL and API_KEY must be set');
+    process.exit(1);
+}
+
+const sleep = ms => new Promise(resolve => setTimeout(resolve, ms));
+
+async function jupiterQuote(outputMint, amountUsd) {
+    const url =
+        `${JUPITER_BASE}/swap/v1/quote?inputMint=${USDC_MINT}&outputMint=${outputMint}` +
+        `&amount=${Math.round(amountUsd * 1_000_000)}&slippageBps=50`;
+    const res = await fetch(url, { headers: { Accept: 'application/json' } });
+    if (!res.ok) return null;
+    const json = await res.json();
+    const inAmount = Number(json.inAmount);
+    const outAmount = Number(json.outAmount);
+    if (!Number.isFinite(inAmount) || !Number.isFinite(outAmount) || inAmount <= 0 || outAmount <= 0) return null;
+    return { sizeUsd: amountUsd, effectivePrice: outAmount / inAmount };
+}
+
+function impactsFromEffectivePrices(points) {
+    const baseline = points.reduce((best, p) => (best === null || p.sizeUsd < best.sizeUsd ? p : best), null);
+    if (!baseline || baseline.effectivePrice <= 0) return new Map();
+    return new Map(
+        points.map(p => [p.sizeUsd, Math.max(0, Math.round((1 - p.effectivePrice / baseline.effectivePrice) * 10_000))]),
+    );
+}
+
+async function main() {
+    const routeRes = await fetch(
+        `${baseUrl}/v2/execution/route?asset=${encodeURIComponent(assetId)}&amountUsd=1000000`,
+        { headers: { 'x-api-key': apiKey } },
+    );
+    if (!routeRes.ok) {
+        console.error(`GET /v2/execution/route failed: HTTP ${routeRes.status}`);
+        process.exit(1);
+    }
+    const route = await routeRes.json();
+    const withCurves = route.variants.filter(v => v.depthAsOf !== null);
+    console.log(
+        `asset=${route.asset.assetId} variants=${route.variants.length} withCurves=${withCurves.length} ` +
+            `primary=${route.primary?.mint ?? 'null'} depthSource=${route.meta.depthSource ?? 'null'}`,
+    );
+    if (withCurves.length === 0) {
+        console.log('No fresh curves to validate — run the refresh-depth-curves job first.');
+        return;
+    }
+
+    let violations = 0;
+    for (const variant of withCurves) {
+        console.log(`\n${variant.symbol ?? variant.mint} (${variant.mint})`);
+        console.log(`  stored: impact@$1M=${variant.estimatedImpactBps}bps asOf=${variant.depthAsOf}`);
+
+        const livePoints = [];
+        for (const sizeUsd of LADDER_USD) {
+            const point = await jupiterQuote(variant.mint, sizeUsd);
+            if (point) livePoints.push(point);
+            await sleep(JUPITER_DELAY_MS);
+        }
+        const liveImpacts = impactsFromEffectivePrices(livePoints);
+        const liveAt1M = liveImpacts.get(1_000_000);
+        if (liveAt1M === undefined) {
+            console.log('  jupiter: no live quote at $1M — skipping comparison');
+            continue;
+        }
+        console.log(`  jupiter: impact@$1M=${liveAt1M}bps (${livePoints.length}/${LADDER_USD.length} rungs quoted)`);
+
+        const stored = variant.estimatedImpactBps;
+        if (stored === null) continue;
+        const reference = Math.max(Math.abs(liveAt1M), 5); // ignore sub-5bps noise in relative terms
+        const driftPct = (Math.abs(stored - liveAt1M) / reference) * 100;
+        const flag = driftPct > driftThresholdPct ? '  ⚠ DRIFT' : '  ok';
+        console.log(`${flag}: |${stored} - ${liveAt1M}| = ${Math.abs(stored - liveAt1M)}bps (${driftPct.toFixed(1)}%)`);
+        if (driftPct > driftThresholdPct) violations += 1;
+    }
+
+    console.log(violations > 0 ? `\n${violations} variant(s) beyond ${driftThresholdPct}% drift` : '\nAll within threshold');
+    process.exit(violations > 0 ? 1 : 0);
+}
+
+main().catch(error => {
+    console.error(String(error?.message ?? error));
+    process.exit(1);
+});


### PR DESCRIPTION
## Summary

PR 6 (final) of the v2 execution endpoints stack (base: `feat/execution-depth-infra`, #101).

Wires stored depth curves into `GET /v2/execution/route`. Per the informational-first decision, size-aware data **never reorders** variants yet — impact fields populate so we can validate curves in production before activating the guardrailed reordering (`SIZE_AWARE_OVERRIDE_DELTA`, already exported) in a follow-up release.

- **Read stack**: `depthCurveReads` handler (cap-250, order-preserving nulls, side/quoteMint/source args defaulting to buy/USDC/titan) + Postgres repo + `variantDepthCurvesGetLatestByMints` cloudrun query + api-side client
- **Scoring helpers** in `@tokens/asset-registry`: `interpolateImpactBps` (log-linear in size space; clamps below/above rungs, flags `beyond_sampled_depth`), `computeSizeAwareScore` (0.6 execution / 0.4 impact with a 500bps floor), `SIZE_AWARE_SCORING_VERSION`
- **Route behavior**: 6h curve freshness gate; stale/missing curves and depth read failures degrade to `depth_unavailable` (the request never fails on depth); `meta.sizeLadderUsd`/`depthSource`/`depthCoverage` now real; `meta.sizeAwareScoringVersion` stays null until reordering activates (version discipline: it reports only when depth influenced ordering)
- **Validation**: `scripts/check-depth-curves.mjs` compares stored Titan curves against live Jupiter lite quotes at the same rungs (same baseline math, independent aggregator), flagging >25% relative drift

## Test plan

- [x] 9 interpolation/blend tests (exact-rung/mid/clamp/extrapolate/unsorted/null ladders; monotonicity; floor/clamp)
- [x] 5 depthCurveReads tests (arg validation, defaults, row mapping, malformed-point drop, 250 cap)
- [x] 5 new route tests: fresh curve populates fields without reordering, extrapolation flag, stale-curve gate, depth-read-failure degradation, Phase-A depth_unavailable
- [x] turbo typecheck + test + lint green for @tokens/api, @tokens/cloudrun-assets, @tokens/asset-registry
- [ ] After PR 5 rollout: `node scripts/check-depth-curves.mjs bitcoin` against prod

🤖 Generated with [Claude Code](https://claude.com/claude-code)