### PR TITLE
lists 3/6: open list writes to every key, 1000-mint batches

### DIFF
--- a/apps/api/src/app/api/v2/lists/[slug]/members/[mint]/route.ts
+++ b/apps/api/src/app/api/v2/lists/[slug]/members/[mint]/route.ts
@@ -41,7 +41,7 @@ export const PUT = route(
             const member = yield* unwrapOutcome(outcome);
             return { member };
         }),
-    { platform: { requiredScopes: ['lists:write'] } },
+    { platform: { requiredScopes: ['assets:read'] } },
 );
 
 /** DELETE /api/v2/lists/{slug}/members/{mint} — remove a member. */
@@ -57,5 +57,5 @@ export const DELETE = route(
             const removed = yield* unwrapOutcome(outcome);
             return { removed };
         }),
-    { platform: { requiredScopes: ['lists:write'] } },
+    { platform: { requiredScopes: ['assets:read'] } },
 );

--- a/apps/api/src/app/api/v2/lists/[slug]/members/[mint]/route.ts
+++ b/apps/api/src/app/api/v2/lists/[slug]/members/[mint]/route.ts
@@ -2,6 +2,7 @@ import { Effect, Schema } from 'effect';
 
 import { route, type PlatformAuthContext } from '@/effect/next-route';
 import { decodeUnknownOrBadRequest } from '@tokens/effect';
+import { enforceProviderBudget } from '@/effect/provider-budget';
 import { tokenListsRemoveMember, tokenListsUpsertMember } from '@/lib/cloudrun';
 
 import { unwrapOutcome } from '../../../_shared';
@@ -34,6 +35,9 @@ export const PUT = route(
                 return text.trim() ? (JSON.parse(text) as unknown) : {};
             });
             const body = yield* decodeUnknownOrBadRequest(putBodySchema, raw, 'Invalid body');
+            // Same provider budget as the batch path: unknown mints resolve via
+            // Birdeye here too, so single PUTs must not be a budget side door.
+            yield* enforceProviderBudget(ctx.platformAuth, 'batch');
 
             const outcome = yield* tokenListsUpsertMember({
                 ownerProjectId: ctx.platformAuth.projectId,

--- a/apps/api/src/app/api/v2/lists/[slug]/members/route.ts
+++ b/apps/api/src/app/api/v2/lists/[slug]/members/route.ts
@@ -34,5 +34,5 @@ export const POST = route(
             });
             return yield* unwrapOutcome(outcome);
         }),
-    { platform: { requiredScopes: ['lists:write'] } },
+    { platform: { requiredScopes: ['assets:read'] } },
 );

--- a/apps/api/src/app/api/v2/lists/[slug]/members/route.ts
+++ b/apps/api/src/app/api/v2/lists/[slug]/members/route.ts
@@ -2,6 +2,7 @@ import { Effect, Schema } from 'effect';
 
 import { route, type PlatformAuthContext } from '@/effect/next-route';
 import { decodeUnknownOrBadRequest } from '@tokens/effect';
+import { enforceProviderBudget } from '@/effect/provider-budget';
 import { tokenListsAddMembersBatch } from '@/lib/cloudrun';
 
 import { unwrapOutcome } from '../../_shared';
@@ -26,6 +27,9 @@ export const POST = route(
             const { slug } = yield* Effect.tryPromise(() => ctx.params);
             const json = yield* Effect.tryPromise(() => request.json());
             const body = yield* decodeUnknownOrBadRequest(bodySchema, json, 'Invalid body');
+            // Per-key window budget: bounds sustained provider (Birdeye) spend
+            // regardless of the per-call lookup cap.
+            yield* enforceProviderBudget(ctx.platformAuth, 'batch');
 
             const outcome = yield* tokenListsAddMembersBatch({
                 ownerProjectId: ctx.platformAuth.projectId,

--- a/apps/api/src/app/api/v2/lists/[slug]/route.ts
+++ b/apps/api/src/app/api/v2/lists/[slug]/route.ts
@@ -115,7 +115,7 @@ export const PATCH = route(
             const list = yield* unwrapOutcome(outcome);
             return { list };
         }),
-    { platform: { requiredScopes: ['lists:write'] } },
+    { platform: { requiredScopes: ['assets:read'] } },
 );
 
 /**
@@ -134,5 +134,5 @@ export const DELETE = route(
             const list = yield* unwrapOutcome(outcome);
             return { list };
         }),
-    { platform: { requiredScopes: ['lists:write'] } },
+    { platform: { requiredScopes: ['assets:read'] } },
 );

--- a/apps/api/src/app/api/v2/lists/_shared.ts
+++ b/apps/api/src/app/api/v2/lists/_shared.ts
@@ -262,8 +262,12 @@ export function failMutationError(
                     details: { code },
                 }),
             );
+        case 'list_full':
+            return Effect.fail(
+                new BadRequestError({ message: 'This list is at its member capacity', details: { code } }),
+            );
         case 'batch_too_large':
-            return Effect.fail(new BadRequestError({ message: 'Batch exceeds the 100-mint cap', details: { code } }));
+            return Effect.fail(new BadRequestError({ message: 'Batch exceeds the per-call mint cap', details: { code } }));
     }
 }
 

--- a/apps/api/src/app/api/v2/lists/_shared.ts
+++ b/apps/api/src/app/api/v2/lists/_shared.ts
@@ -262,6 +262,13 @@ export function failMutationError(
                     details: { code },
                 }),
             );
+        case 'project_lists_limit':
+            return Effect.fail(
+                new BadRequestError({
+                    message: 'This project is at its list limit — delete a list before creating another',
+                    details: { code },
+                }),
+            );
         case 'list_full':
             return Effect.fail(
                 new BadRequestError({ message: 'This list is at its member capacity', details: { code } }),
@@ -277,7 +284,9 @@ export function failMutationError(
         case 'admin_locked':
             return Effect.fail(new ForbiddenError({ message: 'This list has been locked by moderators' }));
         case 'batch_too_large':
-            return Effect.fail(new BadRequestError({ message: 'Batch exceeds the per-call mint cap', details: { code } }));
+            return Effect.fail(
+                new BadRequestError({ message: 'Batch exceeds the per-call mint cap', details: { code } }),
+            );
     }
 }
 

--- a/apps/api/src/app/api/v2/lists/check-slug/route.ts
+++ b/apps/api/src/app/api/v2/lists/check-slug/route.ts
@@ -48,5 +48,5 @@ export const GET = route(
             return { slug: raw, available: true };
         }),
     // No cache: a slug freed by a delete must read as available immediately.
-    { platform: { requiredScopes: ['lists:write'] } },
+    { platform: { requiredScopes: ['assets:read'] } },
 );

--- a/apps/api/src/app/api/v2/lists/route.ts
+++ b/apps/api/src/app/api/v2/lists/route.ts
@@ -66,5 +66,5 @@ export const POST = route(
             const list = yield* unwrapOutcome(outcome);
             return { list };
         }),
-    { platform: { requiredScopes: ['lists:write'] } },
+    { platform: { requiredScopes: ['assets:read'] } },
 );

--- a/apps/api/src/app/api/v2/lists/search-tokens/route.ts
+++ b/apps/api/src/app/api/v2/lists/search-tokens/route.ts
@@ -13,9 +13,9 @@ import { SCORING_VERSION } from '@/lib/judgment/types';
 
 /**
  * GET /api/v2/lists/search-tokens — curator-assist search for list owners
- * deciding which mint to add. Not a public ranking: it is gated behind
- * `lists:write`, defaults to the strict policy, and ALWAYS returns the
- * suppressed set with reasons — a curator must see what was filtered and why.
+ * deciding which mint to add. Not a public ranking: it defaults to the strict
+ * policy and ALWAYS returns the suppressed set with reasons — a curator must
+ * see what was filtered and why.
  * Each result carries `verified` (registry variant exists) and `inLists`
  * (curated + community lists already containing the mint — prior art).
  */
@@ -89,5 +89,5 @@ export const GET = route(
                 suppressed,
             };
         }),
-    { platform: { requiredScopes: ['lists:write'] }, cache: { maxAge: 30 } },
+    { platform: { requiredScopes: ['assets:read'] }, cache: { maxAge: 30 } },
 );

--- a/apps/api/src/app/api/v2/lists/search-tokens/route.ts
+++ b/apps/api/src/app/api/v2/lists/search-tokens/route.ts
@@ -1,6 +1,7 @@
 import { Effect } from 'effect';
 
-import { route } from '@/effect/next-route';
+import { route, type PlatformAuthContext } from '@/effect/next-route';
+import { enforceProviderBudget } from '@/effect/provider-budget';
 import { BadRequestError, decodeLimit, tapErrorAndDefault } from '@tokens/effect';
 import { tokenListsGetSlugsByMints } from '@/lib/cloudrun';
 
