### PR TITLE
de-flap the 429 spike alert: >3/sec for 15m

### DIFF
--- a/alert-rules/api-rate-limit-spike.json
+++ b/alert-rules/api-rate-limit-spike.json
@@ -5,7 +5,7 @@
   "folderUID": "tokens-xyz",
   "noDataState": "OK",
   "execErrState": "OK",
-  "for": "5m",
+  "for": "15m",
   "data": [
     {
       "refId": "A",
@@ -57,7 +57,7 @@
             "evaluator": {
               "type": "gt",
               "params": [
-                1.0
+                3.0
               ]
             },
             "operator": {
@@ -86,8 +86,8 @@
     "slack": "true"
   },
   "annotations": {
-    "summary": "tokens-api 429 rate above 1/sec",
-    "description": "tokens-api returned HTTP 429 (rate-limited) at more than 1/sec sustained for 5 minutes. Either a single API key is hammering the service or the rate limiter is over-firing. Check the Top 10 endpoints panel and per-project rate-limit metrics.",
+    "summary": "tokens-api 429 rate above 3/sec",
+    "description": "tokens-api returned HTTP 429 (rate-limited) at more than 3/sec sustained for 15 minutes. Known bursty consumers bouncing off the per-key default (100/10s) sit well below this; sustained firing means a denial storm — a runaway client or an over-firing limiter. Check 429s by key_prefix in Loki, then raise the project's limit via scripts/set-project-rate-limit.mjs or contact the owner.",
     "runbook_url": "https://example.com/runbooks/api-rate-limit-spike"
   }
 }


### PR DESCRIPTION
The `tokens-api: rate-limit denials spike` alert flapped FIRING/RESOLVED every ~10 minutes this morning (2026-09-01, 06:42–07:06 and ongoing).

**Why it flaps:** two known bursty Personal-tier consumers bounce off the new 100/10s default in cycles — tok_7473 clips a steady ~85 requests per 5m (batch sweep every 5 minutes), and tok_0324 (Lynk) adds 300–800 per 5m during its bursts because it retries 429s without backoff. Together they oscillate right around the old threshold (1/sec = 300 per 5m), firing and resolving with each burst cycle.

**Change:** threshold 1/sec → **3/sec**, `for` 5m → **15m**. The known-consumer baseline (~0.3/sec steady, ~2.5/sec at burst peaks for a single 5m window) stays below it, and the 15m hold means only a *sustained* denial storm fires — which is the situation a human should look at. Annotation updated to point at the by-key Loki breakdown and the limit-raise script (#112).

No query change — same Loki expression, same datasource.

Validation: `node scripts/validate-grafana-config.mjs` — 26 files, 19 alert UIDs, 69 LogQL expressions valid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)