### PR TITLE
operator mutation + script for per-project rate limits

### DIFF
--- a/apps/cloudrun-usage/src/db/dashboard.ts
+++ b/apps/cloudrun-usage/src/db/dashboard.ts
@@ -258,8 +258,6 @@ export function makePostgresDashboardRepo(sql: Sql): DashboardRepo {
         },
 
         async setProjectRateLimit(projectId, rateLimit, nowMs) {
-            // jsonb_build_object sidesteps the string-param double-encoding trap
-            // (see #257); merge preserves sibling keys like `quota`.
             const rows = await sql<{ id: string; name: string; limits: unknown }[]>`
                 UPDATE projects
                 SET limits = ${

--- a/apps/cloudrun-usage/src/db/dashboard.ts
+++ b/apps/cloudrun-usage/src/db/dashboard.ts
@@ -257,19 +257,28 @@ export function makePostgresDashboardRepo(sql: Sql): DashboardRepo {
             `;
         },
 
-        async setProjectRateLimit(projectId, rateLimit, nowMs) {
+        async setProjectRateLimit(projectId, limits, nowMs) {
+            const merged =
+                limits === null
+                    ? sql`NULLIF(COALESCE(limits, '{}'::jsonb) - 'rateLimit' - 'sustainedRateLimit', '{}'::jsonb)`
+                    : sql`COALESCE(limits, '{}'::jsonb) || jsonb_build_object(
+                          'rateLimit', jsonb_build_object(
+                              'requests', ${limits.rateLimit.requests}::int,
+                              'windowSeconds', ${limits.rateLimit.windowSeconds}::int
+                          )
+                      ) || ${
+                          limits.sustainedRateLimit
+                              ? sql`jsonb_build_object(
+                                    'sustainedRateLimit', jsonb_build_object(
+                                        'requests', ${limits.sustainedRateLimit.requests}::int,
+                                        'windowSeconds', ${limits.sustainedRateLimit.windowSeconds}::int
+                                    )
+                                )`
+                              : sql`'{}'::jsonb`
+                      }`;
             const rows = await sql<{ id: string; name: string; limits: unknown }[]>`
                 UPDATE projects
-                SET limits = ${
-                    rateLimit === null
-                        ? sql`NULLIF(COALESCE(limits, '{}'::jsonb) - 'rateLimit', '{}'::jsonb)`
-                        : sql`COALESCE(limits, '{}'::jsonb) || jsonb_build_object(
-                              'rateLimit', jsonb_build_object(
-                                  'requests', ${rateLimit.requests}::int,
-                                  'windowSeconds', ${rateLimit.windowSeconds}::int
-                              )
-                          )`
-                },
+                SET limits = ${merged},
                     updated_at = to_timestamp(${nowMs} / 1000.0)
                 WHERE id = ${projectId}
                 RETURNING id, name, limits

--- a/apps/cloudrun-usage/src/db/dashboard.ts
+++ b/apps/cloudrun-usage/src/db/dashboard.ts
@@ -257,6 +257,29 @@ export function makePostgresDashboardRepo(sql: Sql): DashboardRepo {
             `;
         },
 
+        async setProjectRateLimit(projectId, rateLimit, nowMs) {
+            // jsonb_build_object sidesteps the string-param double-encoding trap
+            // (see #257); merge preserves sibling keys like `quota`.
+            const rows = await sql<{ id: string; name: string; limits: unknown }[]>`
+                UPDATE projects
+                SET limits = ${
+                    rateLimit === null
+                        ? sql`NULLIF(COALESCE(limits, '{}'::jsonb) - 'rateLimit', '{}'::jsonb)`
+                        : sql`COALESCE(limits, '{}'::jsonb) || jsonb_build_object(
+                              'rateLimit', jsonb_build_object(
+                                  'requests', ${rateLimit.requests}::int,
+                                  'windowSeconds', ${rateLimit.windowSeconds}::int
+                              )
+                          )`
+                },
+                    updated_at = to_timestamp(${nowMs} / 1000.0)
+                WHERE id = ${projectId}
+                RETURNING id, name, limits
+            `;
+            const row = rows[0];
+            return row ? { id: row.id, name: row.name, limits: row.limits } : null;
+        },
+
         async deleteProjectCascade(projectId) {
             await sql.begin(async tx => {
                 await tx`DELETE FROM api_keys WHERE project_id = ${projectId}`;

--- a/apps/cloudrun-usage/src/handlers/dashboard.test.ts
+++ b/apps/cloudrun-usage/src/handlers/dashboard.test.ts
@@ -85,7 +85,7 @@ function makeRepo(state: RepoState = {}) {
         setProjectRateLimit: async (...args) => {
             track('setProjectRateLimit', args);
             if (!state.project) return null;
-            return { id: args[0], name: 'P', limits: args[1] === null ? null : { rateLimit: args[1] } };
+            return { id: args[0], name: 'P', limits: args[1] };
         },
         deleteProjectCascade: async (...args) => track('deleteProjectCascade', args),
         listProjectApiKeys: async () => [
@@ -202,8 +202,32 @@ describe('projectsSetRateLimit', () => {
     it('sets the override with a default 10s window', async () => {
         const { deps, calls } = makeDeps({ project: PROJECT });
         const res = await projectsSetRateLimit(deps, { projectId: 'proj_1', requests: 500 });
-        expect(calls.setProjectRateLimit?.[0]).toEqual(['proj_1', { requests: 500, windowSeconds: 10 }, NOW]);
+        expect(calls.setProjectRateLimit?.[0]).toEqual([
+            'proj_1',
+            { rateLimit: { requests: 500, windowSeconds: 10 } },
+            NOW,
+        ]);
         expect(res.limits).toEqual({ rateLimit: { requests: 500, windowSeconds: 10 } });
+    });
+
+    it('sets an optional sustained window with a default 60s window', async () => {
+        const { deps, calls } = makeDeps({ project: PROJECT });
+        await projectsSetRateLimit(deps, { projectId: 'proj_1', requests: 500, sustainedRequests: 3000 });
+        expect(calls.setProjectRateLimit?.[0]).toEqual([
+            'proj_1',
+            {
+                rateLimit: { requests: 500, windowSeconds: 10 },
+                sustainedRateLimit: { requests: 3000, windowSeconds: 60 },
+            },
+            NOW,
+        ]);
+    });
+
+    it('rejects invalid sustained values', async () => {
+        const { deps } = makeDeps({ project: PROJECT });
+        await expect(
+            projectsSetRateLimit(deps, { projectId: 'proj_1', requests: 500, sustainedRequests: 0 }),
+        ).rejects.toBeInstanceOf(InvalidArgsError);
     });
 
     it('clears the override', async () => {

--- a/apps/cloudrun-usage/src/handlers/dashboard.test.ts
+++ b/apps/cloudrun-usage/src/handlers/dashboard.test.ts
@@ -9,6 +9,7 @@ import {
     apiKeysRevoke,
     projectsGetOrCreatePersonalProject,
     projectsListMine,
+    projectsSetRateLimit,
     usersCreateProjectWithApiKey,
     usersDeleteProject,
     usersGetAllProjectApiKeys,
@@ -81,6 +82,11 @@ function makeRepo(state: RepoState = {}) {
         },
         ensureMembership: async (...args) => track('ensureMembership', args),
         updateProject: async (...args) => track('updateProject', args),
+        setProjectRateLimit: async (...args) => {
+            track('setProjectRateLimit', args);
+            if (!state.project) return null;
+            return { id: args[0], name: 'P', limits: args[1] === null ? null : { rateLimit: args[1] } };
+        },
         deleteProjectCascade: async (...args) => track('deleteProjectCascade', args),
         listProjectApiKeys: async () => [
             { id: 'key_a', keyPrefix: 'tok_aaaa', createdAt: 5, revokedAt: null, hasEncrypted: true },
@@ -189,6 +195,40 @@ describe('usersGetProjectById', () => {
 
         const member = makeDeps({ project: PROJECT, membership: { role: 'member' } });
         expect(await usersGetProjectById(member.deps, { projectId: 'proj_1' }, IDENT)).toEqual(PROJECT);
+    });
+});
+
+describe('projectsSetRateLimit', () => {
+    it('sets the override with a default 10s window', async () => {
+        const { deps, calls } = makeDeps({ project: PROJECT });
+        const res = await projectsSetRateLimit(deps, { projectId: 'proj_1', requests: 500 });
+        expect(calls.setProjectRateLimit?.[0]).toEqual(['proj_1', { requests: 500, windowSeconds: 10 }, NOW]);
+        expect(res.limits).toEqual({ rateLimit: { requests: 500, windowSeconds: 10 } });
+    });
+
+    it('clears the override', async () => {
+        const { deps, calls } = makeDeps({ project: PROJECT });
+        await projectsSetRateLimit(deps, { projectId: 'proj_1', clear: true });
+        expect(calls.setProjectRateLimit?.[0]).toEqual(['proj_1', null, NOW]);
+    });
+
+    it('rejects invalid requests values', async () => {
+        const { deps } = makeDeps({ project: PROJECT });
+        for (const requests of [0, -5, 1.5, 2_000_000, '500', undefined]) {
+            await expect(projectsSetRateLimit(deps, { projectId: 'proj_1', requests })).rejects.toBeInstanceOf(
+                InvalidArgsError,
+            );
+        }
+        await expect(
+            projectsSetRateLimit(deps, { projectId: 'proj_1', requests: 500, windowSeconds: 0 }),
+        ).rejects.toBeInstanceOf(InvalidArgsError);
+    });
+
+    it('rejects unknown projects', async () => {
+        const { deps } = makeDeps({ project: null });
+        await expect(projectsSetRateLimit(deps, { projectId: 'nope', requests: 500 })).rejects.toBeInstanceOf(
+            InvalidArgsError,
+        );
     });
 });
 

--- a/apps/cloudrun-usage/src/handlers/dashboard.ts
+++ b/apps/cloudrun-usage/src/handlers/dashboard.ts
@@ -102,7 +102,10 @@ export interface DashboardRepo {
     updateProject(projectId: string, name: string, description: string, nowMs: number): Promise<void>;
     setProjectRateLimit(
         projectId: string,
-        rateLimit: { requests: number; windowSeconds: number } | null,
+        rateLimit: {
+            rateLimit: { requests: number; windowSeconds: number };
+            sustainedRateLimit?: { requests: number; windowSeconds: number };
+        } | null,
         nowMs: number,
     ): Promise<{ id: string; name: string; limits: unknown } | null>;
     /** Transaction: delete api keys + project (memberships cascade). */
@@ -328,6 +331,28 @@ export async function usersUpdateProject(
     return null;
 }
 
+function readWindow(
+    a: Record<string, unknown>,
+    requestsField: string,
+    windowField: string,
+    defaultWindowSeconds: number,
+): { requests: number; windowSeconds: number } {
+    const requests = a[requestsField];
+    if (typeof requests !== 'number' || !Number.isInteger(requests) || requests < 1 || requests > 1_000_000) {
+        throw new InvalidArgsError(`${requestsField} must be an integer between 1 and 1000000`);
+    }
+    const windowSeconds = a[windowField] ?? defaultWindowSeconds;
+    if (
+        typeof windowSeconds !== 'number' ||
+        !Number.isInteger(windowSeconds) ||
+        windowSeconds < 1 ||
+        windowSeconds > 86_400
+    ) {
+        throw new InvalidArgsError(`${windowField} must be an integer between 1 and 86400`);
+    }
+    return { requests, windowSeconds };
+}
+
 export async function projectsSetRateLimit(
     deps: DashboardDeps,
     args: unknown,
@@ -335,25 +360,18 @@ export async function projectsSetRateLimit(
     const a = requireObject(args);
     const projectId = requireString(a, 'projectId');
 
-    let rateLimit: { requests: number; windowSeconds: number } | null = null;
+    let limits: {
+        rateLimit: { requests: number; windowSeconds: number };
+        sustainedRateLimit?: { requests: number; windowSeconds: number };
+    } | null = null;
     if (a.clear !== true) {
-        const requests = a.requests;
-        if (typeof requests !== 'number' || !Number.isInteger(requests) || requests < 1 || requests > 1_000_000) {
-            throw new InvalidArgsError('requests must be an integer between 1 and 1000000');
+        limits = { rateLimit: readWindow(a, 'requests', 'windowSeconds', 10) };
+        if (a.sustainedRequests !== undefined) {
+            limits.sustainedRateLimit = readWindow(a, 'sustainedRequests', 'sustainedWindowSeconds', 60);
         }
-        const windowSeconds = a.windowSeconds ?? 10;
-        if (
-            typeof windowSeconds !== 'number' ||
-            !Number.isInteger(windowSeconds) ||
-            windowSeconds < 1 ||
-            windowSeconds > 3600
-        ) {
-            throw new InvalidArgsError('windowSeconds must be an integer between 1 and 3600');
-        }
-        rateLimit = { requests, windowSeconds };
     }
 
-    const updated = await deps.repo.setProjectRateLimit(projectId, rateLimit, now(deps));
+    const updated = await deps.repo.setProjectRateLimit(projectId, limits, now(deps));
     if (!updated) throw new InvalidArgsError(`Unknown project: ${projectId}`);
     return updated;
 }

--- a/apps/cloudrun-usage/src/handlers/dashboard.ts
+++ b/apps/cloudrun-usage/src/handlers/dashboard.ts
@@ -100,7 +100,6 @@ export interface DashboardRepo {
     /** Insert membership if missing (idempotent). */
     ensureMembership(projectId: string, clerkUserId: string, role: ProjectRole, nowMs: number): Promise<void>;
     updateProject(projectId: string, name: string, description: string, nowMs: number): Promise<void>;
-    /** Set or clear (null) the project's rateLimit override inside `limits` jsonb, preserving other keys. */
     setProjectRateLimit(
         projectId: string,
         rateLimit: { requests: number; windowSeconds: number } | null,
@@ -329,11 +328,6 @@ export async function usersUpdateProject(
     return null;
 }
 
-/**
- * Operator mutation (service bearer token only, no Clerk identity): set or
- * clear a project's rateLimit override. `{projectId, requests, windowSeconds?}`
- * sets; `{projectId, clear: true}` reverts the project to the default limit.
- */
 export async function projectsSetRateLimit(
     deps: DashboardDeps,
     args: unknown,

--- a/apps/cloudrun-usage/src/handlers/dashboard.ts
+++ b/apps/cloudrun-usage/src/handlers/dashboard.ts
@@ -100,6 +100,12 @@ export interface DashboardRepo {
     /** Insert membership if missing (idempotent). */
     ensureMembership(projectId: string, clerkUserId: string, role: ProjectRole, nowMs: number): Promise<void>;
     updateProject(projectId: string, name: string, description: string, nowMs: number): Promise<void>;
+    /** Set or clear (null) the project's rateLimit override inside `limits` jsonb, preserving other keys. */
+    setProjectRateLimit(
+        projectId: string,
+        rateLimit: { requests: number; windowSeconds: number } | null,
+        nowMs: number,
+    ): Promise<{ id: string; name: string; limits: unknown } | null>;
     /** Transaction: delete api keys + project (memberships cascade). */
     deleteProjectCascade(projectId: string): Promise<void>;
 
@@ -321,6 +327,41 @@ export async function usersUpdateProject(
 
     await deps.repo.updateProject(projectId, name, description, now(deps));
     return null;
+}
+
+/**
+ * Operator mutation (service bearer token only, no Clerk identity): set or
+ * clear a project's rateLimit override. `{projectId, requests, windowSeconds?}`
+ * sets; `{projectId, clear: true}` reverts the project to the default limit.
+ */
+export async function projectsSetRateLimit(
+    deps: DashboardDeps,
+    args: unknown,
+): Promise<{ id: string; name: string; limits: unknown }> {
+    const a = requireObject(args);
+    const projectId = requireString(a, 'projectId');
+
+    let rateLimit: { requests: number; windowSeconds: number } | null = null;
+    if (a.clear !== true) {
+        const requests = a.requests;
+        if (typeof requests !== 'number' || !Number.isInteger(requests) || requests < 1 || requests > 1_000_000) {
+            throw new InvalidArgsError('requests must be an integer between 1 and 1000000');
+        }
+        const windowSeconds = a.windowSeconds ?? 10;
+        if (
+            typeof windowSeconds !== 'number' ||
+            !Number.isInteger(windowSeconds) ||
+            windowSeconds < 1 ||
+            windowSeconds > 3600
+        ) {
+            throw new InvalidArgsError('windowSeconds must be an integer between 1 and 3600');
+        }
+        rateLimit = { requests, windowSeconds };
+    }
+
+    const updated = await deps.repo.setProjectRateLimit(projectId, rateLimit, now(deps));
+    if (!updated) throw new InvalidArgsError(`Unknown project: ${projectId}`);
+    return updated;
 }
 
 /** Port of `users.deleteProject` — requires owner role; cascades keys + memberships. */

--- a/apps/cloudrun-usage/src/server.test.ts
+++ b/apps/cloudrun-usage/src/server.test.ts
@@ -39,6 +39,7 @@ const noopDashboard: DashboardRepo = {
     createProjectWithOwner: async () => 'prj_test',
     ensureMembership: async () => {},
     updateProject: async () => {},
+    setProjectRateLimit: async () => null,
     deleteProjectCascade: async () => {},
     listProjectsDigest: async () => [],
     listProjectApiKeys: async () => [],

--- a/apps/cloudrun-usage/src/server.ts
+++ b/apps/cloudrun-usage/src/server.ts
@@ -118,6 +118,7 @@ export function createApp(deps: ServerDeps) {
         dashboard.projectsGetOrCreatePersonalProject(dashDeps, args, identity);
     mutations.apiKeysRevoke = (args, identity) => dashboard.apiKeysRevoke(dashDeps, args, identity);
     mutations.apiKeysReset = (args, identity) => dashboard.apiKeysReset(dashDeps, args, identity);
+    mutations.projectsSetRateLimit = args => dashboard.projectsSetRateLimit(dashDeps, args);
 
     app.get('/health', c => c.json({ ok: true }));
 

--- a/scripts/set-project-rate-limit.mjs
+++ b/scripts/set-project-rate-limit.mjs
@@ -2,13 +2,19 @@ import { callCloudRun } from './_cloudrun.mjs';
 
 function usage(message) {
     if (message) console.error(`error: ${message}\n`);
-    console.error('usage: set-project-rate-limit.mjs <project name|id> <requests> [windowSeconds]');
+    console.error(
+        'usage: set-project-rate-limit.mjs <project name|id> <requests> [windowSeconds] [--sustained N [windowSeconds]]',
+    );
     console.error('       set-project-rate-limit.mjs <project name|id> --clear');
     process.exit(1);
 }
 
-const [target, requestsArg, windowArg] = process.argv.slice(2);
+const argv = process.argv.slice(2);
+const sustainedAt = argv.indexOf('--sustained');
+const sustainedArgs = sustainedAt === -1 ? [] : argv.splice(sustainedAt).slice(1);
+const [target, requestsArg, windowArg] = argv;
 if (!target || !requestsArg) usage();
+if (sustainedAt !== -1 && sustainedArgs.length === 0) usage('--sustained needs a requests value');
 
 async function resolveProject(nameOrId) {
     const projects = await callCloudRun('usage', 'query', 'listProjectsDigest', {});
@@ -28,6 +34,10 @@ if (requestsArg === '--clear') {
 } else {
     args.requests = Number(requestsArg);
     if (windowArg !== undefined) args.windowSeconds = Number(windowArg);
+    if (sustainedArgs.length > 0) {
+        args.sustainedRequests = Number(sustainedArgs[0]);
+        if (sustainedArgs[1] !== undefined) args.sustainedWindowSeconds = Number(sustainedArgs[1]);
+    }
 }
 
 const updated = await callCloudRun('usage', 'mutation', 'projectsSetRateLimit', args);

--- a/scripts/set-project-rate-limit.mjs
+++ b/scripts/set-project-rate-limit.mjs
@@ -1,0 +1,49 @@
+/**
+ * Set, clear, or show a project's API rate-limit override.
+ *
+ * Usage (run under doppler for the usage-service URL + bearer token):
+ *   doppler run --project tokens --config prd_cloudrun -- \
+ *     bun scripts/set-project-rate-limit.mjs "<project name or id>" <requests> [windowSeconds]
+ *   doppler run --project tokens --config prd_cloudrun -- \
+ *     bun scripts/set-project-rate-limit.mjs "<project name or id>" --clear
+ *
+ * Changes take effect within ~60s (API auth cache TTL). Projects without an
+ * override use the code default (TOKENS_DEFAULT_RATE_LIMIT_REQUESTS).
+ */
+
+import { callCloudRun } from './_cloudrun.mjs';
+
+function usage(message) {
+    if (message) console.error(`error: ${message}\n`);
+    console.error('usage: set-project-rate-limit.mjs <project name|id> <requests> [windowSeconds]');
+    console.error('       set-project-rate-limit.mjs <project name|id> --clear');
+    process.exit(1);
+}
+
+const [target, requestsArg, windowArg] = process.argv.slice(2);
+if (!target || !requestsArg) usage();
+
+async function resolveProject(nameOrId) {
+    const projects = await callCloudRun('usage', 'query', 'listProjectsDigest', {});
+    const byId = projects.find(p => p.id === nameOrId);
+    if (byId) return byId;
+    const byName = projects.filter(p => p.name.toLowerCase() === nameOrId.toLowerCase());
+    if (byName.length === 1) return byName[0];
+    if (byName.length > 1) usage(`"${nameOrId}" matches ${byName.length} projects — use the project id`);
+    usage(`no project named or id'd "${nameOrId}"`);
+}
+
+const project = await resolveProject(target);
+
+const args = { projectId: project.id };
+if (requestsArg === '--clear') {
+    args.clear = true;
+} else {
+    args.requests = Number(requestsArg);
+    if (windowArg !== undefined) args.windowSeconds = Number(windowArg);
+}
+
+const updated = await callCloudRun('usage', 'mutation', 'projectsSetRateLimit', args);
+console.log(`${updated.name} (${updated.id})`);
+console.log(`limits: ${JSON.stringify(updated.limits)}`);
+console.log('takes effect within ~60s (auth cache TTL)');

--- a/scripts/set-project-rate-limit.mjs
+++ b/scripts/set-project-rate-limit.mjs
@@ -1,16 +1,3 @@
-/**
- * Set, clear, or show a project's API rate-limit override.
- *
- * Usage (run under doppler for the usage-service URL + bearer token):
- *   doppler run --project tokens --config prd_cloudrun -- \
- *     bun scripts/set-project-rate-limit.mjs "<project name or id>" <requests> [windowSeconds]
- *   doppler run --project tokens --config prd_cloudrun -- \
- *     bun scripts/set-project-rate-limit.mjs "<project name or id>" --clear
- *
- * Changes take effect within ~60s (API auth cache TTL). Projects without an
- * override use the code default (TOKENS_DEFAULT_RATE_LIMIT_REQUESTS).
- */
-
 import { callCloudRun } from './_cloudrun.mjs';
 
 function usage(message) {


### PR DESCRIPTION
Raising a project's rate limit currently requires direct prod SQL (cloud-sql-proxy + temporarily enabling the instance's public IP) — too risky to be the standard operating procedure.

## What this adds

- **`projectsSetRateLimit` mutation** on the usage service — gated by the same service bearer token as the other operator mutations (`logApiRequest`, `ingestUsageAggregates`). Sets or clears the `rateLimit` key inside `projects.limits` jsonb with a SQL-side merge that preserves sibling keys (`quota`), using `jsonb_build_object` (avoids the #257-class string-param double-encoding trap). Validates requests (1–1,000,000 int) and windowSeconds (1–3600 int, default 10). Unknown project → error, not a silent no-op.
- **`scripts/set-project-rate-limit.mjs`** — one command, accepts project name or id:
  ```
  doppler run --project tokens --config prd_cloudrun -- \
    bun scripts/set-project-rate-limit.mjs "Phantom Trading" 500
  bun scripts/set-project-rate-limit.mjs <name|id> --clear   # back to default
  ```
  Ambiguous names are rejected (use the id). Takes effect in ~60s via the auth cache TTL — no deploy, no DB access, no IP toggling.

## Verification
- `bun test` in apps/cloudrun-usage: 111 pass (new handler tests: set with default window, clear, invalid values, unknown project)
- `tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)