@@ -20,8 +21,11 @@ import { SCORING_VERSION } from '@/lib/judgment/types';
  * (curated + community lists already containing the mint — prior art).
  */
 export const GET = route(
-    (request: Request) =>
+    (request: Request, ctx: { platformAuth: PlatformAuthContext }) =>
         Effect.gen(function* () {
+            // Unique-q searches bypass the 30s response cache; the per-key
+            // window budget bounds sustained provider spend.
+            yield* enforceProviderBudget(ctx.platformAuth, 'search');
             const url = new URL(request.url);
             const q = (url.searchParams.get('q') ?? '').trim();
             if (!q) {
@@ -50,10 +54,16 @@ export const GET = route(
             const policy = POLICIES[policyId];
 
             const { candidates, sources } = yield* gatherCandidates(q, interpretation);
-            const { results, suppressed } = judgeCandidates(candidates, interpretation, policy, getProtectedSymbolIndex(), {
-                nowMs: Date.now(),
-                limit,
-            });
+            const { results, suppressed } = judgeCandidates(
+                candidates,
+                interpretation,
+                policy,
+                getProtectedSymbolIndex(),
+                {
+                    nowMs: Date.now(),
+                    limit,
+                },
+            );
 
             // Prior art for the curator: which lists (curated ∪ published
             // community) already contain each candidate. Fail-open — membership
@@ -70,10 +80,7 @@ export const GET = route(
 
             const annotated = results.map(result => {
                 const registry = registryByMint.get(result.mint) ?? null;
-                const inLists = [
-                    ...(registry?.curatedListIds ?? []),
-                    ...(communityByMint.get(result.mint) ?? []),
-                ];
+                const inLists = [...(registry?.curatedListIds ?? []), ...(communityByMint.get(result.mint) ?? [])];
                 return { ...result, verified: registry !== null, inLists };
             });
 

--- a/apps/api/src/effect/next-route.ts
+++ b/apps/api/src/effect/next-route.ts
@@ -65,7 +65,7 @@ const LATENCY_BOUNDS_MS: ReadonlyArray<number> = [
  * `TOKENS_REDIS_TARGET=memorystore` flag (PR #189) flips us between Upstash
  * and Memorystore without touching callsites. Defaults to Upstash.
  */
-function getRedisClientEffect(): Effect.Effect<RedisClient, MissingEnvError, never> {
+export function getRedisClientEffect(): Effect.Effect<RedisClient, MissingEnvError, never> {
     return Effect.gen(function* () {
         const upstash = loadEnv().upstash;
         const target = (process.env.TOKENS_REDIS_TARGET ?? '').trim().toLowerCase();
@@ -164,9 +164,7 @@ function requirePlatformAuth(request: Request) {
 
         if (rawKey) {
             const keyHash = yield* Effect.tryPromise(() => sha256Hex(rawKey));
-            const cachedAuth = yield* getCachedPlatformAuth(keyHash).pipe(
-                Effect.catch(() => Effect.succeed(null)),
-            );
+            const cachedAuth = yield* getCachedPlatformAuth(keyHash).pipe(Effect.catch(() => Effect.succeed(null)));
             if (cachedAuth) return cachedAuth;
 
             const auth = yield* authenticateApiKey(keyHash);
@@ -183,9 +181,7 @@ function requirePlatformAuth(request: Request) {
                 ...(auth.limits ? { limits: auth.limits } : {}),
             } satisfies PlatformAuthContext;
 
-            yield* cachePlatformAuth(keyHash, authContext).pipe(
-                Effect.catch(() => Effect.succeed(undefined)),
-            );
+            yield* cachePlatformAuth(keyHash, authContext).pipe(Effect.catch(() => Effect.succeed(undefined)));
 
             return authContext;
         }
@@ -328,18 +324,20 @@ async function tryLogRequest(params: {
     errorTag?: string;
 }): Promise<void> {
     try {
-        await Effect.runPromise(logApiRequest({
-            projectId: params.platformAuth.projectId,
-            apiKeyId: params.platformAuth.apiKeyId,
-            keyPrefix: params.platformAuth.keyPrefix,
-            method: params.method,
-            path: params.path,
-            endpoint: normalizeEndpointPath(params.path),
-            status: params.status,
-            latencyMs: params.latencyMs,
-            ts: params.ts,
-            ...(params.errorTag ? { errorTag: params.errorTag } : {}),
-        }));
+        await Effect.runPromise(
+            logApiRequest({
+                projectId: params.platformAuth.projectId,
+                apiKeyId: params.platformAuth.apiKeyId,
+                keyPrefix: params.platformAuth.keyPrefix,
+                method: params.method,
+                path: params.path,
+                endpoint: normalizeEndpointPath(params.path),
+                status: params.status,
+                latencyMs: params.latencyMs,
+                ts: params.ts,
+                ...(params.errorTag ? { errorTag: params.errorTag } : {}),
+            }),
+        );
     } catch {
         // Best-effort logging; never fail the API request due to analytics.
     }
@@ -355,39 +353,39 @@ function recordUsageAggregate(params: {
     ts: number;
 }): Effect.Effect<void, unknown> {
     return Effect.gen(function* () {
-    const env = loadEnv();
-    const redis = yield* getRedisClientEffect();
-    const endpoint = normalizeEndpointPath(params.path);
-    const day = dateKeyUtc(params.ts);
-    const endpointHash = yield* Effect.tryPromise(() => sha256Hex(endpoint));
-    const ttl = env.usageAggregationTtlSeconds;
-    const dayKey = `usage:v1:day:${day}:${params.platformAuth.projectId}`;
-    const endpointKey = `usage:v1:endpoint:${day}:${params.platformAuth.projectId}:${endpointHash}`;
-    const endpointNameKey = `usage:v1:endpoint-name:${endpointHash}`;
-    const assetCallDelta = isAssetEndpoint(endpoint) ? 1 : 0;
-    const successDelta = params.status < 400 ? 1 : 0;
-    const latencyMs = Math.max(0, Math.floor(params.latencyMs));
-    const statusField = statusClassField(params.status);
-    const histogramField = `hist:${binLatencyMs(latencyMs)}`;
+        const env = loadEnv();
+        const redis = yield* getRedisClientEffect();
+        const endpoint = normalizeEndpointPath(params.path);
+        const day = dateKeyUtc(params.ts);
+        const endpointHash = yield* Effect.tryPromise(() => sha256Hex(endpoint));
+        const ttl = env.usageAggregationTtlSeconds;
+        const dayKey = `usage:v1:day:${day}:${params.platformAuth.projectId}`;
+        const endpointKey = `usage:v1:endpoint:${day}:${params.platformAuth.projectId}:${endpointHash}`;
+        const endpointNameKey = `usage:v1:endpoint-name:${endpointHash}`;
+        const assetCallDelta = isAssetEndpoint(endpoint) ? 1 : 0;
+        const successDelta = params.status < 400 ? 1 : 0;
+        const latencyMs = Math.max(0, Math.floor(params.latencyMs));
+        const statusField = statusClassField(params.status);
+        const histogramField = `hist:${binLatencyMs(latencyMs)}`;
 
-    yield* Effect.tryPromise(() =>
-        redis
-            .pipeline()
-            .hincrby(dayKey, 'totalCalls', 1)
-            .hincrby(dayKey, 'assetCalls', assetCallDelta)
-            .hincrby(dayKey, 'successCalls', successDelta)
-            .hincrby(dayKey, 'sumLatencyMs', latencyMs)
-            .hincrby(dayKey, statusField, 1)
-            .expire(dayKey, ttl)
-            .hincrby(endpointKey, 'calls', 1)
-            .hincrby(endpointKey, 'successCalls', successDelta)
-            .hincrby(endpointKey, 'sumLatencyMs', latencyMs)
-            .hincrby(endpointKey, statusField, 1)
-            .hincrby(endpointKey, histogramField, 1)
-            .expire(endpointKey, ttl)
-            .set(endpointNameKey, endpoint, { ex: ttl })
-            .exec(),
-    );
+        yield* Effect.tryPromise(() =>
+            redis
+                .pipeline()
+                .hincrby(dayKey, 'totalCalls', 1)
+                .hincrby(dayKey, 'assetCalls', assetCallDelta)
+                .hincrby(dayKey, 'successCalls', successDelta)
+                .hincrby(dayKey, 'sumLatencyMs', latencyMs)
+                .hincrby(dayKey, statusField, 1)
+                .expire(dayKey, ttl)
+                .hincrby(endpointKey, 'calls', 1)
+                .hincrby(endpointKey, 'successCalls', successDelta)
+                .hincrby(endpointKey, 'sumLatencyMs', latencyMs)
+                .hincrby(endpointKey, statusField, 1)
+                .hincrby(endpointKey, histogramField, 1)
+                .expire(endpointKey, ttl)
+                .set(endpointNameKey, endpoint, { ex: ttl })
+                .exec(),
+        );
     });
 }
 
@@ -516,10 +514,9 @@ export function route<T, Ctx = unknown>(
               )
             : handler(request, ctx as Ctx);
 
-        const exit = await Effect.runPromiseExit(
-            effect.pipe(Effect.provideService(CurrentRequestId, requestId)),
-            { signal: request.signal },
-        );
+        const exit = await Effect.runPromiseExit(effect.pipe(Effect.provideService(CurrentRequestId, requestId)), {
+            signal: request.signal,
+        });
 
         const latencyMs = Date.now() - startedAt;
         const url = (() => {

--- a/apps/api/src/effect/provider-budget.ts
+++ b/apps/api/src/effect/provider-budget.ts
@@ -1,0 +1,67 @@
+import { Effect } from 'effect';
+
+import { RateLimitedError } from '@tokens/effect';
+
+import type { PlatformAuthContext } from './next-route';
+import { getRedisClientEffect } from './next-route';
+import { slidingWindowLimit } from './sliding-window-rate-limit';
+
+/**
+ * Per-key window budget for the two endpoints that can burn provider (Birdeye)
+ * lookups: list-member batch adds and curator search. The platform rate limits
+ * bound requests/second but not provider cost over time — a key sending
+ * batches of unknown mints at the allowed rate could sustain hundreds of
+ * provider calls per second. Each *call* is charged (not each lookup — the API
+ * cannot know how many mints will miss the local registry), so the worst-case
+ * provider spend per key per window is `calls × per-call lookup cap`.
+ *
+ * Fail-open on Redis trouble: only an actual over-budget verdict blocks, so a
+ * cache outage degrades to the per-call caps rather than a hard 500/429.
+ */
+
+export type ProviderBudgetKind = 'batch' | 'search';
+
+function envInt(name: string, fallback: number): number {
+    const value = Number(process.env[name]);
+    return Number.isFinite(value) && value > 0 ? Math.floor(value) : fallback;
+}
+
+const DEFAULT_CALLS: Record<ProviderBudgetKind, number> = {
+    // 30 batch calls × 50 budgeted lookups = ≤1500 provider calls / window.
+    batch: 30,
+    // Searches spend ~1 provider lookup each when uncached.
+    search: 120,
+};
+
+export function enforceProviderBudget(
+    auth: PlatformAuthContext,
+    kind: ProviderBudgetKind,
+): Effect.Effect<void, RateLimitedError> {
+    return Effect.gen(function* () {
+        const calls =
+            kind === 'batch'
+                ? envInt('TOKEN_LIST_PROVIDER_BATCH_CALLS_PER_WINDOW', DEFAULT_CALLS.batch)
+                : envInt('TOKEN_LIST_PROVIDER_SEARCH_CALLS_PER_WINDOW', DEFAULT_CALLS.search);
+        const windowSeconds = envInt('TOKEN_LIST_PROVIDER_BUDGET_WINDOW_SECONDS', 600);
+
+        const redis = yield* getRedisClientEffect();
+        const result = yield* slidingWindowLimit({
+            redis,
+            identifier: `provider-budget:${kind}:${auth.apiKeyId}`,
+            tokens: calls,
+            windowSeconds,
+        });
+        if (!result.success) {
+            return yield* Effect.fail(
+                new RateLimitedError({
+                    service: 'providerBudget',
+                    message: 'Provider lookup budget exhausted for this key — retry after the window resets',
+                    retryAfterMs: Math.max(0, result.reset - Date.now()),
+                }),
+            );
+        }
+    }).pipe(
+        // Redis/env failures fail open (per-call lookup caps still bound cost).
+        Effect.catch(error => (error instanceof RateLimitedError ? Effect.fail(error) : Effect.void)),
+    );
+}

--- a/apps/api/src/effect/provider-budget.ts
+++ b/apps/api/src/effect/provider-budget.ts
@@ -45,6 +45,8 @@ export function enforceProviderBudget(
         const windowSeconds = envInt('TOKEN_LIST_PROVIDER_BUDGET_WINDOW_SECONDS', 600);
 
         const redis = yield* getRedisClientEffect();
+        // Keyed per API key, not per project: a project can multiply its budget
+        // by minting keys, bounded by the keys-per-project ceiling. Accepted.
         const result = yield* slidingWindowLimit({
             redis,
             identifier: `provider-budget:${kind}:${auth.apiKeyId}`,
@@ -61,7 +63,18 @@ export function enforceProviderBudget(
             );
         }
     }).pipe(
-        // Redis/env failures fail open (per-call lookup caps still bound cost).
-        Effect.catch(error => (error instanceof RateLimitedError ? Effect.fail(error) : Effect.void)),
+        // Redis/env failures fail open (per-call lookup caps still bound cost)
+        // — but loudly, so a silently-broken budget stays observable.
+        Effect.catch(error => {
+            if (error instanceof RateLimitedError) return Effect.fail(error);
+            console.error(
+                JSON.stringify({
+                    event: 'provider_budget_degraded',
+                    kind,
+                    error: error instanceof Error ? error.message : String(error),
+                }),
+            );
+            return Effect.void;
+        }),
     );
 }

--- a/apps/api/src/lib/cloudrun/tokenLists.ts
+++ b/apps/api/src/lib/cloudrun/tokenLists.ts
@@ -68,7 +68,8 @@ export type TokenListMutationErrorCode =
     | 'forbidden'
     | 'invalid_mint'
     | 'unknown_mint'
-    | 'batch_too_large';
+    | 'batch_too_large'
+    | 'list_full';
 
 export type TokenListMutationOutcome<T> = { ok: true; value: T } | { ok: false; error: TokenListMutationErrorCode };
 
@@ -152,5 +153,7 @@ export function tokenListsAddMembersBatch(args: {
     slug: string;
     mints: string[];
 }): Effect.Effect<TokenListMutationOutcome<TokenListBatchAddResult>, CloudRunError> {
-    return cloudRunMutation('assets', 'tokenListsAddMembersBatch', { ...args });
+    // A 1000-mint batch legitimately outlives the default 15s client timeout
+    // (chunked DB upserts + up to ~50 budgeted provider lookups).
+    return cloudRunMutation('assets', 'tokenListsAddMembersBatch', { ...args }, { timeoutMs: 60_000 });
 }

--- a/apps/api/src/lib/cloudrun/tokenLists.ts
+++ b/apps/api/src/lib/cloudrun/tokenLists.ts
@@ -168,7 +168,7 @@ export function tokenListsAddMembersBatch(args: {
     slug: string;
     mints: string[];
 }): Effect.Effect<TokenListMutationOutcome<TokenListBatchAddResult>, CloudRunError> {
-    // A 1000-mint batch legitimately outlives the default 15s client timeout
+    // A max-size (250-mint) batch legitimately outlives the default 15s client timeout
     // (chunked DB upserts + up to ~50 budgeted provider lookups).
     return cloudRunMutation('assets', 'tokenListsAddMembersBatch', { ...args }, { timeoutMs: 60_000 });
 }

--- a/apps/api/src/lib/cloudrun/tokenLists.ts
+++ b/apps/api/src/lib/cloudrun/tokenLists.ts
@@ -83,6 +83,7 @@ export type TokenListMutationErrorCode =
     | 'invalid_mint'
     | 'unknown_mint'
     | 'batch_too_large'
+    | 'project_lists_limit'
     | 'list_full';
 
 export type TokenListMutationOutcome<T> = { ok: true; value: T } | { ok: false; error: TokenListMutationErrorCode };

--- a/apps/app/src/app/(dashboard)/_components/lists-tab.tsx
+++ b/apps/app/src/app/(dashboard)/_components/lists-tab.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { motion } from 'motion/react';
 import { toast } from 'sonner';
 import {
     IconCheckmark,
@@ -51,8 +50,7 @@ import { useDashboardTab } from '@/hooks/use-dashboard-tab';
  * Community lists management: a first-party client of the public /api/v2/lists
  * API, authenticated through the playground key-reveal proxy — the same write
  * path partners use programmatically, so there is nothing dashboard-only to
- * drift. Projects without the invite-only `lists:write` scope see a
- * request-access state.
+ * drift. Any API key can manage its own project's lists.
  */
 
 interface V2ListSummary {
@@ -97,8 +95,6 @@ function MetadataScoreBar({ label, value }: { label: string; value: number }) {
         </div>
     );
 }
-
-type WriteAccess = 'checking' | 'granted' | 'denied';
 
 const LIST_TOKEN_CACHE_TTL_MS = 5 * 60_000;
 const TOKEN_METADATA_CACHE_TTL_MS = 5 * 60_000;
@@ -599,7 +595,6 @@ export function ListsTab(): React.JSX.Element {
         [projectId, currentApiKeyId],
     );
 
-    const [writeAccess, setWriteAccess] = useState<WriteAccess>('checking');
     const [allLists, setAllLists] = useState<V2ListSummary[] | null>(null);
     const [railTab, setRailTab] = useState<'mine' | 'community'>('mine');
     const [selectedSlug, setSelectedSlug] = useState<string | null>(null);
@@ -607,26 +602,6 @@ export function ListsTab(): React.JSX.Element {
     const activeDetailCacheKeyRef = useRef<string | null>(null);
 
     const ready = Boolean(projectId && currentApiKeyId && hasActiveApiKey);
-
-    // Scope probe: POST with an empty body mutates nothing — a key without
-    // lists:write gets 403 at the scope gate; a granted key reaches body
-    // validation and gets 400.
-    useEffect(() => {
-        if (!ready) return;
-        let cancelled = false;
-        setWriteAccess('checking');
-        void playgroundFetch('/api/v2/lists', { method: 'POST', body: {} }).then(
-            res => {
-                if (!cancelled) setWriteAccess(res.status === 403 ? 'denied' : 'granted');
-            },
-            () => {
-                if (!cancelled) setWriteAccess('denied');
-            },
-        );
-        return () => {
-            cancelled = true;
-        };
-    }, [ready, playgroundFetch]);
 
     const refreshLists = useCallback(async () => {
         if (!ready) return;
@@ -990,7 +965,7 @@ export function ListsTab(): React.JSX.Element {
         );
     }
 
-    if (!ready || writeAccess === 'checking') {
+    if (!ready) {
         return (
             <div className="space-y-6 container max-w-7xl mx-auto py-16 px-6">
                 <div className="mb-6 space-y-2">
@@ -1000,39 +975,6 @@ export function ListsTab(): React.JSX.Element {
                 <div className="grid grid-cols-1 lg:grid-cols-[300px_1fr] gap-8">
                     <Skeleton className="h-[280px] w-full rounded-[12px]" />
                     <Skeleton className="h-[420px] w-full rounded-[12px]" />
-                </div>
-            </div>
-        );
-    }
-
-    if (writeAccess === 'denied') {
-        return (
-            <div className="space-y-6 container max-w-7xl mx-auto py-16 px-6">
-                <div className="mb-6">
-                    <h1 className="text-3xl font-bold text-foreground">Token Lists</h1>
-                    <p className="text-muted-foreground">
-                        Publish curated token lists any app can consume via the v2 API.
-                    </p>
-                </div>
-                <div className="relative z-10 bg-background/80 backdrop-blur-sm rounded-2xl border border-dashed border-black/20 py-12">
-                    <EmptyState
-                        icon={<IconCircleGridCrossFill className="size-[60px] mb-2 fill-muted-foreground" />}
-                        title="List publishing is invite-only"
-                        subtitle="Your project's API key doesn't have the lists:write scope yet. Reach out to the Tokens team to request access for your community."
-                        className="p-12 w-full sm:w-[480px] mx-auto"
-                    />
-                    <motion.div
-                        initial={{ opacity: 0, y: 6 }}
-                        animate={{ opacity: 1, y: 0 }}
-                        transition={{ duration: 0.22, ease: 'easeOut' }}
-                        className="flex justify-center"
-                    >
-                        <Button asChild variant="ghost" size="sm" className="rounded-lg">
-                            <a href="https://docs.tokens.xyz" target="_blank" rel="noreferrer">
-                                Read the lists documentation
-                            </a>
-                        </Button>
-                    </motion.div>
                 </div>
             </div>
         );

--- a/apps/app/src/app/(dashboard)/_components/token-search-command.tsx
+++ b/apps/app/src/app/(dashboard)/_components/token-search-command.tsx
@@ -1,12 +1,23 @@
 'use client';
 
 import { useEffect, useRef, useState } from 'react';
-import { IconCheckmark, IconChevronDown, IconExclamationmarkTriangleFill, IconEyeSlashFill } from 'symbols-react';
+import { ArrowUpRight } from 'lucide-react';
+import { AnimatePresence, motion, useReducedMotion } from 'motion/react';
+import {
+    IconChevronDown,
+    IconCircleGridCrossFill,
+    IconExclamationmarkTriangleFill,
+    IconEyeSlashFill,
+    IconInfoCircle,
+} from 'symbols-react';
+import { TextMorph } from 'torph/react';
 
 import { Button } from '@tokens/ui/button';
 import { CommandDialog, CommandEmpty, CommandGroup, CommandInput, CommandItem, CommandList } from '@tokens/ui/command';
 import { Skeleton } from '@tokens/ui/skeleton';
 import { Spinner } from '@tokens/ui/spinner';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@tokens/ui/tooltip';
+import { EmptyState } from '@/components/global/empty-state';
 
 import {
     TokenIdentity,
@@ -16,7 +27,6 @@ import {
     type PlaygroundFetcher,
     type SearchResponse,
     type SearchResult,
-    type SearchSources,
     type SuppressedResult,
 } from './token-bits';
 
@@ -68,6 +78,92 @@ function CodeChip({
     );
 }
 
+function TooltipChip({ children }: { children: React.ReactNode }) {
+    return (
+        <span className="inline-flex items-center rounded-md bg-white/5 px-1.5 py-0.5 font-berkeley-mono text-[10px] leading-4 text-white">
+            {children}
+        </span>
+    );
+}
+
+function Keycap({ children }: { children: React.ReactNode }) {
+    return (
+        <kbd className="inline-flex h-4 select-none items-center justify-center rounded border border-border-light bg-gray-50 px-2 font-sans text-[11px] font-medium text-muted-foreground">
+            {children}
+        </kbd>
+    );
+}
+
+function ShortcutHint({ keys, label }: { keys: string[]; label: string }) {
+    return (
+        <div className="flex items-center gap-2">
+            <div className="flex items-center gap-1">
+                {keys.map(key => (
+                    <Keycap key={key}>{key}</Keycap>
+                ))}
+            </div>
+            <span className="text-xs text-foreground">{label}</span>
+        </div>
+    );
+}
+
+function AddedCheckmark() {
+    return (
+        <svg
+            width="32"
+            height="32"
+            viewBox="0 0 32 32"
+            fill="none"
+            xmlns="http://www.w3.org/2000/svg"
+            aria-hidden="true"
+            className="size-3.5 shrink-0"
+        >
+            <path
+                d="M6 16.5831L12.2902 23L26 9"
+                stroke="white"
+                strokeWidth="3"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+            />
+        </svg>
+    );
+}
+
+function AddActionIcon({ state }: { state: 'add' | 'adding' | 'added' }) {
+    const shouldReduceMotion = useReducedMotion();
+    const initial = shouldReduceMotion ? { opacity: 0 } : { opacity: 0, transform: 'scale(0.9)' };
+    const animate = shouldReduceMotion ? { opacity: 1 } : { opacity: 1, transform: 'scale(1)' };
+    const exit = shouldReduceMotion ? { opacity: 0 } : { opacity: 0, transform: 'scale(0.95)' };
+
+    return (
+        <AnimatePresence initial={false} mode="popLayout">
+            {state === 'adding' ? (
+                <motion.span
+                    key="adding"
+                    initial={initial}
+                    animate={animate}
+                    exit={exit}
+                    transition={{ duration: 0.12, ease: 'easeOut' }}
+                    className="flex size-3.5 items-center justify-center"
+                >
+                    <Spinner size="sm" />
+                </motion.span>
+            ) : state === 'added' ? (
+                <motion.span
+                    key="added"
+                    initial={initial}
+                    animate={animate}
+                    exit={exit}
+                    transition={{ duration: 0.12, ease: 'easeOut' }}
+                    className="flex size-3.5 items-center justify-center"
+                >
+                    <AddedCheckmark />
+                </motion.span>
+            ) : null}
+        </AnimatePresence>
+    );
+}
+
 function ScoreBar({ label, value }: { label: string; value: number }) {
     return (
         <div className="flex items-center gap-2">
@@ -96,74 +192,124 @@ function ResultInspector({ token, id, onInteraction }: { token: SearchResult; id
             }}
             className="mt-2 w-full cursor-text overflow-hidden rounded-lg border border-black/[0.15] bg-white text-left shadow-sm dark:bg-zinc-950/30"
         >
-            <div className="grid gap-3 p-3 md:grid-cols-2">
-                <div className="flex flex-col gap-1.5">
+            <div className="grid grid-cols-4 border-b border-black/[0.1] dark:border-white/10">
+                <div className="border-r border-black/[0.1] px-3 py-2.5 dark:border-white/10">
+                    <div className="text-[10px] font-inter-semibold uppercase tracking-wide text-muted-foreground">
+                        Price
+                    </div>
+                    <div className="mt-1 font-berkeley-mono text-sm text-foreground">
+                        {formatUsd(token.market.price)}
+                    </div>
+                </div>
+                <div className="border-r border-black/[0.1] px-3 py-2.5 dark:border-white/10">
+                    <div className="text-[10px] font-inter-semibold uppercase tracking-wide text-muted-foreground">
+                        Market cap
+                    </div>
+                    <div className="mt-1 font-berkeley-mono text-sm text-foreground">
+                        {formatUsd(token.market.marketCapUsd)}
+                    </div>
+                </div>
+                <div className="border-r border-black/[0.1] px-3 py-2.5 dark:border-white/10">
+                    <div className="text-[10px] font-inter-semibold uppercase tracking-wide text-muted-foreground">
+                        Liquidity
+                    </div>
+                    <div className="mt-1 font-berkeley-mono text-sm text-foreground">
+                        {formatUsd(token.market.liquidityUsd)}
+                    </div>
+                </div>
+                <div className="px-3 py-2.5">
+                    <div className="text-[10px] font-inter-semibold uppercase tracking-wide text-muted-foreground">
+                        Volume 24h
+                    </div>
+                    <div className="mt-1 font-berkeley-mono text-sm text-foreground">
+                        {formatUsd(token.market.volume24hUsd)}
+                    </div>
+                </div>
+            </div>
+            <div className="p-3">
+                <div className="flex items-center gap-1.5">
                     <span className="text-[10px] font-inter-semibold uppercase tracking-wide text-muted-foreground">
-                        Score components
+                        Score Card
                     </span>
+                    <Tooltip delayDuration={300}>
+                        <TooltipTrigger asChild>
+                            <button
+                                type="button"
+                                aria-label="View score reasons"
+                                className="inline-flex size-3.5 items-center justify-center rounded-full text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                            >
+                                <IconInfoCircle aria-hidden="true" className="size-3 fill-current" />
+                            </button>
+                        </TooltipTrigger>
+                        <TooltipContent
+                            side="right"
+                            className="max-w-64 rounded-sm bg-zinc-800 px-2 py-1.5 dark:bg-zinc-900"
+                        >
+                            <div className="text-[10px] font-inter-semibold uppercase tracking-wide text-white/60">
+                                Reasons
+                            </div>
+                            <div className="mt-1 flex flex-wrap gap-1">
+                                {token.reasons.length > 0 ? (
+                                    token.reasons.map(reason => (
+                                        <TooltipChip key={reason}>{humanize(reason)}</TooltipChip>
+                                    ))
+                                ) : (
+                                    <span className="text-xs text-white/70">No specific reasons.</span>
+                                )}
+                            </div>
+                            <div className="mt-2 border-t border-white/10 pt-2">
+                                <div className="text-[10px] font-inter-semibold uppercase tracking-wide text-white/60">
+                                    Evidence
+                                </div>
+                                <div className="mt-1 flex flex-wrap gap-1">
+                                    {token.claims.attestations.length > 0 ? (
+                                        token.claims.attestations.map(attestation => (
+                                            <TooltipChip key={`${attestation.code}:${attestation.detail}`}>
+                                                {attestation.detail}
+                                            </TooltipChip>
+                                        ))
+                                    ) : (
+                                        <span className="text-xs text-white/70">No attestations.</span>
+                                    )}
+                                </div>
+                            </div>
+                        </TooltipContent>
+                    </Tooltip>
+                    {token.warnings.length > 0 && (
+                        <Tooltip delayDuration={300}>
+                            <TooltipTrigger asChild>
+                                <button
+                                    type="button"
+                                    aria-label={`View ${token.warnings.length} warning${token.warnings.length === 1 ? '' : 's'}`}
+                                    className="inline-flex size-3.5 items-center justify-center rounded-full text-amber-600 transition-colors hover:text-amber-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring dark:text-amber-300 dark:hover:text-amber-200"
+                                >
+                                    <IconExclamationmarkTriangleFill
+                                        aria-hidden="true"
+                                        className="size-3 fill-current"
+                                    />
+                                </button>
+                            </TooltipTrigger>
+                            <TooltipContent
+                                side="right"
+                                className="max-w-64 rounded-sm bg-zinc-800 px-2 py-1.5 dark:bg-zinc-900"
+                            >
+                                <div className="text-[10px] font-inter-semibold uppercase tracking-wide text-white/60">
+                                    Warnings
+                                </div>
+                                <div className="mt-1 flex flex-wrap gap-1">
+                                    {token.warnings.map(warning => (
+                                        <TooltipChip key={warning}>{humanize(warning)}</TooltipChip>
+                                    ))}
+                                </div>
+                            </TooltipContent>
+                        </Tooltip>
+                    )}
+                </div>
+                <div className="mt-2 grid gap-x-6 gap-y-1.5 sm:grid-cols-2">
                     {Object.entries(token.score.components).map(([key, value]) => (
                         <ScoreBar key={key} label={humanize(key)} value={value} />
                     ))}
                 </div>
-                <div className="flex flex-col gap-2">
-                    <div>
-                        <span className="text-[10px] font-inter-semibold uppercase tracking-wide text-muted-foreground">
-                            Reasons
-                        </span>
-                        <div className="mt-1 flex flex-wrap gap-1">
-                            {token.reasons.length > 0 ? (
-                                token.reasons.map(reason => (
-                                    <CodeChip key={reason} tone="good">
-                                        {humanize(reason)}
-                                    </CodeChip>
-                                ))
-                            ) : (
-                                <span className="text-xs text-muted-foreground">none</span>
-                            )}
-                        </div>
-                    </div>
-                    <div>
-                        <span className="text-[10px] font-inter-semibold uppercase tracking-wide text-muted-foreground">
-                            Warnings
-                        </span>
-                        <div className="mt-1 flex flex-wrap gap-1">
-                            {token.warnings.length > 0 ? (
-                                token.warnings.map(warning => (
-                                    <CodeChip key={warning} tone="warn">
-                                        {humanize(warning)}
-                                    </CodeChip>
-                                ))
-                            ) : (
-                                <span className="text-xs text-muted-foreground">none</span>
-                            )}
-                        </div>
-                    </div>
-                    <div>
-                        <span className="text-[10px] font-inter-semibold uppercase tracking-wide text-muted-foreground">
-                            Attestations
-                        </span>
-                        <div className="mt-1 flex flex-wrap gap-1">
-                            {token.claims.attestations.length > 0 ? (
-                                token.claims.attestations.map(attestation => (
-                                    <CodeChip key={`${attestation.code}:${attestation.detail}`} tone="neutral">
-                                        {attestation.detail}
-                                    </CodeChip>
-                                ))
-                            ) : (
-                                <span className="text-xs text-muted-foreground">
-                                    unattested — symbol/name are unverified claims
-                                </span>
-                            )}
-                        </div>
-                    </div>
-                </div>
-            </div>
-            <div className="flex flex-wrap gap-x-4 gap-y-1 border-t border-black/[0.1] px-3 py-2 text-[11px] text-muted-foreground dark:border-white/10">
-                <span className="font-berkeley-mono">{token.mint}</span>
-                <span>liq {formatUsd(token.market.liquidityUsd)}</span>
-                <span>24h vol {formatUsd(token.market.volume24hUsd)}</span>
-                <span>mcap {formatUsd(token.market.marketCapUsd)}</span>
-                {token.inLists.length > 0 && <span>in: {token.inLists.join(', ')}</span>}
             </div>
         </div>
     );
@@ -191,8 +337,6 @@ export function TokenSearchCommand({
     const [policy, setPolicy] = useState<PolicyId>('strict');
     const [results, setResults] = useState<SearchResult[] | null>(null);
     const [suppressed, setSuppressed] = useState<SuppressedResult[]>([]);
-    const [sources, setSources] = useState<SearchSources | null>(null);
-    const [latencyMs, setLatencyMs] = useState<number | null>(null);
     const [loading, setLoading] = useState(false);
     const [error, setError] = useState(false);
     const [expandedMint, setExpandedMint] = useState<string | null>(null);
@@ -210,8 +354,6 @@ export function TokenSearchCommand({
         if (!open || !hasQuery) {
             setResults(null);
             setSuppressed([]);
-            setSources(null);
-            setLatencyMs(null);
             return;
         }
         let cancelled = false;
@@ -226,8 +368,6 @@ export function TokenSearchCommand({
                 if (cancelled) return;
                 setResults(body.results);
                 setSuppressed(body.suppressed);
-                setSources(body.sources);
-                setLatencyMs(body.latencyMs);
             })
             .catch(() => {
                 if (!cancelled) setError(true);
@@ -248,22 +388,53 @@ export function TokenSearchCommand({
         }
     }
 
-    const sourceTone = (status: string): 'good' | 'neutral' | 'warn' =>
-        status === 'ok' ? 'good' : status === 'disabled' ? 'neutral' : 'warn';
-
     const toggleInspector = (mint: string) => {
         setExpandedMint(previous => (previous === mint ? null : mint));
     };
 
     return (
         <CommandDialog open={open} onOpenChange={handleOpenChange}>
-            <CommandInput placeholder={`Search tokens to add to ${listSlug}…`} value={query} onValueChange={setQuery} />
+            <CommandInput
+                placeholder={`Search tokens to add to ${listSlug}…`}
+                value={query}
+                onValueChange={setQuery}
+                endAdornment={
+                    <button
+                        type="button"
+                        aria-label={`Search policy: ${policy}. Click to choose the next policy.`}
+                        title="Search policy"
+                        onClick={() => {
+                            const currentIndex = POLICY_IDS.indexOf(policy);
+                            setPolicy(POLICY_IDS[(currentIndex + 1) % POLICY_IDS.length]);
+                        }}
+                        className="inline-flex cursor-pointer items-center gap-2 rounded-lg bg-muted px-2 py-1 font-berkeley-mono text-xs text-foreground transition-[transform,background-color] duration-150 ease-out hover:bg-accent/50 active:scale-[0.98] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                    >
+                        <span>{policy}</span>
+                        <span className="flex flex-col items-center gap-0.5" aria-hidden="true">
+                            {POLICY_IDS.map(option => (
+                                <span
+                                    key={option}
+                                    className={`rounded-full ${option === policy ? 'size-1 bg-foreground' : 'size-0.5 bg-muted-foreground/60'}`}
+                                />
+                            ))}
+                        </span>
+                    </button>
+                }
+            />
 
             <CommandList className="h-[380px] max-h-[380px]">
                 {!hasQuery ? (
-                    <CommandEmpty>Type at least 2 characters — symbol, name, or a mint address.</CommandEmpty>
+                    <CommandEmpty className="py-0">
+                        <EmptyState
+                            icon={<IconCircleGridCrossFill className="mb-2 size-12 fill-muted-foreground" />}
+                            title="Search for a token"
+                            subtitle="Search by symbol, name, or mint address."
+                            className="py-12"
+                            titleClassName="text-base"
+                        />
+                    </CommandEmpty>
                 ) : error ? (
-                    <CommandEmpty>Search failed — check the API and your key’s lists:write scope.</CommandEmpty>
+                    <CommandEmpty>Search failed — check the API and your key.</CommandEmpty>
                 ) : loading && results === null ? (
                     <CommandGroup heading="Judging candidates…">
                         {Array.from({ length: 4 }, (_, index) => (
@@ -297,11 +468,10 @@ export function TokenSearchCommand({
                             {results.map(result => {
                                 const isMember = memberMints.has(result.mint);
                                 const isAdding = addingMint === result.mint;
+                                const actionState = isAdding ? 'adding' : isMember ? 'added' : 'add';
                                 const expanded = expandedMint === result.mint;
                                 const inspectorId = `token-result-inspector-${result.mint}`;
                                 const symbol = result.claims.symbol ?? shortMint(result.mint);
-                                const warningCount = result.warnings.length;
-                                const warningLabel = `${warningCount} warning${warningCount === 1 ? '' : 's'}`;
                                 return (
                                     <CommandItem
                                         key={result.mint}
@@ -322,94 +492,98 @@ export function TokenSearchCommand({
 
                                             if (!isAdding && addingMint === null) onAdd(result);
                                         }}
-                                        className="group flex cursor-pointer flex-col items-stretch gap-0 rounded-xl px-3 py-2 aria-selected:bg-accent/70"
+                                        className="group flex cursor-pointer flex-col items-stretch gap-0 rounded-xl !px-0.5 pb-0.5 pt-2 aria-selected:bg-accent/70"
                                     >
-                                        <div className="flex w-full items-center gap-2 sm:gap-3">
+                                        <div className="flex w-full items-center gap-2 px-4 sm:gap-3">
                                             <div className="min-w-0 flex-1">
                                                 <TokenIdentity
                                                     mint={result.mint}
                                                     symbol={result.claims.symbol}
-                                                    name={result.claims.name}
+                                                    name={
+                                                        <a
+                                                            href={`https://birdeye.so/token/${result.mint}?chain=solana`}
+                                                            target="_blank"
+                                                            rel="noreferrer"
+                                                            title="Verify on Birdeye"
+                                                            onPointerDown={event => {
+                                                                event.stopPropagation();
+                                                                pointerSelectionMintRef.current = null;
+                                                            }}
+                                                            onClick={event => {
+                                                                event.stopPropagation();
+                                                                pointerSelectionMintRef.current = null;
+                                                            }}
+                                                            className="inline-flex items-center gap-0.5 hover:text-foreground"
+                                                        >
+                                                            {shortMint(result.mint)}
+                                                            <ArrowUpRight aria-hidden="true" className="size-2.5" />
+                                                        </a>
+                                                    }
+                                                    nameClassName="text-[11px] text-muted-foreground"
                                                     logoURI={result.market.logoURI}
                                                     verified={result.verified}
                                                     symbolAccessory={
-                                                        warningCount > 0 ? (
-                                                            <span
-                                                                title={warningLabel}
-                                                                className="inline-flex shrink-0 items-center gap-1 rounded-md bg-amber-100 px-1.5 py-0.5 text-[10px] leading-4 text-amber-700 dark:bg-amber-500/15 dark:text-amber-300"
-                                                            >
-                                                                <IconExclamationmarkTriangleFill
-                                                                    aria-hidden="true"
-                                                                    className="size-3 shrink-0 fill-current"
-                                                                />
-                                                                {warningLabel}
-                                                            </span>
-                                                        ) : undefined
+                                                        <span
+                                                            aria-label={`Judgment score: ${result.score.total}`}
+                                                            title={`Judgment score: ${result.score.total}`}
+                                                            className={`inline-flex shrink-0 items-center rounded-full px-2 py-0.5 font-berkeley-mono text-xs font-semibold ${scoreTone(result.score.total)}`}
+                                                        >
+                                                            {result.score.total}
+                                                        </span>
                                                     }
-                                                >
-                                                    <div className="mt-0.5 flex items-center gap-3 text-xs text-muted-foreground">
-                                                        <span>{formatUsd(result.market.price)}</span>
-                                                        <span>liq {formatUsd(result.market.liquidityUsd)}</span>
-                                                    </div>
-                                                </TokenIdentity>
+                                                />
                                             </div>
-                                            <span
-                                                aria-label={`Judgment score: ${result.score.total}`}
-                                                title={`Judgment score: ${result.score.total}`}
-                                                className={`inline-flex shrink-0 items-center rounded-full px-2 py-0.5 font-berkeley-mono text-xs font-semibold ${scoreTone(result.score.total)}`}
-                                            >
-                                                {result.score.total}
-                                            </span>
-                                            {isAdding ? (
-                                                <Button
-                                                    type="button"
-                                                    size="sm"
-                                                    disabled
-                                                    aria-label={`Adding ${symbol} to ${listSlug}`}
-                                                    className="h-7 shrink-0 rounded-md px-2.5 text-xs"
-                                                >
-                                                    <Spinner size="sm" />
-                                                    Adding
-                                                </Button>
-                                            ) : isMember ? (
-                                                <span className="inline-flex shrink-0 items-center gap-1 rounded-md bg-emerald-50 px-2 py-1 text-xs text-emerald-700 dark:bg-emerald-500/15 dark:text-emerald-300">
-                                                    <IconCheckmark
-                                                        aria-hidden="true"
-                                                        className="size-3 shrink-0 fill-current"
-                                                    />
-                                                    Added
-                                                </span>
-                                            ) : (
-                                                <Button
-                                                    type="button"
-                                                    size="sm"
-                                                    disabled={addingMint !== null}
-                                                    aria-label={`Add ${symbol} to ${listSlug}`}
-                                                    onPointerDown={event => {
-                                                        event.stopPropagation();
-                                                        pointerSelectionMintRef.current = null;
-                                                    }}
-                                                    onClick={event => {
-                                                        event.preventDefault();
-                                                        event.stopPropagation();
-                                                        pointerSelectionMintRef.current = null;
-                                                        if (addingMint === null) onAdd(result);
-                                                    }}
-                                                    className="h-7 shrink-0 rounded-md px-2.5 text-xs"
-                                                >
-                                                    Add
-                                                    <span
-                                                        aria-hidden="true"
-                                                        className="font-berkeley-mono text-[10px] opacity-60"
-                                                    >
-                                                        ↵
-                                                    </span>
-                                                </Button>
-                                            )}
-                                            <IconChevronDown
-                                                aria-hidden="true"
-                                                className={`size-3.5 shrink-0 fill-muted-foreground transition-transform duration-150 ease-out motion-reduce:transition-none ${expanded ? 'rotate-180' : ''}`}
-                                            />
+                                            <div className="flex shrink-0 items-start gap-2">
+                                                <div className="flex flex-col items-end gap-1">
+                                                    <div className="flex items-center gap-2">
+                                                        <Button
+                                                            type="button"
+                                                            size="sm"
+                                                            variant={isMember ? 'secondary' : 'default'}
+                                                            disabled={isAdding || (!isMember && addingMint !== null)}
+                                                            aria-disabled={isMember || undefined}
+                                                            tabIndex={isMember ? -1 : undefined}
+                                                            aria-label={
+                                                                isAdding
+                                                                    ? `Adding ${symbol} to ${listSlug}`
+                                                                    : isMember
+                                                                      ? `${symbol} is already in ${listSlug}`
+                                                                      : `Add ${symbol} to ${listSlug}`
+                                                            }
+                                                            onPointerDown={event => {
+                                                                if (actionState !== 'add') return;
+                                                                event.stopPropagation();
+                                                                pointerSelectionMintRef.current = null;
+                                                            }}
+                                                            onClick={event => {
+                                                                if (actionState !== 'add') return;
+                                                                event.preventDefault();
+                                                                event.stopPropagation();
+                                                                pointerSelectionMintRef.current = null;
+                                                                if (addingMint === null) onAdd(result);
+                                                            }}
+                                                            className={`h-6 shrink-0 rounded-md pl-2.5 pr-3 text-xs ${
+                                                                isMember
+                                                                    ? 'pointer-events-none bg-emerald-600 text-white hover:bg-emerald-600 dark:bg-emerald-500 dark:hover:bg-emerald-500'
+                                                                    : ''
+                                                            }`}
+                                                        >
+                                                            <AddActionIcon state={actionState} />
+                                                            <TextMorph as="span" respectReducedMotion>
+                                                                {actionState === 'adding'
+                                                                    ? 'Adding'
+                                                                    : actionState === 'added'
+                                                                      ? 'Added'
+                                                                      : 'Add'}
+                                                            </TextMorph>
+                                                        </Button>
+                                                    </div>
+                                                </div>
+                                                <IconChevronDown
+                                                    aria-hidden="true"
+                                                    className={`mt-1.5 size-3 shrink-0 fill-muted-foreground transition-transform duration-150 ease-out motion-reduce:transition-none ${expanded ? 'rotate-180' : ''}`}
+                                                />
+                                            </div>
                                         </div>
                                         {expanded && (
                                             <ResultInspector
@@ -458,41 +632,11 @@ export function TokenSearchCommand({
                     </>
                 ) : null}
             </CommandList>
-
-            {/* Policy + sources footer */}
-            <div className="flex flex-wrap items-center justify-between gap-2 border-t border-border-extra-light px-4 py-2.5">
-                <div className="flex items-center gap-1">
-                    <span className="mr-1 text-[10px] font-inter-semibold uppercase tracking-wide text-muted-foreground">
-                        policy
-                    </span>
-                    {POLICY_IDS.map(id => (
-                        <button
-                            key={id}
-                            type="button"
-                            onClick={() => setPolicy(id)}
-                            className={`rounded-full px-2.5 py-1 font-berkeley-mono text-xs transition-colors ${
-                                policy === id
-                                    ? id === 'strict'
-                                        ? 'bg-emerald-600 text-white'
-                                        : id === 'degen'
-                                          ? 'bg-red-500 text-white'
-                                          : 'bg-gray-800 text-white'
-                                    : 'bg-gray-100 text-muted-foreground hover:text-foreground'
-                            }`}
-                        >
-                            {id}
-                        </button>
-                    ))}
-                </div>
-                <div className="flex items-center gap-1 text-[10px] text-muted-foreground">
-                    {sources && (
-                        <>
-                            <CodeChip tone={sourceTone(sources.provider)}>provider:{sources.provider}</CodeChip>
-                            <CodeChip tone={sourceTone(sources.db)}>db:{sources.db}</CodeChip>
-                            <CodeChip tone="good">registry:ok</CodeChip>
-                        </>
-                    )}
-                    {latencyMs !== null && <span className="font-berkeley-mono">{latencyMs}ms</span>}
+            <div className="hidden w-full items-center justify-center border-t border-border-light px-3 py-3 md:flex">
+                <div className="flex flex-wrap items-center gap-x-5 gap-y-2">
+                    <ShortcutHint keys={['↑', '↓']} label="List" />
+                    <ShortcutHint keys={['Enter']} label="Add" />
+                    <ShortcutHint keys={['Esc']} label="Close" />
                 </div>
             </div>
         </CommandDialog>

--- a/apps/cloudrun-assets/src/db.ts
+++ b/apps/cloudrun-assets/src/db.ts
@@ -3475,7 +3475,107 @@ export function makePostgresTokenListsMutationsRepo(sql: Sql): TokenListsMutatio
             `;
             return rows[0]?.exists === true;
         },
+        async filterMintsWithActiveVariants(mints) {
+            const found: string[] = [];
+            for (const part of chunkStrings(mints, 500)) {
+                const rows = await sql<{ mint: string }[]>`
+                    SELECT DISTINCT av.mint
+                    FROM asset_variants av
+                    WHERE av.mint IN ${sql([...part])}
+                      AND av.is_active = true
+                      AND NOT EXISTS (
+                          SELECT 1 FROM asset_deletion_tombstones t WHERE t.asset_id = av.asset_id
+                      )
+                `;
+                for (const row of rows) found.push(row.mint);
+            }
+            return found;
+        },
+        async filterMintsKnownTokens(mints) {
+            const found: string[] = [];
+            for (const part of chunkStrings(mints, 500)) {
+                const rows = await sql<{ address: string }[]>`
+                    SELECT address FROM tokens WHERE address IN ${sql([...part])}
+                `;
+                for (const row of rows) found.push(row.address);
+            }
+            return found;
+        },
+        async filterMintsExistingMembers(listId, mints) {
+            const found: string[] = [];
+            for (const part of chunkStrings(mints, 500)) {
+                const rows = await sql<{ mint: string }[]>`
+                    SELECT mint FROM token_list_members
+                    WHERE list_id = ${listId} AND mint IN ${sql([...part])}
+                `;
+                for (const row of rows) found.push(row.mint);
+            }
+            return found;
+        },
+        async countMembers(listId) {
+            const rows = await sql<{ count: number }[]>`
+                SELECT COUNT(*)::int AS count FROM token_list_members WHERE list_id = ${listId}
+            `;
+            return rows[0]?.count ?? 0;
+        },
+        async upsertMembersBulk(listId, rows) {
+            if (rows.length === 0) return;
+            // New mints append after the current max rank in array order;
+            // conflicts keep their rank and refresh note/snapshot.
+            const baseRows = await sql<{ next: number }[]>`
+                SELECT COALESCE(MAX(rank), -1) + 1 AS next FROM token_list_members WHERE list_id = ${listId}
+            `;
+            let nextRank = baseRows[0]?.next ?? 0;
+            for (const part of chunkArray(rows, 500)) {
+                const values = part.map(row => ({
+                    id: randomId('tlm'),
+                    list_id: listId,
+                    mint: row.mint,
+                    rank: nextRank++,
+                    note: row.note,
+                    added_at: row.addedAt,
+                    symbol: row.snapshot?.symbol ?? null,
+                    name: row.snapshot?.name ?? null,
+                    logo_uri: row.snapshot?.logoUri ?? null,
+                    decimals: row.snapshot?.decimals ?? null,
+                }));
+                await sql`
+                    INSERT INTO token_list_members ${sql(
+                        values,
+                        'id',
+                        'list_id',
+                        'mint',
+                        'rank',
+                        'note',
+                        'added_at',
+                        'symbol',
+                        'name',
+                        'logo_uri',
+                        'decimals',
+                    )}
+                    ON CONFLICT (list_id, mint) DO UPDATE SET
+                        note = EXCLUDED.note,
+                        symbol = EXCLUDED.symbol,
+                        name = EXCLUDED.name,
+                        logo_uri = EXCLUDED.logo_uri,
+                        decimals = EXCLUDED.decimals
+                `;
+            }
+            await sql`UPDATE token_lists SET updated_at = now() WHERE id = ${listId}`;
+        },
     };
+}
+
+function chunkStrings(items: readonly string[], size: number): string[][] {
+    const chunks: string[][] = [];
+    for (let i = 0; i < items.length; i += size) chunks.push(items.slice(i, i + size) as string[]);
+    return chunks;
+}
+
+function chunkArray<T>(items: readonly T[], size: number): T[][] {
+    const chunks: T[][] = [];
+    for (let i = 0; i < items.length; i += size) chunks.push(items.slice(i, i + size) as T[]);
+    return chunks;
 }
 
 export function makePostgresSeedRepo(sql: Sql): SeedRepo {

--- a/apps/cloudrun-assets/src/db.ts
+++ b/apps/cloudrun-assets/src/db.ts
@@ -3551,50 +3551,94 @@ export function makePostgresTokenListsMutationsRepo(sql: Sql): TokenListsMutatio
             `;
             return rows[0]?.count ?? 0;
         },
-        async upsertMembersBulk(listId, rows) {
-            if (rows.length === 0) return;
-            // New mints append after the current max rank in array order;
-            // conflicts keep their rank and refresh note/snapshot.
-            const baseRows = await sql<{ next: number }[]>`
-                SELECT COALESCE(MAX(rank), -1) + 1 AS next FROM token_list_members WHERE list_id = ${listId}
-            `;
-            let nextRank = baseRows[0]?.next ?? 0;
-            for (const part of chunkArray(rows, 500)) {
-                const values = part.map(row => ({
-                    id: randomId('tlm'),
-                    list_id: listId,
-                    mint: row.mint,
-                    rank: nextRank++,
-                    note: row.note,
-                    added_at: row.addedAt,
-                    symbol: row.snapshot?.symbol ?? null,
-                    name: row.snapshot?.name ?? null,
-                    logo_uri: row.snapshot?.logoUri ?? null,
-                    decimals: row.snapshot?.decimals ?? null,
-                }));
-                await sql`
-                    INSERT INTO token_list_members ${sql(
-                        values,
-                        'id',
-                        'list_id',
-                        'mint',
-                        'rank',
-                        'note',
-                        'added_at',
-                        'symbol',
-                        'name',
-                        'logo_uri',
-                        'decimals',
-                    )}
-                    ON CONFLICT (list_id, mint) DO UPDATE SET
-                        note = EXCLUDED.note,
-                        symbol = EXCLUDED.symbol,
-                        name = EXCLUDED.name,
-                        logo_uri = EXCLUDED.logo_uri,
-                        decimals = EXCLUDED.decimals
+        async upsertMembersBulk(listId, rows, membersPerListCap) {
+            if (rows.length === 0) return { overflowMints: [] };
+            const overflowMints: string[] = [];
+            // One transaction, list row locked: the cap and MAX(rank) are read
+            // under the lock so concurrent batches serialize per-list — no cap
+            // overshoot, no duplicate ranks.
+            await sql.begin(async tx => {
+                await tx`SELECT id FROM token_lists WHERE id = ${listId} FOR UPDATE`;
+
+                const existing = new Set<string>();
+                for (const part of chunkStrings(
+                    rows.map(row => row.mint),
+                    500,
+                )) {
+                    const found = await tx<{ mint: string }[]>`
+                        SELECT mint FROM token_list_members
+                        WHERE list_id = ${listId} AND mint IN ${tx([...part])}
+                    `;
+                    for (const row of found) existing.add(row.mint);
+                }
+                const countRows = await tx<{ count: number }[]>`
+                    SELECT COUNT(*)::int AS count FROM token_list_members WHERE list_id = ${listId}
                 `;
-            }
-            await sql`UPDATE token_lists SET updated_at = now() WHERE id = ${listId}`;
+                let slots = Math.max(0, membersPerListCap - (countRows[0]?.count ?? 0));
+
+                const insertable: typeof rows = [];
+                for (const row of rows) {
+                    if (!existing.has(row.mint)) {
+                        if (slots === 0) {
+                            overflowMints.push(row.mint);
+                            continue;
+                        }
+                        slots -= 1;
+                    }
+                    insertable.push(row);
+                }
+                if (insertable.length === 0) return;
+
+                const baseRows = await tx<{ next: number }[]>`
+                    SELECT COALESCE(MAX(rank), -1) + 1 AS next FROM token_list_members WHERE list_id = ${listId}
+                `;
+                let nextRank = baseRows[0]?.next ?? 0;
+                for (const part of chunkArray(insertable, 500)) {
+                    const values = part.map(row => ({
+                        id: randomId('tlm'),
+                        list_id: listId,
+                        mint: row.mint,
+                        rank: nextRank++,
+                        note: row.note,
+                        added_at: row.addedAt,
+                        symbol: row.snapshot?.symbol ?? null,
+                        name: row.snapshot?.name ?? null,
+                        logo_uri: row.snapshot?.logoUri ?? null,
+                        decimals: row.snapshot?.decimals ?? null,
+                    }));
+                    await tx`
+                        INSERT INTO token_list_members ${tx(
+                            values,
+                            'id',
+                            'list_id',
+                            'mint',
+                            'rank',
+                            'note',
+                            'added_at',
+                            'symbol',
+                            'name',
+                            'logo_uri',
+                            'decimals',
+                        )}
+                        ON CONFLICT (list_id, mint) DO UPDATE SET
+                            note = EXCLUDED.note,
+                            symbol = EXCLUDED.symbol,
+                            name = EXCLUDED.name,
+                            logo_uri = EXCLUDED.logo_uri,
+                            decimals = EXCLUDED.decimals
+                    `;
+                }
+                await tx`UPDATE token_lists SET updated_at = now() WHERE id = ${listId}`;
+            });
+            return { overflowMints };
+        },
+        async countListsByOwner(ownerProjectId) {
+            const rows = await sql<{ count: number }[]>`
+                SELECT COUNT(*)::int AS count
+                FROM token_lists
+                WHERE owner_project_id = ${ownerProjectId} AND status <> 'archived'
+            `;
+            return rows[0]?.count ?? 0;
         },
     };
 }

--- a/apps/cloudrun-assets/src/db.ts
+++ b/apps/cloudrun-assets/src/db.ts
@@ -3469,27 +3469,47 @@ export function makePostgresTokenListsMutationsRepo(sql: Sql): TokenListsMutatio
         },
         async upsertMember(args) {
             const rank = args.rank;
-            await sql`
-                INSERT INTO token_list_members (id, list_id, mint, rank, note, added_at, symbol, name, logo_uri, decimals)
-                VALUES (
-                    ${randomId('tlm')}, ${args.listId}, ${args.mint},
-                    COALESCE(${rank}, (
-                        SELECT COALESCE(MAX(rank), -1) + 1 FROM token_list_members WHERE list_id = ${args.listId}
-                    )),
-                    ${args.note}, ${args.addedAt},
-                    ${args.snapshot?.symbol ?? null}, ${args.snapshot?.name ?? null},
-                    ${args.snapshot?.logoUri ?? null}, ${args.snapshot?.decimals ?? null}
-                )
-                ON CONFLICT (list_id, mint) DO UPDATE SET
-                    rank = COALESCE(${rank}, token_list_members.rank),
-                    note = EXCLUDED.note,
-                    symbol = EXCLUDED.symbol,
-                    name = EXCLUDED.name,
-                    logo_uri = EXCLUDED.logo_uri,
-                    decimals = EXCLUDED.decimals
-            `;
-            // Discovery updatedAt must reflect member changes, not just metadata edits.
-            await sql`UPDATE token_lists SET updated_at = ${new Date(args.addedAt)} WHERE id = ${args.listId}`;
+            let inserted = true;
+            // Same locking discipline as upsertMembersBulk: cap and default
+            // rank are read with the list row locked, so a single PUT cannot
+            // race a batch into cap overshoot or duplicate ranks.
+            await sql.begin(async tx => {
+                await tx`SELECT id FROM token_lists WHERE id = ${args.listId} FOR UPDATE`;
+                const existingRows = await tx<{ id: string }[]>`
+                    SELECT id FROM token_list_members WHERE list_id = ${args.listId} AND mint = ${args.mint}
+                `;
+                if (existingRows.length === 0) {
+                    const countRows = await tx<{ count: number }[]>`
+                        SELECT COUNT(*)::int AS count FROM token_list_members WHERE list_id = ${args.listId}
+                    `;
+                    if ((countRows[0]?.count ?? 0) >= args.membersPerListCap) {
+                        inserted = false;
+                        return;
+                    }
+                }
+                await tx`
+                    INSERT INTO token_list_members (id, list_id, mint, rank, note, added_at, symbol, name, logo_uri, decimals)
+                    VALUES (
+                        ${randomId('tlm')}, ${args.listId}, ${args.mint},
+                        COALESCE(${rank}, (
+                            SELECT COALESCE(MAX(rank), -1) + 1 FROM token_list_members WHERE list_id = ${args.listId}
+                        )),
+                        ${args.note}, ${args.addedAt},
+                        ${args.snapshot?.symbol ?? null}, ${args.snapshot?.name ?? null},
+                        ${args.snapshot?.logoUri ?? null}, ${args.snapshot?.decimals ?? null}
+                    )
+                    ON CONFLICT (list_id, mint) DO UPDATE SET
+                        rank = COALESCE(${rank}, token_list_members.rank),
+                        note = EXCLUDED.note,
+                        symbol = EXCLUDED.symbol,
+                        name = EXCLUDED.name,
+                        logo_uri = EXCLUDED.logo_uri,
+                        decimals = EXCLUDED.decimals
+                `;
+                // Discovery updatedAt must reflect member changes, not just metadata edits.
+                await tx`UPDATE token_lists SET updated_at = ${new Date(args.addedAt)} WHERE id = ${args.listId}`;
+            });
+            return inserted;
         },
         async removeMember(listId, mint, nowMs) {
             const rows = await sql<{ id: string }[]>`

--- a/apps/cloudrun-assets/src/handlers/tokenListsMutations.test.ts
+++ b/apps/cloudrun-assets/src/handlers/tokenListsMutations.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'bun:test';
 
 import { InvalidArgsError } from './assets';
 import {
-    MEMBER_BATCH_CAP,
+    DEFAULT_TOKEN_LIST_CAPS,
     SlugConflictError,
     addMembersBatch,
     archiveList,
@@ -51,10 +51,18 @@ function makeDeps(
             removeMember: async () => true,
             hasActiveVariantForMint: async () => true,
             hasTokenForAddress: async () => false,
+            // Batch resolution defaults mirror the single-mint fakes above:
+            // every well-formed mint counts as registry-known.
+            filterMintsWithActiveVariants: async mints => [...mints],
+            filterMintsKnownTokens: async () => [],
+            filterMintsExistingMembers: async () => [],
+            countMembers: async () => 0,
+            upsertMembersBulk: async () => {},
             ...repoOverrides,
         },
         fetchTokenOverview: async () => null,
         now: () => FIXED_NOW,
+        caps: { ...DEFAULT_TOKEN_LIST_CAPS },
         ...depsOverrides,
     };
 }
@@ -263,21 +271,30 @@ describe('upsertMember mint resolution', () => {
     });
 });
 
+function uniqueMints(count: number, prefix = 'M'): string[] {
+    // Base58 excludes 0, O, I, l — encode the index with safe letters only.
+    return Array.from({ length: count }, (_, i) => {
+        const tag = String(i)
+            .split('')
+            .map(digit => 'ABCDEFGHJK'[Number(digit)])
+            .join('');
+        return `${prefix}${tag}`.padEnd(40, 'z');
+    });
+}
+
 describe('addMembersBatch', () => {
-    it('caps the batch size', async () => {
-        const mints = Array.from({ length: MEMBER_BATCH_CAP + 1 }, (_, i) =>
-            `M${String(i).padStart(3, 'x')}`.padEnd(40, 'z'),
-        );
+    it('caps the batch size at caps.batch', async () => {
+        const mints = uniqueMints(DEFAULT_TOKEN_LIST_CAPS.batch + 1);
         expect(await addMembersBatch(makeDeps(), { ownerProjectId: 'proj_1', slug: 'ownership-core', mints })).toEqual({
             ok: false,
             error: 'batch_too_large',
         });
     });
 
-    it('partitions per-mint successes and failures', async () => {
+    it('partitions per-mint successes and failures via batched resolution', async () => {
         const deps = makeDeps({
-            hasActiveVariantForMint: async mint => mint === USDC_MINT,
-            hasTokenForAddress: async () => false,
+            filterMintsWithActiveVariants: async mints => mints.filter(mint => mint === USDC_MINT),
+            filterMintsKnownTokens: async () => [],
         });
         const result = await addMembersBatch(deps, {
             ownerProjectId: 'proj_1',
@@ -289,11 +306,93 @@ describe('addMembersBatch', () => {
             value: {
                 added: [{ mint: USDC_MINT, verified: true, snapshot: null }],
                 failed: [
-                    { mint: MEME_MINT, error: 'unknown_mint' },
                     { mint: 'garbage', error: 'invalid_mint' },
+                    { mint: MEME_MINT, error: 'unknown_mint' },
                 ],
             },
         });
+    });
+
+    it('writes through the bulk upsert, not the per-mint path', async () => {
+        const bulkCalls: number[] = [];
+        let singleCalls = 0;
+        const deps = makeDeps({
+            upsertMembersBulk: async (_listId, rows) => void bulkCalls.push(rows.length),
+            upsertMember: async () => {
+                singleCalls += 1;
+            },
+        });
+        await addMembersBatch(deps, {
+            ownerProjectId: 'proj_1',
+            slug: 'ownership-core',
+            mints: uniqueMints(3),
+        });
+        expect(bulkCalls).toEqual([3]);
+        expect(singleCalls).toBe(0);
+    });
+
+    it('spends at most caps.providerLookups on Birdeye and fails the rest as unknown_mint', async () => {
+        let lookups = 0;
+        const deps = makeDeps(
+            {
+                // Nothing resolves locally — every mint is a provider candidate.
+                filterMintsWithActiveVariants: async () => [],
+                filterMintsKnownTokens: async () => [],
+            },
+            {
+                fetchTokenOverview: async () => {
+                    lookups += 1;
+                    return { symbol: 'X', name: 'X Token', decimals: 6 };
+                },
+                caps: { ...DEFAULT_TOKEN_LIST_CAPS, providerLookups: 5 },
+            },
+        );
+        const result = await addMembersBatch(deps, {
+            ownerProjectId: 'proj_1',
+            slug: 'ownership-core',
+            mints: uniqueMints(8),
+        });
+        expect(lookups).toBe(5);
+        if (!result.ok) throw new Error('expected ok');
+        expect(result.value.added.length).toBe(5);
+        expect(result.value.failed.filter(f => f.error === 'unknown_mint').length).toBe(3);
+    });
+
+    it('fails net-new mints beyond the members-per-list cap with list_full, updates stay free', async () => {
+        const mints = uniqueMints(4);
+        const existing = mints[0] as string;
+        const deps = makeDeps(
+            {
+                countMembers: async () => 4999,
+                filterMintsExistingMembers: async () => [existing],
+            },
+            { caps: { ...DEFAULT_TOKEN_LIST_CAPS, membersPerList: 5000 } },
+        );
+        const result = await addMembersBatch(deps, { ownerProjectId: 'proj_1', slug: 'ownership-core', mints });
+        if (!result.ok) throw new Error('expected ok');
+        // 1 update (existing) + 1 new fills the last slot; 2 overflow.
+        expect(result.value.added.map(m => m.mint)).toEqual([mints[0], mints[1]]);
+        expect(result.value.failed).toEqual([
+            { mint: mints[2], error: 'list_full' },
+            { mint: mints[3], error: 'list_full' },
+        ]);
+    });
+});
+
+describe('upsertMember list_full', () => {
+    it('rejects a net-new member on a full list but allows updating an existing one', async () => {
+        const fullDeps = makeDeps({ countMembers: async () => 5000, filterMintsExistingMembers: async () => [] });
+        expect(
+            await upsertMember(fullDeps, { ownerProjectId: 'proj_1', slug: 'ownership-core', mint: USDC_MINT }),
+        ).toEqual({ ok: false, error: 'list_full' });
+
+        const updateDeps = makeDeps({
+            countMembers: async () => 5000,
+            filterMintsExistingMembers: async () => [USDC_MINT],
+        });
+        expect(
+            await upsertMember(updateDeps, { ownerProjectId: 'proj_1', slug: 'ownership-core', mint: USDC_MINT }),
+        ).toEqual({ ok: true, value: { mint: USDC_MINT, verified: true, snapshot: null } });
     });
 });
 

--- a/apps/cloudrun-assets/src/handlers/tokenListsMutations.test.ts
+++ b/apps/cloudrun-assets/src/handlers/tokenListsMutations.test.ts
@@ -49,7 +49,7 @@ function makeDeps(
             }),
             updateList: async (_listId, patch) => ({ ...LIST_ROW, ...patch }),
             deleteList: async () => {},
-            upsertMember: async () => {},
+            upsertMember: async () => true,
             removeMember: async () => true,
             hasActiveVariantForMint: async () => true,
             hasTokenForAddress: async () => false,
@@ -490,6 +490,7 @@ describe('addMembersBatch', () => {
             },
             upsertMember: async () => {
                 singleCalls += 1;
+                return true;
             },
         });
         await addMembersBatch(deps, {
@@ -550,19 +551,23 @@ describe('addMembersBatch', () => {
 });
 
 describe('upsertMember list_full', () => {
-    it('rejects a net-new member on a full list but allows updating an existing one', async () => {
-        const fullDeps = makeDeps({ countMembers: async () => 5000, filterMintsExistingMembers: async () => [] });
+    it('surfaces the repo cap verdict (enforced under the list lock) and passes the cap through', async () => {
+        const caps: number[] = [];
+        const fullDeps = makeDeps({
+            upsertMember: async args => {
+                caps.push(args.membersPerListCap);
+                return false;
+            },
+        });
         expect(
             await upsertMember(fullDeps, { ownerProjectId: 'proj_1', slug: 'ownership-core', mint: USDC_MINT }),
         ).toEqual({ ok: false, error: 'list_full' });
+        expect(caps).toEqual([5000]);
 
-        const updateDeps = makeDeps({
-            countMembers: async () => 5000,
-            filterMintsExistingMembers: async () => [USDC_MINT],
-        });
+        const updateDeps = makeDeps({ upsertMember: async () => true });
         expect(
             await upsertMember(updateDeps, { ownerProjectId: 'proj_1', slug: 'ownership-core', mint: USDC_MINT }),
-        ).toEqual({ ok: true, value: { mint: USDC_MINT, verified: true, snapshot: null } });
+        ).toMatchObject({ ok: true });
     });
 });
 

--- a/apps/cloudrun-assets/src/handlers/tokenListsMutations.test.ts
+++ b/apps/cloudrun-assets/src/handlers/tokenListsMutations.test.ts
@@ -12,6 +12,7 @@ import {
     removeMember,
     updateList,
     upsertMember,
+    withOverviewMissCache,
     type TokenListMutationRow,
     type TokenListsMutationsDeps,
     type TokenListsMutationsRepo,
@@ -58,7 +59,8 @@ function makeDeps(
             filterMintsKnownTokens: async () => [],
             filterMintsExistingMembers: async () => [],
             countMembers: async () => 0,
-            upsertMembersBulk: async () => {},
+            upsertMembersBulk: async () => ({ overflowMints: [] }),
+            countListsByOwner: async () => 0,
             getSlugHold: async () => null,
             recordSlugHold: async () => {},
             clearSlugHold: async () => {},
@@ -298,6 +300,78 @@ describe('text caps and rank validation', () => {
     });
 });
 
+describe('lists-per-project cap', () => {
+    it('refuses creation once the project owns caps.listsPerProject lists', async () => {
+        const deps = makeDeps({ countListsByOwner: async () => 100 });
+        expect(await createList(deps, { ownerProjectId: 'proj_1', slug: 'one-more', name: 'X' })).toEqual({
+            ok: false,
+            error: 'project_lists_limit',
+        });
+        const under = makeDeps({ countListsByOwner: async () => 99 });
+        expect(await createList(under, { ownerProjectId: 'proj_1', slug: 'one-more', name: 'X' })).toMatchObject({
+            ok: true,
+        });
+    });
+});
+
+describe('withOverviewMissCache', () => {
+    it('serves misses from the cache within the TTL and retries after it', async () => {
+        let calls = 0;
+        let clock = 0;
+        const fetch = withOverviewMissCache(
+            async () => {
+                calls += 1;
+                return null;
+            },
+            { ttlMs: 1000, now: () => clock },
+        );
+        expect(await fetch('MintA')).toBeNull();
+        expect(await fetch('MintA')).toBeNull();
+        expect(calls).toBe(1);
+        clock = 1001;
+        expect(await fetch('MintA')).toBeNull();
+        expect(calls).toBe(2);
+    });
+
+    it('does not cache hits and evicts FIFO past maxEntries', async () => {
+        let calls = 0;
+        const fetch = withOverviewMissCache(
+            async mint => {
+                calls += 1;
+                return mint === 'Known' ? ({ symbol: 'K' } as never) : null;
+            },
+            { maxEntries: 1 },
+        );
+        await fetch('Known');
+        await fetch('Known');
+        expect(calls).toBe(2);
+        await fetch('MissA');
+        await fetch('MissB'); // evicts MissA
+        await fetch('MissA'); // refetches
+        expect(calls).toBe(5);
+    });
+});
+
+describe('bulk cap reconciliation', () => {
+    it('moves txn-detected overflow mints from added to failed', async () => {
+        const deps = makeDeps({
+            upsertMembersBulk: async () => ({ overflowMints: [MEME_MINT] }),
+        });
+        const result = await addMembersBatch(deps, {
+            ownerProjectId: 'proj_1',
+            slug: 'ownership-core',
+            mints: [USDC_MINT, MEME_MINT],
+        });
+        expect(result).toMatchObject({
+            ok: true,
+            value: {
+                added: [{ mint: USDC_MINT }],
+                failed: [{ mint: MEME_MINT, error: 'list_full' }],
+            },
+        });
+    });
+});
+
 describe('upsertMember mint resolution', () => {
     it('registry-known mint → verified, no snapshot', async () => {
         const result = await upsertMember(makeDeps(), {
@@ -408,7 +482,10 @@ describe('addMembersBatch', () => {
         const bulkCalls: number[] = [];
         let singleCalls = 0;
         const deps = makeDeps({
-            upsertMembersBulk: async (_listId, rows) => void bulkCalls.push(rows.length),
+            upsertMembersBulk: async (_listId, rows) => {
+                bulkCalls.push(rows.length);
+                return { overflowMints: [] };
+            },
             upsertMember: async () => {
                 singleCalls += 1;
             },

--- a/apps/cloudrun-assets/src/handlers/tokenListsMutations.ts
+++ b/apps/cloudrun-assets/src/handlers/tokenListsMutations.ts
@@ -31,7 +31,21 @@ const SOLANA_MINT_REGEX = /^[1-9A-HJ-NP-Za-km-z]{32,44}$/;
 export const TOKEN_LIST_STATUSES = ['draft', 'published', 'archived'] as const;
 export type TokenListStatus = (typeof TOKEN_LIST_STATUSES)[number];
 
-export const MEMBER_BATCH_CAP = 100;
+/** Infrastructure bounds (env-tunable at wiring time; see index.ts). */
+export interface TokenListCaps {
+    /** Max mints per addMembersBatch call. */
+    batch: number;
+    /** Max members a single list may hold. */
+    membersPerList: number;
+    /** Max Birdeye lookups a single batch call may spend on unknown mints. */
+    providerLookups: number;
+}
+
+export const DEFAULT_TOKEN_LIST_CAPS: TokenListCaps = {
+    batch: 1000,
+    membersPerList: 5000,
+    providerLookups: 50,
+};
 
 export interface TokenListMutationRow {
     id: string;
@@ -85,6 +99,22 @@ export interface TokenListsMutationsRepo {
     hasActiveVariantForMint(mint: string): Promise<boolean>;
     /** The mint exists in the tokens table (read-time hydration will cover metadata). */
     hasTokenForAddress(mint: string): Promise<boolean>;
+    /** Subset of `mints` with an active, non-tombstoned registry variant. One IN-query, chunked. */
+    filterMintsWithActiveVariants(mints: readonly string[]): Promise<string[]>;
+    /** Subset of `mints` present in the tokens table. One IN-query, chunked. */
+    filterMintsKnownTokens(mints: readonly string[]): Promise<string[]>;
+    /** Subset of `mints` already members of the list. */
+    filterMintsExistingMembers(listId: string, mints: readonly string[]): Promise<string[]>;
+    countMembers(listId: string): Promise<number>;
+    /**
+     * Multi-row upsert (chunked): new mints append after the current max rank
+     * in array order, existing mints keep their rank and refresh note/snapshot.
+     * Touches the parent list's updated_at ONCE.
+     */
+    upsertMembersBulk(
+        listId: string,
+        rows: Array<{ mint: string; note: string | null; addedAt: number; snapshot: MemberSnapshot | null }>,
+    ): Promise<void>;
 }
 
 export class SlugConflictError extends Error {
@@ -99,6 +129,7 @@ export interface TokenListsMutationsDeps {
     /** Birdeye token_overview for mints unknown locally; null when the provider has nothing. */
     fetchTokenOverview(mint: string): Promise<BirdeyeOverview | null>;
     now(): number;
+    caps: TokenListCaps;
 }
 
 export type TokenListMutationErrorCode =
@@ -109,7 +140,8 @@ export type TokenListMutationErrorCode =
     | 'forbidden'
     | 'invalid_mint'
     | 'unknown_mint'
-    | 'batch_too_large';
+    | 'batch_too_large'
+    | 'list_full';
 
 export interface TokenListResult {
     id: string;
@@ -340,6 +372,13 @@ export async function upsertMember(
     const owned = await requireOwnedList(deps, slug, ownerProjectId);
     if (!owned.ok) return owned;
 
+    // Updating an existing member never consumes a slot; only net-new inserts
+    // count against the members-per-list cap.
+    if ((await deps.repo.countMembers(owned.value.id)) >= deps.caps.membersPerList) {
+        const existing = await deps.repo.filterMintsExistingMembers(owned.value.id, [mint]);
+        if (existing.length === 0) return { ok: false, error: 'list_full' };
+    }
+
     const resolved = await resolveMint(deps, mint);
     if (!resolved.ok) return resolved;
 
@@ -376,6 +415,26 @@ export interface BatchAddResult {
     failed: Array<{ mint: string; error: TokenListMutationErrorCode }>;
 }
 
+/** Run `fn` over `items` with at most `limit` in flight. Results keep item order. */
+async function mapWithConcurrency<T, R>(
+    items: readonly T[],
+    limit: number,
+    fn: (item: T) => Promise<R>,
+): Promise<R[]> {
+    const results: R[] = new Array(items.length);
+    let next = 0;
+    async function worker() {
+        while (next < items.length) {
+            const index = next++;
+            results[index] = await fn(items[index] as T);
+        }
+    }
+    await Promise.all(Array.from({ length: Math.min(limit, items.length) }, worker));
+    return results;
+}
+
+const PROVIDER_LOOKUP_CONCURRENCY = 5;
+
 export async function addMembersBatch(
     deps: TokenListsMutationsDeps,
     args: unknown,
@@ -387,28 +446,79 @@ export async function addMembersBatch(
         throw new InvalidArgsError('mints must be an array of strings');
     }
     const mints = [...new Set((a.mints as string[]).map(m => m.trim()).filter(Boolean))];
-    if (mints.length > MEMBER_BATCH_CAP) return { ok: false, error: 'batch_too_large' };
+    if (mints.length > deps.caps.batch) return { ok: false, error: 'batch_too_large' };
 
     const owned = await requireOwnedList(deps, slug, ownerProjectId);
     if (!owned.ok) return owned;
+    const listId = owned.value.id;
 
-    const added: MemberResult[] = [];
     const failed: BatchAddResult['failed'] = [];
-    for (const mint of mints) {
-        const resolved = await resolveMint(deps, mint);
-        if (!resolved.ok) {
-            failed.push({ mint, error: resolved.error });
-            continue;
-        }
-        await deps.repo.upsertMember({
-            listId: owned.value.id,
-            mint,
-            rank: null,
-            note: null,
-            addedAt: deps.now(),
-            snapshot: resolved.value.snapshot,
-        });
-        added.push(resolved.value);
+
+    // Format gate first — malformed strings never reach the DB or the provider.
+    const wellFormed = mints.filter(mint => {
+        if (SOLANA_MINT_REGEX.test(mint)) return true;
+        failed.push({ mint, error: 'invalid_mint' });
+        return false;
+    });
+
+    // Batched local resolution: two IN-queries instead of 2N round trips.
+    const verifiedSet = new Set(await deps.repo.filterMintsWithActiveVariants(wellFormed));
+    const unverifiedCandidates = wellFormed.filter(mint => !verifiedSet.has(mint));
+    const knownSet = new Set(await deps.repo.filterMintsKnownTokens(unverifiedCandidates));
+    const providerCandidates = unverifiedCandidates.filter(mint => !knownSet.has(mint));
+
+    // Provider lookups are budgeted per call: a batch full of unknown mints
+    // must not turn into a thousand Birdeye requests. Over-budget unknowns
+    // fail individually and can be retried in a later batch.
+    const withinBudget = providerCandidates.slice(0, deps.caps.providerLookups);
+    for (const mint of providerCandidates.slice(deps.caps.providerLookups)) {
+        failed.push({ mint, error: 'unknown_mint' });
     }
+    const providerResolved = new Map<string, MemberSnapshot>();
+    await mapWithConcurrency(withinBudget, PROVIDER_LOOKUP_CONCURRENCY, async mint => {
+        const overview = await deps.fetchTokenOverview(mint).catch(() => null);
+        if (!overview) {
+            failed.push({ mint, error: 'unknown_mint' });
+            return;
+        }
+        providerResolved.set(mint, {
+            symbol: typeof overview.symbol === 'string' ? overview.symbol : null,
+            name: typeof overview.name === 'string' ? overview.name : null,
+            logoUri: typeof overview.logoURI === 'string' ? overview.logoURI : null,
+            decimals: typeof overview.decimals === 'number' ? overview.decimals : null,
+        });
+    });
+
+    const resolved: MemberResult[] = wellFormed.flatMap((mint): MemberResult[] => {
+        if (verifiedSet.has(mint)) return [{ mint, verified: true, snapshot: null }];
+        if (knownSet.has(mint)) return [{ mint, verified: false, snapshot: null }];
+        const snapshot = providerResolved.get(mint);
+        return snapshot ? [{ mint, verified: false, snapshot }] : [];
+    });
+
+    // Members-per-list cap: updates of existing members are free; net-new
+    // inserts consume slots in request order, and the overflow fails as
+    // list_full without sinking the rest of the batch.
+    const existingSet = new Set(
+        await deps.repo.filterMintsExistingMembers(listId, resolved.map(member => member.mint)),
+    );
+    const currentCount = await deps.repo.countMembers(listId);
+    let slots = Math.max(0, deps.caps.membersPerList - currentCount);
+    const added: MemberResult[] = [];
+    const rows: Array<{ mint: string; note: string | null; addedAt: number; snapshot: MemberSnapshot | null }> = [];
+    const addedAt = deps.now();
+    for (const member of resolved) {
+        if (!existingSet.has(member.mint)) {
+            if (slots === 0) {
+                failed.push({ mint: member.mint, error: 'list_full' });
+                continue;
+            }
+            slots -= 1;
+        }
+        rows.push({ mint: member.mint, note: null, addedAt, snapshot: member.snapshot });
+        added.push(member);
+    }
+
+    if (rows.length > 0) await deps.repo.upsertMembersBulk(listId, rows);
     return { ok: true, value: { added, failed } };
 }

--- a/apps/cloudrun-assets/src/handlers/tokenListsMutations.ts
+++ b/apps/cloudrun-assets/src/handlers/tokenListsMutations.ts
@@ -135,6 +135,12 @@ export interface TokenListsMutationsRepo {
     /** Non-archived lists owned by the project (lists-per-project cap). */
     countListsByOwner(ownerProjectId: string): Promise<number>;
     /** Upsert on (list_id, mint); missing rank appends after the current max. Touches the parent list. */
+    /**
+     * Single upsert in ONE transaction with the list row locked (FOR UPDATE):
+     * the members-per-list cap and default rank are read under the lock, same
+     * guarantees as the bulk path. Returns false when a net-new insert would
+     * exceed the cap (updates of existing members always succeed).
+     */
     upsertMember(args: {
         listId: string;
         mint: string;
@@ -142,7 +148,8 @@ export interface TokenListsMutationsRepo {
         note: string | null;
         addedAt: number;
         snapshot: MemberSnapshot | null;
-    }): Promise<void>;
+        membersPerListCap: number;
+    }): Promise<boolean>;
     /** Returns false when the mint was not a member. Touches the parent list when it was. */
     removeMember(listId: string, mint: string, nowMs: number): Promise<boolean>;
     /** An active registry variant exists for the mint (tombstone-filtered). */
@@ -473,24 +480,21 @@ export async function upsertMember(
     const owned = await requireOwnedList(deps, slug, ownerProjectId);
     if (!owned.ok) return owned;
 
-    // Updating an existing member never consumes a slot; only net-new inserts
-    // count against the members-per-list cap.
-    if ((await deps.repo.countMembers(owned.value.id)) >= deps.caps.membersPerList) {
-        const existing = await deps.repo.filterMintsExistingMembers(owned.value.id, [mint]);
-        if (existing.length === 0) return { ok: false, error: 'list_full' };
-    }
-
     const resolved = await resolveMint(deps, mint);
     if (!resolved.ok) return resolved;
 
-    await deps.repo.upsertMember({
+    // Cap enforcement happens inside the repo transaction (list row locked),
+    // so a PUT racing a batch cannot overshoot or duplicate ranks.
+    const inserted = await deps.repo.upsertMember({
         listId: owned.value.id,
         mint,
         rank,
         note,
         addedAt: deps.now(),
         snapshot: resolved.value.snapshot,
+        membersPerListCap: deps.caps.membersPerList,
     });
+    if (!inserted) return { ok: false, error: 'list_full' };
     return resolved;
 }
 

--- a/apps/cloudrun-assets/src/handlers/tokenListsMutations.ts
+++ b/apps/cloudrun-assets/src/handlers/tokenListsMutations.ts
@@ -39,13 +39,50 @@ export interface TokenListCaps {
     membersPerList: number;
     /** Max Birdeye lookups a single batch call may spend on unknown mints. */
     providerLookups: number;
+    /** Max non-archived lists a single project may own. */
+    listsPerProject: number;
 }
 
 export const DEFAULT_TOKEN_LIST_CAPS: TokenListCaps = {
-    batch: 1000,
+    // 250 bounds per-call wall time (~3 chunked IN-queries + inserts); large
+    // imports chunk client-side. Was 1000, which let a burst of multi-second
+    // calls park on the service (see the #121 review).
+    batch: 250,
     membersPerList: 5000,
     providerLookups: 50,
+    listsPerProject: 100,
 };
+
+/**
+ * Negative cache for provider lookups: a mint Birdeye doesn't know keeps not
+ * existing for a while — without this, replayed batches of the same unknown
+ * mints burn the provider budget forever. FIFO-evicted, per-instance.
+ */
+export function withOverviewMissCache(
+    inner: (mint: string) => Promise<BirdeyeOverview | null>,
+    options: { ttlMs?: number; maxEntries?: number; now?: () => number } = {},
+): (mint: string) => Promise<BirdeyeOverview | null> {
+    const ttlMs = options.ttlMs ?? 15 * 60 * 1000;
+    const maxEntries = options.maxEntries ?? 50_000;
+    const now = options.now ?? (() => Date.now());
+    const misses = new Map<string, number>();
+    return async mint => {
+        const missedAt = misses.get(mint);
+        if (missedAt !== undefined) {
+            if (now() - missedAt < ttlMs) return null;
+            misses.delete(mint);
+        }
+        const overview = await inner(mint);
+        if (overview === null) {
+            misses.set(mint, now());
+            if (misses.size > maxEntries) {
+                const oldest = misses.keys().next().value;
+                if (oldest !== undefined) misses.delete(oldest);
+            }
+        }
+        return overview;
+    };
+}
 
 export interface TokenListMutationRow {
     id: string;
@@ -95,6 +132,8 @@ export interface TokenListsMutationsRepo {
     recordSlugHold(slug: string, ownerProjectId: string, releasedAt: number): Promise<void>;
     /** Drop a hold once the slug is claimed again. */
     clearSlugHold(slug: string): Promise<void>;
+    /** Non-archived lists owned by the project (lists-per-project cap). */
+    countListsByOwner(ownerProjectId: string): Promise<number>;
     /** Upsert on (list_id, mint); missing rank appends after the current max. Touches the parent list. */
     upsertMember(args: {
         listId: string;
@@ -118,14 +157,19 @@ export interface TokenListsMutationsRepo {
     filterMintsExistingMembers(listId: string, mints: readonly string[]): Promise<string[]>;
     countMembers(listId: string): Promise<number>;
     /**
-     * Multi-row upsert (chunked): new mints append after the current max rank
-     * in array order, existing mints keep their rank and refresh note/snapshot.
+     * Multi-row upsert inside ONE transaction that locks the list row
+     * (FOR UPDATE): the members-per-list cap and MAX(rank) are re-read under
+     * the lock, so concurrent batches can neither overshoot the cap nor mint
+     * duplicate ranks. New mints append after the current max rank in array
+     * order; existing mints keep their rank and refresh note/snapshot; net-new
+     * rows beyond the cap are skipped and returned as `overflowMints`.
      * Touches the parent list's updated_at ONCE.
      */
     upsertMembersBulk(
         listId: string,
         rows: Array<{ mint: string; note: string | null; addedAt: number; snapshot: MemberSnapshot | null }>,
-    ): Promise<void>;
+        membersPerListCap: number,
+    ): Promise<{ overflowMints: string[] }>;
 }
 
 export class SlugConflictError extends Error {
@@ -156,7 +200,8 @@ export type TokenListMutationErrorCode =
     | 'invalid_mint'
     | 'unknown_mint'
     | 'batch_too_large'
-    | 'list_full';
+    | 'list_full'
+    | 'project_lists_limit';
 
 export interface TokenListResult {
     id: string;
@@ -264,6 +309,9 @@ export async function createList(
     if (!TOKEN_LIST_SLUG_REGEX.test(slug)) return { ok: false, error: 'invalid_slug' };
     if (isReservedTokenListSlug(slug)) return { ok: false, error: 'reserved_slug' };
     if (await slugHeldForOther(deps, slug, ownerProjectId)) return { ok: false, error: 'slug_held' };
+    if ((await deps.repo.countListsByOwner(ownerProjectId)) >= deps.caps.listsPerProject) {
+        return { ok: false, error: 'project_lists_limit' };
+    }
 
     try {
         const row = await deps.repo.insertList({
@@ -464,11 +512,7 @@ export interface BatchAddResult {
 }
 
 /** Run `fn` over `items` with at most `limit` in flight. Results keep item order. */
-async function mapWithConcurrency<T, R>(
-    items: readonly T[],
-    limit: number,
-    fn: (item: T) => Promise<R>,
-): Promise<R[]> {
+async function mapWithConcurrency<T, R>(items: readonly T[], limit: number, fn: (item: T) => Promise<R>): Promise<R[]> {
     const results: R[] = new Array(items.length);
     let next = 0;
     async function worker() {
@@ -548,7 +592,10 @@ export async function addMembersBatch(
     // inserts consume slots in request order, and the overflow fails as
     // list_full without sinking the rest of the batch.
     const existingSet = new Set(
-        await deps.repo.filterMintsExistingMembers(listId, resolved.map(member => member.mint)),
+        await deps.repo.filterMintsExistingMembers(
+            listId,
+            resolved.map(member => member.mint),
+        ),
     );
     const currentCount = await deps.repo.countMembers(listId);
     let slots = Math.max(0, deps.caps.membersPerList - currentCount);
@@ -567,6 +614,17 @@ export async function addMembersBatch(
         added.push(member);
     }
 
-    if (rows.length > 0) await deps.repo.upsertMembersBulk(listId, rows);
+    if (rows.length > 0) {
+        // The pre-check above is a fast path only; the repo re-checks the cap
+        // under a row lock, so concurrent batches cannot overshoot it.
+        const { overflowMints } = await deps.repo.upsertMembersBulk(listId, rows, deps.caps.membersPerList);
+        if (overflowMints.length > 0) {
+            const overflow = new Set(overflowMints);
+            for (const mint of overflowMints) failed.push({ mint, error: 'list_full' });
+            const kept = added.filter(member => !overflow.has(member.mint));
+            added.length = 0;
+            added.push(...kept);
+        }
+    }
     return { ok: true, value: { added, failed } };
 }

--- a/apps/cloudrun-assets/src/index.ts
+++ b/apps/cloudrun-assets/src/index.ts
@@ -45,6 +45,7 @@ import {
     makePostgresVariantMarketsRepo,
 } from './db';
 import type { AdminActionsDeps } from './handlers/adminActions';
+import { DEFAULT_TOKEN_LIST_CAPS } from './handlers/tokenListsMutations';
 import type { CacheWarmDeps } from './handlers/cacheWarm';
 import type { CronDeps } from './handlers/crons';
 import type { ClickhouseCronDeps } from './handlers/crons.clickhouse';
@@ -56,6 +57,12 @@ import type { ClickhouseExtrasCronDeps } from './handlers/crons.clickhouse.extra
 import type { PrestocksCronDeps } from './handlers/crons.prestocks';
 import { makeGoogleOidcVerifier } from './oidc';
 import { createApp, type ServiceRole } from './server';
+
+/** Positive-integer env override with a default. */
+function envInt(name: string, fallback: number): number {
+    const parsed = Number.parseInt(process.env[name] ?? '', 10);
+    return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
 
 const authToken = process.env.TOKENS_CLOUDRUN_AUTH_TOKEN?.trim();
 if (!authToken) {
@@ -300,6 +307,11 @@ const app = createApp({
         // simply resolve as unknown_mint instead of snapshotting metadata.
         fetchTokenOverview: async mint => (cronDeps ? cronDeps.birdeye.fetchTokenOverview(mint) : null),
         now: () => Date.now(),
+        caps: {
+            batch: envInt('TOKEN_LIST_BATCH_CAP', DEFAULT_TOKEN_LIST_CAPS.batch),
+            membersPerList: envInt('TOKEN_LIST_MEMBERS_PER_LIST_CAP', DEFAULT_TOKEN_LIST_CAPS.membersPerList),
+            providerLookups: envInt('TOKEN_LIST_PROVIDER_LOOKUP_BUDGET', DEFAULT_TOKEN_LIST_CAPS.providerLookups),
+        },
     },
     coingeckoReadsRepo: makePostgresCoingeckoReadsRepo(sql),
     stockReadsRepo: makePostgresStockReadsRepo(sql),

--- a/apps/cloudrun-assets/src/index.ts
+++ b/apps/cloudrun-assets/src/index.ts
@@ -45,7 +45,7 @@ import {
     makePostgresVariantMarketsRepo,
 } from './db';
 import type { AdminActionsDeps } from './handlers/adminActions';
-import { DEFAULT_TOKEN_LIST_CAPS } from './handlers/tokenListsMutations';
+import { DEFAULT_TOKEN_LIST_CAPS, withOverviewMissCache } from './handlers/tokenListsMutations';
 import type { CacheWarmDeps } from './handlers/cacheWarm';
 import type { CronDeps } from './handlers/crons';
 import type { ClickhouseCronDeps } from './handlers/crons.clickhouse';
@@ -305,12 +305,16 @@ const app = createApp({
         repo: makePostgresTokenListsMutationsRepo(sql),
         // Without a Birdeye key, mints unknown to the registry/tokens table
         // simply resolve as unknown_mint instead of snapshotting metadata.
-        fetchTokenOverview: async mint => (cronDeps ? cronDeps.birdeye.fetchTokenOverview(mint) : null),
+        // Miss-cached: unknown mints stop replaying against the provider.
+        fetchTokenOverview: withOverviewMissCache(async mint =>
+            cronDeps ? cronDeps.birdeye.fetchTokenOverview(mint) : null,
+        ),
         now: () => Date.now(),
         caps: {
             batch: envInt('TOKEN_LIST_BATCH_CAP', DEFAULT_TOKEN_LIST_CAPS.batch),
             membersPerList: envInt('TOKEN_LIST_MEMBERS_PER_LIST_CAP', DEFAULT_TOKEN_LIST_CAPS.membersPerList),
             providerLookups: envInt('TOKEN_LIST_PROVIDER_LOOKUP_BUDGET', DEFAULT_TOKEN_LIST_CAPS.providerLookups),
+            listsPerProject: envInt('TOKEN_LIST_LISTS_PER_PROJECT_CAP', DEFAULT_TOKEN_LIST_CAPS.listsPerProject),
         },
         // Freed slugs are reclaimable only by their previous owner for this window.
         slugHoldMs: (Number(process.env.TOKEN_LIST_SLUG_HOLD_DAYS) || 30) * 24 * 60 * 60 * 1000,

--- a/apps/cloudrun-assets/src/server.jobs.test.ts
+++ b/apps/cloudrun-assets/src/server.jobs.test.ts
@@ -115,9 +115,15 @@ const noopTokenListsMutationsDeps: TokenListsMutationsDeps = {
         async removeMember() { return false; },
         async hasActiveVariantForMint() { return false; },
         async hasTokenForAddress() { return false; },
+        async filterMintsWithActiveVariants() { return []; },
+        async filterMintsKnownTokens() { return []; },
+        async filterMintsExistingMembers() { return []; },
+        async countMembers() { return 0; },
+        async upsertMembersBulk() {},
     },
     fetchTokenOverview: async () => null,
     now: () => 0,
+    caps: { batch: 1000, membersPerList: 5000, providerLookups: 50 },
 };
 const noopAssetCollectionsReadsRepo: AssetCollectionsReadsRepo = {
     async listMembersBySlug() { return []; },

--- a/apps/cloudrun-assets/src/server.jobs.test.ts
+++ b/apps/cloudrun-assets/src/server.jobs.test.ts
@@ -240,7 +240,9 @@ const noopTokenListsMutationsDeps: TokenListsMutationsDeps = {
         },
         async recordSlugHold() {},
         async clearSlugHold() {},
-        async upsertMember() {},
+        async upsertMember() {
+            return true;
+        },
         async removeMember() {
             return false;
         },

--- a/apps/cloudrun-assets/src/server.jobs.test.ts
+++ b/apps/cloudrun-assets/src/server.jobs.test.ts
@@ -241,19 +241,38 @@ const noopTokenListsMutationsDeps: TokenListsMutationsDeps = {
         async recordSlugHold() {},
         async clearSlugHold() {},
         async upsertMember() {},
-        async removeMember() { return false; },
-        async hasActiveVariantForMint() { return false; },
-        async hasTokenForAddress() { return false; },
-        async filterMintsWithActiveVariants() { return []; },
-        async filterMintsKnownTokens() { return []; },
-        async filterMintsExistingMembers() { return []; },
-        async countMembers() { return 0; },
-        async upsertMembersBulk() {},
+        async removeMember() {
+            return false;
+        },
+        async hasActiveVariantForMint() {
+            return false;
+        },
+        async hasTokenForAddress() {
+            return false;
+        },
+        async filterMintsWithActiveVariants() {
+            return [];
+        },
+        async filterMintsKnownTokens() {
+            return [];
+        },
+        async filterMintsExistingMembers() {
+            return [];
+        },
+        async countMembers() {
+            return 0;
+        },
+        async upsertMembersBulk() {
+            return { overflowMints: [] };
+        },
+        async countListsByOwner() {
+            return 0;
+        },
     },
     fetchTokenOverview: async () => null,
     slugHoldMs: 30 * 24 * 60 * 60 * 1000,
     now: () => 0,
-    caps: { batch: 1000, membersPerList: 5000, providerLookups: 50 },
+    caps: { batch: 250, membersPerList: 5000, providerLookups: 50, listsPerProject: 100 },
 };
 const noopAssetCollectionsReadsRepo: AssetCollectionsReadsRepo = {
     async listMembersBySlug() {

--- a/apps/cloudrun-assets/src/server.test.ts
+++ b/apps/cloudrun-assets/src/server.test.ts
@@ -3481,9 +3481,15 @@ function emptyTokenListsMutationsDeps(): TokenListsMutationsDeps {
             async hasTokenForAddress() {
                 return false;
             },
+        async filterMintsWithActiveVariants() { return []; },
+        async filterMintsKnownTokens() { return []; },
+        async filterMintsExistingMembers() { return []; },
+        async countMembers() { return 0; },
+        async upsertMembersBulk() {},
         },
         fetchTokenOverview: async () => null,
         now: () => 0,
+        caps: { batch: 1000, membersPerList: 5000, providerLookups: 50 },
     };
 }
 

--- a/apps/cloudrun-assets/src/server.test.ts
+++ b/apps/cloudrun-assets/src/server.test.ts
@@ -3492,16 +3492,29 @@ function emptyTokenListsMutationsDeps(): TokenListsMutationsDeps {
             async hasTokenForAddress() {
                 return false;
             },
-        async filterMintsWithActiveVariants() { return []; },
-        async filterMintsKnownTokens() { return []; },
-        async filterMintsExistingMembers() { return []; },
-        async countMembers() { return 0; },
-        async upsertMembersBulk() {},
+            async filterMintsWithActiveVariants() {
+                return [];
+            },
+            async filterMintsKnownTokens() {
+                return [];
+            },
+            async filterMintsExistingMembers() {
+                return [];
+            },
+            async countMembers() {
+                return 0;
+            },
+            async upsertMembersBulk() {
+                return { overflowMints: [] };
+            },
+            async countListsByOwner() {
+                return 0;
+            },
         },
         fetchTokenOverview: async () => null,
         slugHoldMs: 30 * 24 * 60 * 60 * 1000,
         now: () => 0,
-        caps: { batch: 1000, membersPerList: 5000, providerLookups: 50 },
+        caps: { batch: 250, membersPerList: 5000, providerLookups: 50, listsPerProject: 100 },
     };
 }
 

--- a/apps/cloudrun-assets/src/server.test.ts
+++ b/apps/cloudrun-assets/src/server.test.ts
@@ -3482,7 +3482,9 @@ function emptyTokenListsMutationsDeps(): TokenListsMutationsDeps {
             },
             async recordSlugHold() {},
             async clearSlugHold() {},
-            async upsertMember() {},
+            async upsertMember() {
+                return true;
+            },
             async removeMember() {
                 return false;
             },

--- a/apps/docs/content/docs/v2/endpoints/lists.mdx
+++ b/apps/docs/content/docs/v2/endpoints/lists.mdx
@@ -5,8 +5,9 @@ description: Discover, read, compose, and manage community token lists.
 
 All endpoints on this page are Platform API endpoints authenticated with `x-api-key`.
 
-Reads require the `assets:read` scope. Writes and curator search require `lists:write`
-(invite-only — the team grants it on a partner project's key).
+Every endpoint requires only the default `assets:read` scope. Writes are bound to the
+API key's project: the key that creates a list owns it, and only keys from that project
+can modify it. Anyone can read any published list.
 
 ## `GET /v2/lists`
 
@@ -96,8 +97,16 @@ interface ComposeResponse {
 
 ## Managing lists
 
-All write endpoints require `lists:write`. The API key's project owns the lists it creates;
-keys from other projects get `403`.
+Any API key can create lists. The key's project owns the lists it creates; keys from
+other projects get `403` on writes. Caps (all generous, env-tunable server-side):
+**1000 mints per batch call**, **5000 members per list** (`400` with
+`details.code: "list_full"` beyond it), and **~50 provider lookups per batch call**
+for mints unknown to the registry/token index — over-budget unknowns fail individually
+as `unknown_mint` and can be retried in a later batch.
+
+**Recommended automation flow**: create the list, load it with one (or a few) batch
+calls, then keep it fresh with individual `PUT`/`DELETE /members/{mint}` calls as your
+own filters decide.
 
 ### `POST /v2/lists`
 
@@ -133,23 +142,24 @@ Remove a member. `404` when the mint was not in the list.
 
 ### `POST /v2/lists/{slug}/members`
 
-Bulk add: `{ mints: string[] }`, max 100 per call. Per-mint failures are reported without
-failing the batch:
+Bulk add: `{ mints: string[] }`, max 1000 per call, deduped. Mints are resolved in
+bulk (registry → token index → budgeted provider lookups). Per-mint failures are
+reported without failing the batch:
 
 ```ts
 interface BatchAddResponse {
     added: Array<{ mint: string; verified: boolean; snapshot: object | null }>;
-    failed: Array<{ mint: string; error: 'invalid_mint' | 'unknown_mint' }>;
+    failed: Array<{ mint: string; error: 'invalid_mint' | 'unknown_mint' | 'list_full' }>;
 }
 ```
 
 ## `GET /v2/lists/search-tokens`
 
 Curator-assist search: decision support for a list owner choosing which mint to add. This is
-**not** a public ranking — it is gated behind `lists:write`, and always returns the suppressed
+**not** a public ranking — it defaults to the strict policy and always returns the suppressed
 set with reasons so the curator sees what was filtered and why.
 
-- **Scope**: `lists:write`
+- **Scope**: `assets:read`
 - **Query params**:
   - `q` (**required**): symbol, name, or mint address (max 100 chars)
   - `policy` (optional): `strict` (default), `default`, or `degen` — bundles of hard gates +

--- a/apps/docs/content/docs/v2/endpoints/lists.mdx
+++ b/apps/docs/content/docs/v2/endpoints/lists.mdx
@@ -97,12 +97,16 @@ interface ComposeResponse {
 
 ## Managing lists
 
-Any API key can create lists. The key's project owns the lists it creates; keys from
-other projects get `403` on writes. Caps (all generous, env-tunable server-side):
-**1000 mints per batch call**, **5000 members per list** (`400` with
-`details.code: "list_full"` beyond it), and **~50 provider lookups per batch call**
+Any API key can create lists — project ownership is the security boundary: every key
+on a project (regardless of read scopes) may manage that project's lists, and keys
+from other projects get `403` on writes. Caps (env-tunable server-side):
+**250 mints per batch call**, **5000 members per list** (`400` with
+`details.code: "list_full"` beyond it), **100 lists per project** (`400` with
+`details.code: "project_lists_limit"`), and **~50 provider lookups per batch call**
 for mints unknown to the registry/token index — over-budget unknowns fail individually
-as `unknown_mint` and can be retried in a later batch.
+as `unknown_mint` and can be retried in a later batch. Batch adds and curator search
+additionally draw from a per-key provider budget (30 batch calls / 120 searches per
+10 minutes by default) and return `429` when it is exhausted.
 
 **Recommended automation flow**: create the list, load it with one (or a few) batch
 calls, then keep it fresh with individual `PUT`/`DELETE /members/{mint}` calls as your
@@ -142,7 +146,7 @@ Remove a member. `404` when the mint was not in the list.
 
 ### `POST /v2/lists/{slug}/members`
 
-Bulk add: `{ mints: string[] }`, max 1000 per call, deduped. Mints are resolved in
+Bulk add: `{ mints: string[] }`, max 250 per call, deduped. Mints are resolved in
 bulk (registry → token index → budgeted provider lookups). Per-mint failures are
 reported without failing the batch:
 

--- a/apps/docs/content/docs/v2/overview.mdx
+++ b/apps/docs/content/docs/v2/overview.mdx
@@ -14,8 +14,8 @@ one corpus — there is deliberately no global "all lists" union, because trust 
 model.
 
 - **Anyone can read** any published list with an `assets:read` API key.
-- **Creating and editing lists is invite-only**: the team provisions `lists:write` on a partner
-  project's API key. Contact us to publish lists.
+- **Anyone can publish**: every API key can create lists; each list is owned by the
+  creating key's project and only that project can modify it.
 - Lists may include mints outside our canonical registry; those tokens are flagged `verified: false`
   so your UI can render appropriate caution.
 

--- a/docs/community-lists-provisioning.md
+++ b/docs/community-lists-provisioning.md
@@ -1,67 +1,35 @@
-# Community lists: partner provisioning runbook
+# Community lists: operations notes
 
-Community token lists (`/api/v2/lists`) are invite-only on the write side: a partner
-manages lists with an API key whose project owns them and whose scopes include
-`lists:write`. This runbook is the manual grant flow until an admin UI exists.
+List creation is open to every API key — there is no scope grant or whitelist. A list
+is owned by the creating key's **project**; any key on that project can manage it, and
+other projects get `403` on writes. Reads (`assets:read`, the default scope) are public
+for all published lists.
 
-## 1. Partner creates (or already has) a project + key
+## Caps (env vars on cloudrun-assets)
 
-The partner signs into the developer dashboard (`apps/app`) and creates a project with an
-API key via the normal flow (`usersCreateProjectWithApiKey` on cloudrun-usage). Note the
-key prefix shown in the dashboard and the project id.
+| Env var | Default | Bounds |
+|---|---|---|
+| `TOKEN_LIST_BATCH_CAP` | 1000 | mints per `POST /members` batch call |
+| `TOKEN_LIST_MEMBERS_PER_LIST_CAP` | 5000 | members a single list may hold (`list_full`) |
+| `TOKEN_LIST_PROVIDER_LOOKUP_BUDGET` | 50 | Birdeye lookups a batch call may spend on locally-unknown mints |
 
-## 2. Grant the `lists:write` scope
+These bound infrastructure cost, not access: batch size protects request timeouts, the
+provider budget protects the Birdeye bill, the member cap bounds storage. Over-budget
+unknown mints fail individually as `unknown_mint` and can be retried in later batches.
 
-Scopes live in `api_keys.scopes` (jsonb) and pass through auth verbatim — no code change
-or deploy is needed. Against the prod Cloud SQL instance (see
-`docs/`-adjacent prod DB runbook for connecting):
+## Abuse response
 
-```sql
--- Inspect first
-SELECT key_prefix, project_id, scopes FROM api_keys WHERE key_prefix = '<prefix>';
-
--- Append the scope (idempotence: skip if already present)
-UPDATE api_keys
-SET scopes = scopes || '["lists:write"]'::jsonb
-WHERE key_prefix = '<prefix>'
-  AND NOT scopes ? 'lists:write';
-```
-
-## 3. Bust the auth cache
-
-apps/api caches `authenticateApiKey` results in Redis under `api-auth:v1:<sha256(key)>`.
-The new scope takes effect when that entry expires (TTL `authCacheTtlSeconds`) or after
-deleting it manually. If the partner reports `403 missing scope` right after the grant,
-wait out the TTL before debugging further.
-
-## 4. Verify
-
-With the partner's key:
-
-```bash
-curl -s -X POST "$API/api/v2/lists" \
-  -H "x-api-key: $KEY" -H 'content-type: application/json' \
-  -d '{"slug":"<partner>-core","name":"<Partner> Core"}'
-```
-
-Expected: `200` with the list body. A read-only key gets `403`. Slug rules:
-`^[a-z][a-z0-9-]{2,62}$`, unique among existing lists, curated ids +
-`all`/`lists`/`curated`/`tokens`/`search-tokens` reserved. Ask partners to prefix slugs
-with their community name.
-
-Slugs are not permanent: `PATCH /v2/lists/{slug}` accepts a new `slug`, and a deleted
-list's slug returns to the pool for anyone to claim. Renaming is a clean cut — the old
-path 404s the moment it lands, so warn partners before they move a live list.
+- Reversible hide: `PATCH /v2/lists/{slug}` with `{"status":"archived"}` (or the admin
+  app's Lists page) — the list drops out of discovery/reads but keeps its row and slug.
+- The admin app (`/lists`) shows every list across projects (any status) with the
+  emergency archive action.
+- Hard delete is owner-only (`DELETE /v2/lists/{slug}`): the row and members go, and the
+  slug returns to the pool.
 
 ## Notes
 
-- Ownership is by **project**: any key on the same project (with the scope) can manage the
-  project's lists. Revoking a key does not orphan lists.
-- `DELETE /v2/lists/{slug}` hard-deletes: the row and its members go, and the slug is
-  immediately claimable by any project. Irreversible.
-- `PATCH /v2/lists/{slug}` with `{"status":"archived"}` is the reversible option — the list
-  drops out of discovery and reads but keeps its row and its slug. Emergency takedown =
-  archive via the admin app's Lists page (or SQL `UPDATE token_lists SET
-  status='archived'`), which leaves the evidence in place.
+- Slug rules: `^[a-z][a-z0-9-]{2,62}$`, globally unique; curated ids +
+  `all`/`lists`/`curated`/`tokens`/`search-tokens`/`check-slug` reserved. Renames via
+  `PATCH` are a clean cut — the old path 404s immediately and the slug frees up.
 - Lists may contain mints outside the registry; they appear with `verified: false` in all
-  read responses.
+  read responses, with provider metadata snapshotted at add time.

--- a/docs/community-lists-provisioning.md
+++ b/docs/community-lists-provisioning.md
@@ -9,7 +9,7 @@ for all published lists.
 
 | Env var | Default | Bounds |
 |---|---|---|
-| `TOKEN_LIST_BATCH_CAP` | 1000 | mints per `POST /members` batch call |
+| `TOKEN_LIST_BATCH_CAP` | 250 | mints per `POST /members` batch call |
 | `TOKEN_LIST_MEMBERS_PER_LIST_CAP` | 5000 | members a single list may hold (`list_full`) |
 | `TOKEN_LIST_PROVIDER_LOOKUP_BUDGET` | 50 | Birdeye lookups a batch call may spend on locally-unknown mints |
 


### PR DESCRIPTION
Review slice **3 of 6** of the community-token-lists stack (integration PR: #96). Base: #120.

- removes the invite-only `lists:write` gate — every API key can manage its project's lists
- scales batch member adds to 1000 mints with caps (batch / members-per-list / provider-lookup budget)
- restores the iterated ⌘K palette design

Commits: 3052c86, 31f2ea9