### PR TITLE
default API rate limit 1000 → 100 req/10s

### DIFF
--- a/apps/api/src/lib/env.ts
+++ b/apps/api/src/lib/env.ts
@@ -130,7 +130,7 @@ export function loadEnv(): ApiEnv {
             readNumber('TOKENS_USAGE_AGGREGATION_TTL_SECONDS', 172_800, 60, 604_800),
         ),
         defaultRateLimit: {
-            requests: Math.floor(readNumber('TOKENS_DEFAULT_RATE_LIMIT_REQUESTS', 1_000, 1, 10_000_000)),
+            requests: Math.floor(readNumber('TOKENS_DEFAULT_RATE_LIMIT_REQUESTS', 100, 1, 10_000_000)),
             windowSeconds: Math.floor(readNumber('TOKENS_DEFAULT_RATE_LIMIT_WINDOW_SECONDS', 10, 1, 3_600)),
         },
         defaultQuota: {


### PR DESCRIPTION
Second step of the rate-limit tiering after #106:

- **Default (no `projects.limits` row): 100 req/10s** (= 600/min). Applies to all 444 existing projects except those with explicit overrides, and to every new project.
- **Phantom Trading**: explicit override of **500 req/10s** already applied in prd (`projects.limits` jsonb for `kx73qde6ksejfdtrnpsbay5evx84f170`) — verified their busiest key (tok_bfdc, 141k req/24h) peaks at ~208 req/10s, comfortably inside.
- Per-key/project overrides and the `TOKENS_DEFAULT_RATE_LIMIT_REQUESTS` env var keep working unchanged.

Heads-up on who the new default can clip (observed bursts over the last week): tok_0324 and tok_1ed8 (project "Tokens") hit 400+ req/10s during Thursday's saturation burst, and tok_7473 (a Personal project doing 115k req/24h) peaks around 140 req/10s. All are non-Phantom and will now see 429s on bursts past 100/10s — intended, but if "Tokens" is an internal project it may deserve its own override.

🤖 Generated with [Claude Code](https://claude.com/claude-code)