### PR TITLE
rate limits: burst window + sustained flatline window

### DIFF
--- a/apps/api/src/effect/next-route.ts
+++ b/apps/api/src/effect/next-route.ts
@@ -38,6 +38,7 @@ export interface PlatformAuthContext {
     scopes: string[];
     limits?: {
         rateLimit?: { requests: number; windowSeconds: number };
+        sustainedRateLimit?: { requests: number; windowSeconds: number };
         quota?: { requestsPerMonth: number };
     };
 }
@@ -207,12 +208,13 @@ function requirePlatformAuth(request: Request) {
     });
 }
 
-function enforceUpstashLimits(auth: PlatformAuthContext) {
+function enforceUpstashLimits(auth: PlatformAuthContext, redisOverride?: RedisClient) {
     return Effect.gen(function* () {
-        const redis = yield* getRedisClientEffect();
+        const redis = redisOverride ?? (yield* getRedisClientEffect());
 
         const env = loadEnv();
         const rateLimitCfg = auth.limits?.rateLimit ?? env.defaultRateLimit;
+        const sustainedCfg = auth.limits?.sustainedRateLimit ?? env.defaultSustainedRateLimit;
 
         const quotaCfg = auth.limits?.quota ?? env.defaultQuota;
         const now = new Date();
@@ -224,7 +226,7 @@ function enforceUpstashLimits(auth: PlatformAuthContext) {
         // The quota INCR+EXPIRE share a single pipelined request; EXPIRE NX sets
         // the TTL only when none exists (fixes the `used === 1` TOCTOU).
         // Trade-off: rate-limited (429) requests still increment the quota.
-        const [rate, [used]] = yield* Effect.all(
+        const [rate, sustained, [used]] = yield* Effect.all(
             [
                 slidingWindowLimit({
                     redis,
@@ -233,6 +235,12 @@ function enforceUpstashLimits(auth: PlatformAuthContext) {
                     windowSeconds: rateLimitCfg.windowSeconds,
                     // A hung Redis must not hold the request hostage; TimeoutError
                     // falls into the caller's fail-open catch (only RateLimitedError blocks).
+                }).pipe(Effect.timeout('1 second')),
+                slidingWindowLimit({
+                    redis,
+                    identifier: `key:${auth.apiKeyId}:sustained`,
+                    tokens: sustainedCfg.requests,
+                    windowSeconds: sustainedCfg.windowSeconds,
                 }).pipe(Effect.timeout('1 second')),
                 Effect.tryPromise(() =>
                     redis
@@ -251,6 +259,17 @@ function enforceUpstashLimits(auth: PlatformAuthContext) {
                 new RateLimitedError({
                     service: 'rateLimit',
                     message: 'Rate limited',
+                    retryAfterMs,
+                }),
+            );
+        }
+
+        if (!sustained.success) {
+            const retryAfterMs = Math.max(0, sustained.reset - Date.now());
+            return yield* Effect.fail(
+                new RateLimitedError({
+                    service: 'sustainedRateLimit',
+                    message: 'Rate limited (sustained)',
                     retryAfterMs,
                 }),
             );

--- a/apps/api/src/effect/rate-limit-windows.test.ts
+++ b/apps/api/src/effect/rate-limit-windows.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it, mock } from 'bun:test';
+import { Effect } from 'effect';
+
+mock.module('server-only', () => ({}));
+
+const { __internals } = await import('./next-route');
+import type { RedisClient } from '@/lib/redis';
+
+function makeStub(state: { burstRemaining: number; sustainedRemaining: number }) {
+    const evalCalls: Array<{ keys: string[]; args: Array<string | number> }> = [];
+    const windowResult = (keys: string[], args: Array<string | number>): [number, number] => {
+        evalCalls.push({ keys, args });
+        const isSustained = keys[0]?.includes(':sustained:');
+        return [isSustained ? state.sustainedRemaining : state.burstRemaining, Number(args[0])];
+    };
+    const pipeline = () => {
+        const p = {
+            incr: () => p,
+            expire: () => p,
+            hincrby: () => p,
+            set: () => p,
+            exec: async () => [1, 1] as [number, 0 | 1],
+        };
+        return p;
+    };
+    const redis = {
+        get: async () => null,
+        set: async () => 'OK' as const,
+        pipeline,
+        eval: async (_s: string, keys: string[], args: Array<string | number>) => windowResult(keys, args),
+        evalsha: async (_s: string, keys: string[], args: Array<string | number>) => windowResult(keys, args),
+        scriptLoad: async () => 'sha',
+    } as unknown as RedisClient;
+    return { redis, evalCalls };
+}
+
+const AUTH = {
+    apiKeyId: 'key_1',
+    keyPrefix: 'tok_test',
+    projectId: 'proj_1',
+    ownerClerkUserId: 'user_1',
+    scopes: ['assets:read'],
+};
+
+describe('enforceUpstashLimits burst + sustained windows', () => {
+    it('checks both windows and passes when both allow', async () => {
+        const { redis, evalCalls } = makeStub({ burstRemaining: 10, sustainedRemaining: 10 });
+        const meta = await Effect.runPromise(__internals.enforceUpstashLimits(AUTH, redis));
+        expect(meta.rateLimit.limit).toBe(400);
+        const identifiers = evalCalls.map(c => c.keys[0] ?? '');
+        expect(identifiers.some(k => k.includes('key:key_1:') && !k.includes(':sustained:'))).toBe(true);
+        expect(identifiers.some(k => k.includes('key:key_1:sustained:'))).toBe(true);
+    });
+
+    it('fails with service=rateLimit when the burst window rejects', async () => {
+        const { redis } = makeStub({ burstRemaining: -1, sustainedRemaining: 10 });
+        const err = (await Effect.runPromise(Effect.flip(__internals.enforceUpstashLimits(AUTH, redis)))) as {
+            _tag: string;
+            service?: string;
+        };
+        expect(err._tag).toBe('RateLimitedError');
+        expect(err.service).toBe('rateLimit');
+    });
+
+    it('fails with service=sustainedRateLimit when only the long window rejects', async () => {
+        const { redis } = makeStub({ burstRemaining: 10, sustainedRemaining: -1 });
+        const err = (await Effect.runPromise(Effect.flip(__internals.enforceUpstashLimits(AUTH, redis)))) as {
+            _tag: string;
+            service?: string;
+        };
+        expect(err._tag).toBe('RateLimitedError');
+        expect(err.service).toBe('sustainedRateLimit');
+    });
+
+    it('honors per-project overrides for both windows', async () => {
+        const { redis, evalCalls } = makeStub({ burstRemaining: 10, sustainedRemaining: 10 });
+        await Effect.runPromise(
+            __internals.enforceUpstashLimits(
+                {
+                    ...AUTH,
+                    limits: {
+                        rateLimit: { requests: 500, windowSeconds: 10 },
+                        sustainedRateLimit: { requests: 3000, windowSeconds: 60 },
+                    },
+                },
+                redis,
+            ),
+        );
+        const burst = evalCalls.find(c => !c.keys[0]?.includes(':sustained:'));
+        const sustained = evalCalls.find(c => c.keys[0]?.includes(':sustained:'));
+        expect(burst?.args[0]).toBe(500);
+        expect(sustained?.args[0]).toBe(3000);
+    });
+});

--- a/apps/api/src/lib/cloudrun/platformAuth.ts
+++ b/apps/api/src/lib/cloudrun/platformAuth.ts
@@ -18,6 +18,7 @@ export interface AuthenticateApiKeyResult {
     scopes: string[];
     limits?: {
         rateLimit?: { requests: number; windowSeconds: number };
+        sustainedRateLimit?: { requests: number; windowSeconds: number };
         quota?: { requestsPerMonth: number };
     };
 }

--- a/apps/api/src/lib/env.ts
+++ b/apps/api/src/lib/env.ts
@@ -139,7 +139,7 @@ export function loadEnv(): ApiEnv {
             windowSeconds: Math.floor(readNumber('TOKENS_DEFAULT_RATE_LIMIT_WINDOW_SECONDS', 10, 1, 3_600)),
         },
         defaultSustainedRateLimit: {
-            requests: Math.floor(readNumber('TOKENS_DEFAULT_SUSTAINED_RATE_LIMIT_REQUESTS', 600, 1, 10_000_000)),
+            requests: Math.floor(readNumber('TOKENS_DEFAULT_SUSTAINED_RATE_LIMIT_REQUESTS', 1_000, 1, 10_000_000)),
             windowSeconds: Math.floor(
                 readNumber('TOKENS_DEFAULT_SUSTAINED_RATE_LIMIT_WINDOW_SECONDS', 60, 1, 86_400),
             ),

--- a/apps/api/src/lib/env.ts
+++ b/apps/api/src/lib/env.ts
@@ -32,8 +32,13 @@ export interface ApiEnv {
      * per-project override. Tunable via env so real limits can be set before
      * offering the API externally without a code change. Fallbacks preserve
      * the current "launch mode" behavior.
+     *
+     * Two windows: `defaultRateLimit` is the short burst window and
+     * `defaultSustainedRateLimit` is the long flatline window — a request is
+     * admitted only when both allow it.
      */
     defaultRateLimit: { requests: number; windowSeconds: number };
+    defaultSustainedRateLimit: { requests: number; windowSeconds: number };
     defaultQuota: { requestsPerMonth: number };
 }
 
@@ -130,8 +135,14 @@ export function loadEnv(): ApiEnv {
             readNumber('TOKENS_USAGE_AGGREGATION_TTL_SECONDS', 172_800, 60, 604_800),
         ),
         defaultRateLimit: {
-            requests: Math.floor(readNumber('TOKENS_DEFAULT_RATE_LIMIT_REQUESTS', 100, 1, 10_000_000)),
+            requests: Math.floor(readNumber('TOKENS_DEFAULT_RATE_LIMIT_REQUESTS', 400, 1, 10_000_000)),
             windowSeconds: Math.floor(readNumber('TOKENS_DEFAULT_RATE_LIMIT_WINDOW_SECONDS', 10, 1, 3_600)),
+        },
+        defaultSustainedRateLimit: {
+            requests: Math.floor(readNumber('TOKENS_DEFAULT_SUSTAINED_RATE_LIMIT_REQUESTS', 600, 1, 10_000_000)),
+            windowSeconds: Math.floor(
+                readNumber('TOKENS_DEFAULT_SUSTAINED_RATE_LIMIT_WINDOW_SECONDS', 60, 1, 86_400),
+            ),
         },
         defaultQuota: {
             requestsPerMonth: Math.floor(


### PR DESCRIPTION
Follow-up to #111 after two days of live data. The single 10s window makes burst capacity and sustained throughput the same number — and every 429 producer so far is bursty-but-light (peaks 1.5–3× over 100/10s, averages under 1.5 rps): a 5-minute batch sweep (peak 145/10s), a catalog crawl (290/10s), and a retrying poller (302/10s).

## Change

Each request now passes **two** sliding windows (same primitive, second identifier `key:<id>:sustained`):

| window | default | env | per-project override |
|---|---|---|---|
| burst | **400 / 10s** | `TOKENS_DEFAULT_RATE_LIMIT_REQUESTS` | `limits.rateLimit` |
| sustained | **1,000 / 60s** (~16.7 rps) | `TOKENS_DEFAULT_SUSTAINED_RATE_LIMIT_*` | `limits.sustainedRateLimit` |

Long-run ceiling moves from 10 rps to ~16.7 rps sustained, sized so a full 400 burst plus steady traffic does not starve the rest of the minute (400 burst + 600 remaining). All three current 429 producers fit under these defaults — while anything sustaining >1,000 requests in a minute still gets 429s (`RateLimitedError` with `service: sustainedRateLimit`, distinguishable in logs from burst rejections).

Fail-open semantics, quota accounting, and the response `rate_limit` meta (burst window) are unchanged.

## ⚠️ Deploy ordering

Phantom Trading's peak minutes reach ~976 req/min — now *under* the 1,000/60s default, but with only 2% headroom. Recommended: still give them `sustainedRateLimit: 3000/60s` via #112's script (`--sustained 3000`) so a modest growth week does not clip them. Not a hard merge blocker anymore.

## Verification
- New tests: both windows consulted, burst-reject vs sustained-reject error services, per-project overrides for both windows (`rate-limit-windows.test.ts`, via an injected stub Redis)
- Full apps/api suite: 217 pass; `tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)