### PR TITLE
fix(api): ignore poisoned open/close when snapping OHLCV wicks

### DIFF
--- a/apps/api/src/lib/ohlcv-sanitize.test.ts
+++ b/apps/api/src/lib/ohlcv-sanitize.test.ts
@@ -162,4 +162,39 @@ describe('sanitizeOhlcvWicks', () => {
     test('empty input', () => {
         expect(sanitizeOhlcvWicks([])).toEqual([]);
     });
+    test('a poisoned open does not drag the snapped low to zero', () => {
+        // A zero open is not a real price, and the reference prices already
+        // reject it. Using it as the body floor would put the low back at 0,
+        // which is the flat-zero y-axis this module exists to prevent.
+        const input = [
+            candle({ time: 1, open: 75, high: 75.4, low: 74.9, close: 75.2 }),
+            candle({ time: 2, open: 0, high: 75.5, low: 75, close: 75.3 }),
+            candle({ time: 3, open: 75.3, high: 75.6, low: 75.1, close: 75.4 }),
+        ];
+        const out = sanitizeOhlcvWicks(input);
+        expect(out[1]!.low).toBe(75);
+        expect(out[1]!.high).toBe(75.5);
+    });
+
+    test('a non-finite open does not spread to both wicks', () => {
+        const input = [
+            candle({ time: 1, open: 75, high: 75.4, low: 74.9, close: 75.2 }),
+            candle({ time: 2, open: Number.NaN, high: 75.5, low: 75, close: 75.3 }),
+            candle({ time: 3, open: 75.3, high: 75.6, low: 75.1, close: 75.4 }),
+        ];
+        const out = sanitizeOhlcvWicks(input);
+        expect(out[1]!.high).toBe(75.5);
+        expect(out[1]!.low).toBe(75);
+    });
+
+    test('a poisoned close falls back to the open for the body', () => {
+        const input = [
+            candle({ time: 1, open: 75, high: 75.4, low: 74.9, close: 75.2 }),
+            candle({ time: 2, open: 75.2, high: 75.5, low: 75, close: 0 }),
+            candle({ time: 3, open: 75.3, high: 75.6, low: 75.1, close: 75.4 }),
+        ];
+        const out = sanitizeOhlcvWicks(input);
+        expect(out[1]!.low).toBe(75);
+        expect(out[1]!.high).toBe(75.5);
+    });
 });

--- a/apps/api/src/lib/ohlcv-sanitize.ts
+++ b/apps/api/src/lib/ohlcv-sanitize.ts
@@ -72,8 +72,14 @@ export function sanitizeOhlcvWicks<T extends OhlcvCandleLike>(candles: readonly 
         const maxHigh = ref * WICK_TOLERANCE;
         const minLow = ref / WICK_TOLERANCE;
 
-        const bodyHigh = Math.max(candle.open, candle.close);
-        const bodyLow = Math.min(candle.open, candle.close);
+        // Open/close are only trusted here if they pass the same validity check
+        // used for the reference prices. A poisoned open of 0 would otherwise
+        // become the snapped low and reintroduce the flat-zero y-axis this
+        // module exists to prevent, and a NaN would spread to both wicks.
+        // When neither is usable the body collapses to the reference price.
+        const bodyPrices = [candle.open, candle.close].filter(isValidPrice);
+        const bodyHigh = bodyPrices.length > 0 ? Math.max(...bodyPrices) : ref;
+        const bodyLow = bodyPrices.length > 0 ? Math.min(...bodyPrices) : ref;
 
         // Snap untrusted wicks to the body; always re-establish the OHLC
         // invariant (high >= body >= low) in case stored data violates it.


### PR DESCRIPTION
### What

`sanitizeOhlcvWicks` runs every reference price through `isValidPrice`, but builds the candle body straight from `candle.open` and `candle.close`:

```ts
const bodyHigh = Math.max(candle.open, candle.close);
const bodyLow = Math.min(candle.open, candle.close);
```

Those are the same two values the module header calls out as "occasionally poisoned", so the body could be built from a number the function had already rejected as a reference one line earlier.

### Why it matters

Two ways it goes wrong, both on a candle whose neighbours are perfectly healthy:

| `open` | resulting `low` | resulting `high` |
| --- | --- | --- |
| `0` | **`0`** | 75.5 |
| `NaN` | **`NaN`** | **`NaN`** |

A zero open becomes the body floor, so the snapped low comes back as `0`. That is precisely the flat-zero y-axis autoscaling described at the top of the file as the reason this module exists, arriving through the open instead of through a dust wick.

A non-finite open is worse: `Math.max`/`Math.min` propagate `NaN`, so both wicks come back `NaN` and poison the series rather than just one candle. The early return can't help, because `high === candle.high` is false when `high` is `NaN`, so a fresh object is returned carrying it.

The existing "snaps non-finite and non-positive wicks to the body" test covers a bad `high`/`low`, and "candle with no valid reference prices is returned unchanged" covers the all-zero candle that exits early. Neither reaches a bad `open`/`close` alongside valid references, which is the gap here.

### The change

Filter `open` and `close` through the same `isValidPrice` check before using them, falling back to the reference price when neither is usable. Wick handling and `WICK_TOLERANCE` are untouched, and clean candles are still returned by identity.

### Verification

Three tests added. I confirmed each fails without the source change, with `Received: 0` and `Received: NaN` respectively, and that the other 13 tests in the file pass either way, so they isolate the new behaviour. Full `apps/api` suite is 101 passing; `turbo run typecheck` and `turbo run lint` are clean and Prettier reports no issues.