### PR TITLE
fix: shield the API from assets Cloud Run saturation bursts

### DIFF
--- a/apps/api/src/app/api/v1/assets/_resolve-coingecko-coin-id.test.ts
+++ b/apps/api/src/app/api/v1/assets/_resolve-coingecko-coin-id.test.ts
@@ -1,6 +1,13 @@
 import { describe, expect, it } from 'bun:test';
+import { Effect } from 'effect';
 
-import { pickBestTokenizedCoinId, type CoinGeckoCoinSearchResult } from './_resolve-coingecko-coin-id';
+import type { RedisClient, RedisSetOptions } from '@/lib/redis';
+import {
+    coinIdCacheGet,
+    coinIdCacheSet,
+    pickBestTokenizedCoinId,
+    type CoinGeckoCoinSearchResult,
+} from './_resolve-coingecko-coin-id';
 
 function coin(partial: Partial<CoinGeckoCoinSearchResult> & Pick<CoinGeckoCoinSearchResult, 'id' | 'name' | 'symbol'>) {
     return {
@@ -40,5 +47,42 @@ describe('pickBestTokenizedCoinId', () => {
         expect(pickBestTokenizedCoinId(coins, { name: 'AMC Entertainment', symbol: 'AMC' })).toBe(
             'amc-entertainment-ondo-tokenized-stocks',
         );
+    });
+});
+
+function stubRedis(store: Map<string, string>): () => RedisClient {
+    const client = {
+        get: async <T = string>(key: string) => (store.get(key) ?? null) as T | null,
+        set: async (key: string, value: string | number, _options?: RedisSetOptions) => {
+            store.set(key, String(value));
+            return 'OK' as const;
+        },
+    } as RedisClient;
+    return () => client;
+}
+
+describe('coinIdCache', () => {
+    it('roundtrips a resolved coin id', async () => {
+        const redis = stubRedis(new Map());
+        await Effect.runPromise(coinIdCacheSet('verizon', 'verizon-ondo-tokenized', redis));
+        expect(await Effect.runPromise(coinIdCacheGet('verizon', redis))).toBe('verizon-ondo-tokenized');
+    });
+
+    it('roundtrips a null resolution as null, not a miss', async () => {
+        const redis = stubRedis(new Map());
+        await Effect.runPromise(coinIdCacheSet('spacex', null, redis));
+        expect(await Effect.runPromise(coinIdCacheGet('spacex', redis))).toBeNull();
+    });
+
+    it('returns undefined on cache miss', async () => {
+        expect(await Effect.runPromise(coinIdCacheGet('spacex', stubRedis(new Map())))).toBe(undefined);
+    });
+
+    it('fails open when redis is unavailable', async () => {
+        const broken = () => {
+            throw new Error('redis down');
+        };
+        expect(await Effect.runPromise(coinIdCacheGet('spacex', broken))).toBe(undefined);
+        await Effect.runPromise(coinIdCacheSet('spacex', null, broken));
     });
 });

--- a/apps/api/src/app/api/v1/assets/_resolve-coingecko-coin-id.ts
+++ b/apps/api/src/app/api/v1/assets/_resolve-coingecko-coin-id.ts
@@ -2,6 +2,41 @@ import { Effect } from 'effect';
 
 import { tapErrorAndDefault } from '@tokens/effect';
 import { coingeckoSearchCoins } from '@/lib/cloudrun';
