### PR TITLE
fix: backend saturation returns 429/504 to callers, pager alert on Cloud Run instance-cap rejections

### DIFF
--- a/alert-rules/assets-cloudrun-no-instance.json
+++ b/alert-rules/assets-cloudrun-no-instance.json
@@ -1,0 +1,93 @@
+{
+  "uid": "tokens-assets-cloudrun-no-instance",
+  "title": "tokens-assets: Cloud Run rejecting requests (no available instance)",
+  "ruleGroup": "tokens-api-availability",
+  "folderUID": "tokens-xyz",
+  "noDataState": "OK",
+  "execErrState": "OK",
+  "for": "2m",
+  "data": [
+    {
+      "refId": "A",
+      "datasourceUid": "grafanacloud-logs",
+      "queryType": "range",
+      "relativeTimeRange": {
+        "from": 600,
+        "to": 0
+      },
+      "model": {
+        "expr": "sum by (service) (rate({service=~\"tokens-(assets|prices|usage|admin)-prd-us\"} |= \"no available instance\" [5m]))",
+        "queryType": "range",
+        "refId": "A"
+      }
+    },
+    {
+      "refId": "B",
+      "datasourceUid": "__expr__",
+      "queryType": "",
+      "relativeTimeRange": {
+        "from": 0,
+        "to": 0
+      },
+      "model": {
+        "type": "reduce",
+        "refId": "B",
+        "expression": "A",
+        "reducer": "last",
+        "settings": {
+          "mode": "replaceNN",
+          "replaceWithValue": 0
+        }
+      }
+    },
+    {
+      "refId": "C",
+      "datasourceUid": "__expr__",
+      "queryType": "",
+      "relativeTimeRange": {
+        "from": 0,
+        "to": 0
+      },
+      "model": {
+        "type": "threshold",
+        "refId": "C",
+        "expression": "B",
+        "conditions": [
+          {
+            "evaluator": {
+              "type": "gt",
+              "params": [
+                0.1
+              ]
+            },
+            "operator": {
+              "type": "and"
+            },
+            "query": {
+              "params": [
+                "B"
+              ]
+            },
+            "reducer": {
+              "type": "last",
+              "params": []
+            },
+            "type": "query"
+          }
+        ]
+      }
+    }
+  ],
+  "condition": "C",
+  "labels": {
+    "service": "tokens-cloudrun",
+    "severity": "critical",
+    "pagerduty": "true",
+    "slack": "true"
+  },
+  "annotations": {
+    "summary": "Cloud Run is aborting requests: instance cap reached (label: service)",
+    "description": "A Cloud Run service is rejecting requests with 'no available instance' (HTTP 429 to its callers) at more than ~6/min sustained — it is pegged at its max-instances cap or instances are failing to start. This is the earliest saturation signal: tokens-api degrades to fallbacks and returns 429/504 to users while this fires. Check instance count vs maxScale on the named service, then look for a traffic burst (per-key request rates on the API overview dashboard) or a stuck revision. Raising cloud_run_assets_max_instances in terraform is the capacity lever.",
+    "runbook_url": "https://example.com/runbooks/assets-cloudrun-no-instance"
+  }
+}

--- a/packages/effect/src/api-errors.test.ts
+++ b/packages/effect/src/api-errors.test.ts
@@ -110,4 +110,16 @@ describe('httpStatusForError', () => {
         const wrapped = new Cause.UnknownError({ _tag: 'BadRequestError', message: 'bad input' }, 'An unknown error occurred');
         expect(httpStatusForError(wrapped)).toBe(500);
     });
+
+    it('maps a saturated backend (CloudRun 429) to 429', () => {
+        expect(httpStatusForError({ _tag: 'CloudRunHttpError', message: 'HTTP 429', status: 429 })).toBe(429);
+    });
+
+    it('keeps 500 for other CloudRun HTTP failures', () => {
+        expect(httpStatusForError({ _tag: 'CloudRunHttpError', message: 'HTTP 503', status: 503 })).toBe(500);
+    });
+
+    it('maps CloudRun timeouts to 504', () => {
+        expect(httpStatusForError({ _tag: 'CloudRunTimeoutError', message: 'timed out after 15000ms' })).toBe(504);
+    });
 });

--- a/packages/effect/src/api-errors.ts
+++ b/packages/effect/src/api-errors.ts
@@ -184,6 +184,12 @@ export function httpStatusForError(error: unknown): number {
             return 404;
         case 'RateLimitedError':
             return 429;
+        case 'CloudRunHttpError':
+            // A saturated backend rejecting work (429) is not an internal error —
+            // surface it to the caller as 429 so they back off instead of retrying a "500".
+            return isRecord(error) && error.status === 429 ? 429 : 500;
+        case 'CloudRunTimeoutError':
+            return 504;
         case 'UpstreamDataError':
         case 'MissingEnvError':
         case 'UpstreamHttpError':


### PR DESCRIPTION
Follow-up to #106 (today's saturation incident).

## Correct status codes

When the assets Cloud Run service pegs its instance cap, its 429s were laundered into API **500s**: `httpStatusForError` had no case for CloudRun errors, so backend rejections and timeouts fell through to the default. Callers now get the truthful status:

- backend HTTP 429 ("no available instance") → **429** — clients back off instead of retrying what looks like a server bug
- backend timeout → **504**
- other backend HTTP failures unchanged (500)

## Alert on the real saturation signal

New rule `tokens-assets: Cloud Run rejecting requests (no available instance)` (critical, PagerDuty): fires when any prd Cloud Run service logs `no available instance` aborts at >~6/min sustained 2m. Baseline check over 7 days: zero noise, and it would have caught **three** episodes — 08-22 (1,161 aborts), 08-23 (434), and today's (784). Only today's was noticed, via downstream symptoms, 3+ minutes late.

This alert also compensates for the status-code change: once saturation yields 429s instead of 500s, the 5xx pager no longer covers it. Client-facing 429 spikes are already covered by the existing `tokens-api: rate-limit denials spike` (warning, Slack).

## Known issue, not addressed here

While verifying, I found the existing `tokens-assets: 5xx ratio > 1%` alert queries `httpRequest_status` fields that **do not exist in Loki** — Cloud Run HTTP request logs are not shipped by the gcp-logs sink (0 lines in 6h; only text warnings and app JSON logs arrive). That alert can never fire and needs either the sink filter widened or the rule rewritten. Left out of this PR to keep it reviewable — needs its own decision on log volume.

## Verification
- `bun test` packages/effect (58 pass) + apps/api (213 pass); `tsc --noEmit` clean
- `node scripts/validate-grafana-config.mjs`: 26 files, 19 alert UIDs, 69 LogQL expressions valid
- Alert query manually confirmed against Loki over today's incident window

🤖 Generated with [Claude Code](https://claude.com/claude-code)