+import { getRedisClient, type RedisClient } from '@/lib/redis';
+
+const COIN_ID_CACHE_NONE = '__none__';
+const COIN_ID_CACHE_HIT_TTL_SECONDS = 24 * 60 * 60;
+const COIN_ID_CACHE_MISS_TTL_SECONDS = 60 * 60;
+
+function coinIdCacheKey(assetId: string): string {
+    return `cg-coin-id:v1:${assetId}`;
+}
+
+/** `undefined` = no usable cache entry; `null` = cached "resolves to no coin id". */
+export function coinIdCacheGet(
+    assetId: string,
+    redis: () => RedisClient = getRedisClient,
+): Effect.Effect<string | null | undefined> {
+    return Effect.tryPromise(async () => redis().get<string>(coinIdCacheKey(assetId))).pipe(
+        Effect.map(value => (value === null ? undefined : value === COIN_ID_CACHE_NONE ? null : value)),
+        Effect.catch(() => Effect.succeed(undefined)),
+    );
+}
+
+export function coinIdCacheSet(
+    assetId: string,
+    coinId: string | null,
+    redis: () => RedisClient = getRedisClient,
+): Effect.Effect<void> {
+    return Effect.tryPromise(async () =>
+        redis().set(coinIdCacheKey(assetId), coinId ?? COIN_ID_CACHE_NONE, {
+            ex: coinId ? COIN_ID_CACHE_HIT_TTL_SECONDS : COIN_ID_CACHE_MISS_TTL_SECONDS,
+        }),
+    ).pipe(
+        Effect.asVoid,
+        Effect.catch(() => Effect.void),
+    );
+}
 
 export type CoinGeckoCoinSearchResult = {
     id: string;
@@ -90,6 +125,9 @@ export function resolveCoinGeckoCoinIdForAsset(params: {
     if (queries.length === 0) return Effect.succeed(null);
 
     return Effect.gen(function* () {
+        const cached = yield* coinIdCacheGet(params.assetId);
+        if (cached !== undefined) return cached;
+
         for (const query of queries) {
             const coins = (yield* coingeckoSearchCoins({ query, limit: 25 }).pipe(
                 tapErrorAndDefault('assets.resolveCoinGeckoCoinId.search', [] as CoinGeckoCoinSearchResult[], {
@@ -99,9 +137,13 @@ export function resolveCoinGeckoCoinIdForAsset(params: {
             )) as CoinGeckoCoinSearchResult[];
 
             const best = pickBestTokenizedCoinId(coins, { name: params.name ?? null, symbol: params.symbol ?? null });
-            if (best) return best;
+            if (best) {
+                yield* coinIdCacheSet(params.assetId, best);
+                return best;
+            }
         }
 
+        yield* coinIdCacheSet(params.assetId, null);
         return null;
     });
 }

--- a/apps/api/src/lib/env.ts
+++ b/apps/api/src/lib/env.ts
@@ -130,7 +130,7 @@ export function loadEnv(): ApiEnv {
             readNumber('TOKENS_USAGE_AGGREGATION_TTL_SECONDS', 172_800, 60, 604_800),
         ),
         defaultRateLimit: {
-            requests: Math.floor(readNumber('TOKENS_DEFAULT_RATE_LIMIT_REQUESTS', 100_000, 1, 10_000_000)),
+            requests: Math.floor(readNumber('TOKENS_DEFAULT_RATE_LIMIT_REQUESTS', 500, 1, 10_000_000)),
             windowSeconds: Math.floor(readNumber('TOKENS_DEFAULT_RATE_LIMIT_WINDOW_SECONDS', 10, 1, 3_600)),
         },
         defaultQuota: {

--- a/apps/api/src/lib/env.ts
+++ b/apps/api/src/lib/env.ts
@@ -130,7 +130,7 @@ export function loadEnv(): ApiEnv {
             readNumber('TOKENS_USAGE_AGGREGATION_TTL_SECONDS', 172_800, 60, 604_800),
         ),
         defaultRateLimit: {
-            requests: Math.floor(readNumber('TOKENS_DEFAULT_RATE_LIMIT_REQUESTS', 500, 1, 10_000_000)),
+            requests: Math.floor(readNumber('TOKENS_DEFAULT_RATE_LIMIT_REQUESTS', 1_000, 1, 10_000_000)),
             windowSeconds: Math.floor(readNumber('TOKENS_DEFAULT_RATE_LIMIT_WINDOW_SECONDS', 10, 1, 3_600)),
         },
         defaultQuota: {

--- a/terraform/envs/prd/main.tf
+++ b/terraform/envs/prd/main.tf
@@ -72,6 +72,7 @@ module "env" {
   memorystore_memory_size_gb = 1
 
   cloud_run_max_instances              = 10
+  cloud_run_assets_max_instances       = 20
   cloud_run_assets_cpu                 = "8"
   cloud_run_assets_memory              = "8Gi"
   cloud_run_assets_request_concurrency = 40

--- a/terraform/modules/env/main.tf
+++ b/terraform/modules/env/main.tf
@@ -81,7 +81,7 @@ module "cloud_run" {
   runtime_sa_email    = module.iam.cloud_run_runtime_sa_email
   network_id          = module.network.vpc_id
   subnet_id           = module.network.subnet_id
-  max_instances       = var.cloud_run_max_instances
+  max_instances       = each.value == "assets" ? coalesce(var.cloud_run_assets_max_instances, var.cloud_run_max_instances) : var.cloud_run_max_instances
   request_concurrency = each.value == "assets" ? var.cloud_run_assets_request_concurrency : 80
   # `usage` hosts Cloud Scheduler cron endpoints — Scheduler sends from GCP-managed
   # infra outside the VPC, so it can't reach an INTERNAL_LOAD_BALANCER ingress.

--- a/terraform/modules/env/variables.tf
+++ b/terraform/modules/env/variables.tf
@@ -87,6 +87,12 @@ variable "cloud_run_max_instances" {
   default = 10
 }
 
+variable "cloud_run_assets_max_instances" {
+  type        = number
+  description = "Max instances for the `assets` Cloud Run service. Overrides cloud_run_max_instances because assets sits behind every asset read, so pegging its cap rejects requests across the whole API. Null falls back to cloud_run_max_instances."
+  default     = null
+}
+
 variable "cloud_run_assets_cpu" {
   type        = string
   description = "CPU limit for the `assets` Cloud Run service. Overrides the module default because prd composite handlers (curated/search) are CPU-bound on 1 vCPU; other services stay on default."


### PR DESCRIPTION
## Incident (2026-08-28 19:40–19:50 IST)

A traffic burst on asset-detail endpoints (~8x baseline, three API keys) pegged `tokens-assets-prd-us` at `maxScale: 10`. Cloud Run rejected ~600 requests in 20 min with 429 "no available instance" and queued others past the 15s client timeout. Every backend read from tokens-api degraded to `tapErrorAndDefault` fallbacks (warning alert 19:42), and spacex detail endpoints returned 500s (critical 5xx alert 19:45) — spacex requests ran 49–58s because its CoinGecko id deliberately resolves to null and the resolver re-ran up to 3 sequential `searchCoins` Cloud Run queries on every request, each eating the full 15s timeout under saturation. That path alone produced 1,006 fallback errors in 30 min (~⅔ of the total), making spacex both the biggest victim and the biggest load amplifier.

## Changes

**1. Redis cache for CoinGecko coin-id resolution** (`_resolve-coingecko-coin-id.ts`)
- Positive resolutions cached 24h, null resolutions 1h (`cg-coin-id:v1:<assetId>`).
- Null caching is the point: spacex/equities whose id legitimately resolves to nothing stop fanning out 3 searches per request. During a backend outage the search falls back to `[]` → null gets cached → load sheds for up to 1h, self-healing on expiry.
- Redis errors fall open to the previous per-request search behavior.
- Shared by both callers (asset detail + price-chart routes).

**2. Assets max instances 10 → 20 in prd** (terraform)
- New `cloud_run_assets_max_instances` override, same pattern as the existing assets-specific cpu/memory/concurrency/min-instances overrides. Null falls back to `cloud_run_max_instances`, so stg is unchanged. Other prd services stay at 10 to keep Cloud SQL connection pressure bounded.

**3. Default API rate limit 100,000 → 1,000 req/10s** (`env.ts`)
- 100k/10s was effectively unlimited — every key observed in the incident ran on the default. 1,000/10s is 2.4x the highest 10-second burst observed from any key in the last 7 days (419, during today's incident), so legit consumers are untouched while a runaway consumer now gets 429s instead of saturating the backend for everyone.
- Per-key limits from the usage service and the `TOKENS_DEFAULT_RATE_LIMIT_REQUESTS` env var still override.

## Verification
- `bun test` in `apps/api`: 213 pass, 0 fail (new cache roundtrip/sentinel/fail-open tests included).
- `terraform validate` on `envs/prd`: valid; `terraform fmt -check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)